### PR TITLE
Add Narwal Flow 2 support (product key QxMSPG6VSO)

### DIFF
--- a/custom_components/narwal/const.py
+++ b/custom_components/narwal/const.py
@@ -15,6 +15,7 @@ MODEL = "Flow (AX12)"
 # "auto" cycles all known keys during discovery (slower, fallback).
 NARWAL_MODELS: dict[str, str] = {
     "Narwal Flow": "QoEsI5qYXO",
+    "Narwal Flow 2": "QxMSPG6VSO",
     "Narwal Freo Z10 Ultra": "DrzDKQ0MU8",
     "Narwal Freo X10 Pro": "CNbforyZWI",
     "Other / Auto-detect": "auto",

--- a/narwal_client/const.py
+++ b/narwal_client/const.py
@@ -23,6 +23,7 @@ DEFAULT_TOPIC_PREFIX = "/QoEsI5qYXO"
 KNOWN_PRODUCT_KEYS = [
     # Confirmed working (local WebSocket)
     "QoEsI5qYXO",  # AX12 — Narwal Flow (primary, confirmed)
+    "QxMSPG6VSO",  # Narwal Flow 2 (confirmed working via local WebSocket)
     "DrzDKQ0MU8",   # CX4  — Freo Z10 Ultra (confirmed by @irekkl-maker)
     # Confirmed cloud-only (port 9002 open but no local broadcasts)
     "BYWBPqSxeC",   # CX7  — Freo Z Ultra (cloud-only, confirmed by @gabrielozcomidi)


### PR DESCRIPTION
## Summary

Adds support for the **Narwal Flow 2** (launched April 13, 2026) to both the model selector and the product key discovery list.

Addresses #18.

### Changes

- `narwal_client/const.py`: Added `QxMSPG6VSO` to `KNOWN_PRODUCT_KEYS` after the existing Flow (AX12) entry, in the "confirmed working" section
- `custom_components/narwal/const.py`: Added `"Narwal Flow 2": "QxMSPG6VSO"` to `NARWAL_MODELS` so users can select it in the config flow

### How the key was found

The Flow 2 was released very recently and its product key was not in the existing list. The key (`QxMSPG6VSO`) was identified by running the NarwalIntegration against a live Flow 2 unit and extracting the key returned by `get_device_info`. The integration works correctly with the Flow 2 — all features available for the original Flow (start/stop/dock, fan speed, sensors, live map) function as expected.

### Testing

- Confirmed working on a Narwal Flow 2 (firmware v01.07.16.01) via local WebSocket on port 9002
- Full cleaning session monitored, map streaming confirmed, all controls functional
