### PR TITLE
Flow 2: live broadcast state, Mop humidity Select, Freo Mind, station sensors

### DIFF
--- a/custom_components/narwal/const.py
+++ b/custom_components/narwal/const.py
@@ -28,6 +28,7 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
     Platform.CAMERA,
+    Platform.SELECT,
 ]
 
 FAN_SPEED_MAP: dict[str, FanLevel] = {

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -408,6 +408,10 @@ class NarwalClient:
             _LOGGER.debug("Failed to decode protobuf for topic %s", short_topic)
             return
 
+        # Log every decoded broadcast at DEBUG so tools/narwal_capture.py
+        # (and ad-hoc protocol RE) can pick them out of `ha core logs`.
+        # Cheap when DEBUG isn't enabled — _LOGGER.debug short-circuits.
+        _LOGGER.debug("DUMP %s: %r", short_topic, decoded)
         if short_topic == "status/working_status":
             self.state.update_from_working_status(decoded)
         elif short_topic == "status/robot_base_status":

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -914,6 +914,64 @@ class NarwalClient:
             timeout=10.0,
         )
 
+    async def start_freo_mind(self, **kwargs) -> CommandResponse:
+        """Start a Freo Mind (AI auto) whole-house clean.
+
+        Flow 2 only. Reverse-engineered from a live capture of an
+        app-initiated Freo Mind clean (firmware v01.07.19.00):
+
+            {1: {2: {}, 5: {1: {1: 4, 2: 2, 3: 1}, 7: {1: {}}}}}
+
+          field 5.1.1 = mode (4 = Vacuum and mop)
+          field 5.1.2 = mop humidity (2 = Standard)
+          field 5.1.3 = "Freo Mind / AI auto" marker (1)
+          field 5.7   = secondary marker also present in Freo Mind cleans
+        """
+        import blackboxprotobuf
+
+        msg = {
+            "1": {
+                "2": {},
+                "5": {
+                    "1": {"1": 4, "2": 2, "3": 1},
+                    "7": {"1": {}},
+                },
+            }
+        }
+        typedef = {
+            "1": {
+                "type": "message",
+                "message_typedef": {
+                    "2": {"type": "message", "message_typedef": {}},
+                    "5": {
+                        "type": "message",
+                        "message_typedef": {
+                            "1": {
+                                "type": "message",
+                                "message_typedef": {
+                                    "1": {"type": "int"},
+                                    "2": {"type": "int"},
+                                    "3": {"type": "int"},
+                                },
+                            },
+                            "7": {
+                                "type": "message",
+                                "message_typedef": {
+                                    "1": {"type": "message", "message_typedef": {}},
+                                },
+                            },
+                        },
+                    },
+                },
+            }
+        }
+        payload = blackboxprotobuf.encode_message(msg, typedef)
+        return await self.send_command(
+            TOPIC_CMD_START_CLEAN,
+            payload=payload,
+            timeout=10.0,
+        )
+
     def _build_room_clean_payload(self, room_ids: list[int]) -> bytes:
         """Build CleanTask protobuf with per-room clean params in field 1.2.
 

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -1144,7 +1144,8 @@ class NarwalClient:
     async def get_map(self) -> MapData:
         """Download the full map data."""
         resp = await self.send_command(TOPIC_CMD_GET_MAP, timeout=15.0)
-        map_data = MapData.from_response(resp.data)
+        product_key = self.state.device_info.product_key if self.state.device_info else None
+        map_data = MapData.from_response(resp.data, product_key=product_key)
         self.state.map_data = map_data
         return map_data
 

--- a/custom_components/narwal/narwal_client/const.py
+++ b/custom_components/narwal/narwal_client/const.py
@@ -169,6 +169,7 @@ class WorkingStatus(IntEnum):
     CLEANING_ALT = 5  # cleaning — observed when robot was physically stuck; may indicate error/stuck state
     DOCKED = 10       # on dock (does NOT reliably indicate charging vs charged)
     CHARGED = 14      # on dock (reported before 100% — use battery_level for charge state)
+    MOP_DRYING = 17   # station is drying the mop (Flow 2, observed live after a clean)
     # PLACEHOLDER: error state value not yet observed live.
     # Trigger a real error (e.g., pick up robot mid-clean) to discover the value.
     ERROR = 99

--- a/custom_components/narwal/narwal_client/const.py
+++ b/custom_components/narwal/narwal_client/const.py
@@ -164,6 +164,7 @@ class WorkingStatus(IntEnum):
 
     UNKNOWN = 0
     STANDBY = 1       # idle / transition state
+    MOP_WASHING = 3   # robot is washing the mop on the station (Flow 2, observed live)
     CLEANING = 4      # active cleaning (stays 4 even while returning to dock)
     CLEANING_ALT = 5  # cleaning — observed when robot was physically stuck; may indicate error/stuck state
     DOCKED = 10       # on dock (does NOT reliably indicate charging vs charged)

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -523,6 +523,14 @@ class NarwalState:
     fan_level_raw: int = 0
     mop_humidity_raw: int = 0
 
+    # Station / consumables. Field 41 is broadcast as a percentage that
+    # tracks dust-bag remaining capacity (100 = healthy/empty bag, drops
+    # toward 0 as it fills). Validated against the app's "Dust bag:
+    # Healthy" indicator at 100. Other tank/solution levels (clean
+    # water, dirty water, cleaning solution, mop pad wear) are not yet
+    # mapped — most appear constant at 1 (=OK) until a fault occurs.
+    dust_bag_health: int = 0
+
     # Device identity
     device_info: DeviceInfo | None = None
 
@@ -710,6 +718,12 @@ class NarwalState:
                 self.mop_humidity_raw = int(decoded["29"])
             except (ValueError, TypeError):
                 self.mop_humidity_raw = 0
+        # Field 41 = dust bag remaining capacity, 0–100.
+        if "41" in decoded:
+            try:
+                self.dust_bag_health = int(decoded["41"])
+            except (ValueError, TypeError):
+                self.dust_bag_health = 0
         # Field 47 = dock indicator (3=docked, 2=undocked)
         if "47" in decoded:
             try:

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -516,6 +516,13 @@ class NarwalState:
     firmware_version: str = ""
     firmware_target: str = ""
 
+    # Current clean settings (Flow 2 — live-broadcast in robot_base_status).
+    # 0 means "not yet observed" (the robot uses 1-indexed values).
+    #   field 26 = suction (1=Quiet, 2=Standard, 3=Strong, 4=Super powerful)
+    #   field 29 = mop humidity (1=Slightly dry, 2=Standard, 3=Slightly wet)
+    fan_level_raw: int = 0
+    mop_humidity_raw: int = 0
+
     # Device identity
     device_info: DeviceInfo | None = None
 
@@ -687,6 +694,22 @@ class NarwalState:
                 self.dock_field11 = int(decoded["11"])
             except (ValueError, TypeError):
                 self.dock_field11 = 0
+        # Field 26 = current suction level (Flow 2 only; live captures from
+        # firmware v01.07.19.00 confirm the 1-indexed scale 1=Quiet,
+        # 2=Standard, 3=Strong, 4=Super powerful). Not observed on Flow 1
+        # — leaves fan_level_raw at 0 there.
+        if "26" in decoded:
+            try:
+                self.fan_level_raw = int(decoded["26"])
+            except (ValueError, TypeError):
+                self.fan_level_raw = 0
+        # Field 29 = current mop humidity (Flow 2). 1=Slightly dry,
+        # 2=Standard, 3=Slightly wet (live-confirmed).
+        if "29" in decoded:
+            try:
+                self.mop_humidity_raw = int(decoded["29"])
+            except (ValueError, TypeError):
+                self.mop_humidity_raw = 0
         # Field 47 = dock indicator (3=docked, 2=undocked)
         if "47" in decoded:
             try:

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -18,17 +18,67 @@ class DeviceInfo:
     firmware_version: str = ""
 
 
+# ROOM_TYPE enum → display name (Flow 1 / AX12, from APK libapp.so strings).
+_FLOW1_ROOM_TYPE_NAMES: dict[int, str] = {
+    0: "Room",
+    1: "Primary Bedroom",
+    2: "Secondary Bedroom",
+    3: "Living Room",
+    4: "Kitchen",
+    5: "Study",
+    6: "Bathroom",
+    7: "Dining Room",
+    8: "Corridor",
+    9: "Balcony",
+    10: "Utility Room",
+    11: "Cloak Room",
+    12: "Nursery",
+    13: "Recreation Room",
+    14: "Shower Room",
+    15: "Other",
+}
+
+# Flow 2 reorders the ROOM_TYPE enum vs Flow 1. Confirmed via live capture
+# (firmware v01.07.19.00, product_key QxMSPG6VSO) by walking every type in
+# the Narwal app's room-type picker. Only deltas are listed; sub_types not
+# present here use the Flow 1 name.
+_FLOW2_ROOM_TYPE_OVERRIDES: dict[int, str] = {
+    1: "Master Bedroom",
+    5: "Bathroom",
+    6: "Toilet",
+    7: "Balcony",
+    8: "Dining Room",
+    9: "Cloakroom",
+    10: "Corridor",
+    11: "Study",
+    14: "Storage Room",
+}
+
+# product_keys that use the Flow 2 mapping. Add more as community confirms.
+_FLOW2_PRODUCT_KEYS: frozenset[str] = frozenset({"QxMSPG6VSO"})
+
+
+def get_room_type_names(product_key: str | None) -> dict[int, str]:
+    """Return the ROOM_TYPE → display-name mapping for a given device.
+
+    Flow 2 (and possibly other newer models) renamed/reordered the ROOM_TYPE
+    enum. We pick the right base mapping from product_key and fall back to
+    Flow 1 for unknown devices.
+    """
+    base = dict(_FLOW1_ROOM_TYPE_NAMES)
+    if product_key and product_key in _FLOW2_PRODUCT_KEYS:
+        base.update(_FLOW2_ROOM_TYPE_OVERRIDES)
+    return base
+
+
 @dataclass
 class RoomInfo:
     """A room on the map.
 
     Fields from get_map / get_editable_map field 2.12:
       field 1: room_id (matches pixel value >> 8 in map grid)
-      field 2: room_sub_type — ROOM_TYPE enum from APK (0=unspecified,
-               1=main bedroom, 2=secondary room, 3=living room, 4=kitchen,
-               5=study, 6=bathroom, 7=dining room, 8=corridor, 9=balcony,
-               10=utility room, 11=cloak room, 12=nursery, 13=recreation,
-               14=shower room, 15=other)
+      field 2: room_sub_type — ROOM_TYPE enum from APK. The string mapping
+               differs between Flow 1 and Flow 2 (see get_room_type_names).
       field 3: user-assigned name (UTF-8, empty if not named by user)
       field 4: category (1=room, 2=utility/small space)
       field 8: instance_index (1-based, for numbering duplicates: Bathroom 1, 2, 3...)
@@ -40,29 +90,13 @@ class RoomInfo:
     category: int = 0  # 1=room, 2=utility (field 4)
     instance_index: int = 0  # numbering for duplicates (field 8)
 
-    # ROOM_TYPE enum → default display name (from APK libapp.so string analysis)
+    # ROOM_TYPE enum → default display name. Set by MapData.from_response
+    # based on the connected device's product_key; defaults to Flow 1 names.
     ROOM_TYPE_NAMES: dict[int, str] = field(default=None, repr=False)
 
     def __post_init__(self):
         if self.ROOM_TYPE_NAMES is None:
-            object.__setattr__(self, "ROOM_TYPE_NAMES", {
-                0: "Room",
-                1: "Primary Bedroom",
-                2: "Secondary Bedroom",
-                3: "Living Room",
-                4: "Kitchen",
-                5: "Study",
-                6: "Bathroom",
-                7: "Dining Room",
-                8: "Corridor",
-                9: "Balcony",
-                10: "Utility Room",
-                11: "Cloak Room",
-                12: "Nursery",
-                13: "Recreation Room",
-                14: "Shower Room",
-                15: "Other",
-            })
+            object.__setattr__(self, "ROOM_TYPE_NAMES", dict(_FLOW1_ROOM_TYPE_NAMES))
 
     @property
     def display_name(self) -> str:
@@ -238,11 +272,21 @@ class MapData:
     raw: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def from_response(cls, decoded: dict[str, Any]) -> MapData:
-        """Parse map data from a get_map field5 response."""
+    def from_response(
+        cls, decoded: dict[str, Any], product_key: str | None = None,
+    ) -> MapData:
+        """Parse map data from a get_map field5 response.
+
+        Args:
+            decoded: bbp-decoded map response payload.
+            product_key: Connected device's product_key. Selects the
+                ROOM_TYPE → display-name mapping (Flow 1 vs Flow 2).
+        """
         payload = decoded.get("2", {})
         if not payload:
             return cls()
+
+        type_names = get_room_type_names(product_key)
 
         rooms = []
         room_list = payload.get("12", [])
@@ -266,6 +310,7 @@ class MapData:
                     room_sub_type=int(room.get("2", 0)),
                     category=int(room.get("4", 0)),
                     instance_index=int(room.get("8", 0)),
+                    ROOM_TYPE_NAMES=type_names,
                 ))
 
         compressed = payload.get("17", b"")

--- a/custom_components/narwal/select.py
+++ b/custom_components/narwal/select.py
@@ -1,0 +1,90 @@
+"""Select entities for Narwal vacuum."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import NarwalConfigEntry
+from .coordinator import NarwalCoordinator
+from .entity import NarwalEntity
+from .narwal_client import MopHumidity
+
+_LOGGER = logging.getLogger(__name__)
+
+# Flow 2 broadcasts the live mop humidity in robot_base_status field 29
+# using a 1-indexed scale (1=Slightly dry, 2=Standard, 3=Slightly wet).
+_MOP_HUMIDITY_BROADCAST_TO_NAME: dict[int, str] = {
+    1: "slightly_dry",
+    2: "standard",
+    3: "slightly_wet",
+}
+
+# Maps the HA select option name to the MopHumidity enum value sent over
+# the wire by client.set_mop_humidity().
+_MOP_HUMIDITY_NAME_TO_ENUM: dict[str, MopHumidity] = {
+    "slightly_dry": MopHumidity.DRY,
+    "standard": MopHumidity.NORMAL,
+    "slightly_wet": MopHumidity.WET,
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: NarwalConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Narwal select entities."""
+    coordinator = entry.runtime_data
+    async_add_entities([NarwalMopHumiditySelect(coordinator)])
+
+
+class NarwalMopHumiditySelect(NarwalEntity, SelectEntity):
+    """Select entity for the vacuum's mop humidity setting."""
+
+    _attr_translation_key = "mop_humidity"
+    _attr_options = list(_MOP_HUMIDITY_NAME_TO_ENUM.keys())
+    _attr_icon = "mdi:water-percent"
+
+    def __init__(self, coordinator: NarwalCoordinator) -> None:
+        super().__init__(coordinator)
+        device_id = coordinator.config_entry.data["device_id"]
+        self._attr_unique_id = f"{device_id}_mop_humidity"
+        self._last_set: str | None = None
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current mop humidity setting.
+
+        Like fan_speed, the broadcasted value (field 29) only reflects
+        the *active* clean and reverts to a default while docked. We
+        prefer the live broadcast during cleaning, otherwise show the
+        last user-set value.
+        """
+        state = self.coordinator.data
+        if state is not None:
+            from .narwal_client import WorkingStatus  # local import to avoid cycle
+            cleaning = state.working_status in (
+                WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT,
+            )
+            if cleaning and state.mop_humidity_raw in _MOP_HUMIDITY_BROADCAST_TO_NAME:
+                return _MOP_HUMIDITY_BROADCAST_TO_NAME[state.mop_humidity_raw]
+        return self._last_set
+
+    async def async_select_option(self, option: str) -> None:
+        """Set the mop humidity on the robot."""
+        level = _MOP_HUMIDITY_NAME_TO_ENUM.get(option)
+        if level is None:
+            _LOGGER.warning("Unknown mop humidity option: %s", option)
+            return
+        resp = await self.coordinator.client.set_mop_humidity(level)
+        _LOGGER.info(
+            "Set mop humidity %s (enum=%d): code=%s, success=%s",
+            option, int(level), resp.result_code, resp.success,
+        )
+        if resp.success:
+            self._last_set = option
+            self.async_write_ha_state()

--- a/custom_components/narwal/sensor.py
+++ b/custom_components/narwal/sensor.py
@@ -15,7 +15,7 @@ from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfArea, UnitOfTi
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .narwal_client import NarwalState
+from .narwal_client import NarwalState, WorkingStatus
 
 from . import NarwalConfigEntry
 from .coordinator import NarwalCoordinator
@@ -67,6 +67,15 @@ SENSOR_DESCRIPTIONS: tuple[NarwalSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda state: state.firmware_version or None,
     ),
+    NarwalSensorEntityDescription(
+        key="dust_bag_health",
+        translation_key="dust_bag_health",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        # robot_base_status field 41: 100 = bag healthy/empty, drops as full.
+        value_fn=lambda state: state.dust_bag_health or None,
+    ),
 )
 
 
@@ -81,6 +90,7 @@ async def async_setup_entry(
         NarwalSensor(coordinator, description) for description in SENSOR_DESCRIPTIONS
     ]
     entities.append(NarwalChargingStateSensor(coordinator))
+    entities.append(NarwalStationActivitySensor(coordinator))
     async_add_entities(entities)
 
 
@@ -147,3 +157,33 @@ class NarwalChargingStateSensor(NarwalEntity, SensorEntity):
         if self.native_value == "not_charging":
             return "mdi:battery-off-outline"
         return "mdi:battery-unknown"
+
+
+class NarwalStationActivitySensor(NarwalEntity, SensorEntity):
+    """Reports what the dock station is currently doing.
+
+    Derived from the robot's working_status. Distinct from the vacuum's
+    own activity because the station can run mop wash/dry cycles while
+    the robot itself is parked on it.
+    """
+
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_translation_key = "station_activity"
+    _attr_options = ["idle", "mop_washing", "mop_drying"]
+    _attr_icon = "mdi:dishwasher"
+
+    def __init__(self, coordinator: NarwalCoordinator) -> None:
+        super().__init__(coordinator)
+        device_id = coordinator.config_entry.data["device_id"]
+        self._attr_unique_id = f"{device_id}_station_activity"
+
+    @property
+    def native_value(self) -> str | None:
+        state = self.coordinator.data
+        if state is None:
+            return None
+        if state.working_status == WorkingStatus.MOP_WASHING:
+            return "mop_washing"
+        if state.working_status == WorkingStatus.MOP_DRYING:
+            return "mop_drying"
+        return "idle"

--- a/custom_components/narwal/strings.json
+++ b/custom_components/narwal/strings.json
@@ -55,6 +55,16 @@
       "charging": {
         "name": "Charging"
       }
+    },
+    "select": {
+      "mop_humidity": {
+        "name": "Mop humidity",
+        "state": {
+          "slightly_dry": "Slightly dry",
+          "standard": "Standard",
+          "slightly_wet": "Slightly wet"
+        }
+      }
     }
   }
 }

--- a/custom_components/narwal/strings.json
+++ b/custom_components/narwal/strings.json
@@ -42,6 +42,17 @@
           "fully_charged": "Fully Charged",
           "not_charging": "Not Charging"
         }
+      },
+      "dust_bag_health": {
+        "name": "Dust bag health"
+      },
+      "station_activity": {
+        "name": "Station activity",
+        "state": {
+          "idle": "Idle",
+          "mop_washing": "Mop washing",
+          "mop_drying": "Mop drying"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/narwal/translations/en.json
+++ b/custom_components/narwal/translations/en.json
@@ -42,6 +42,17 @@
           "fully_charged": "Fully Charged",
           "not_charging": "Not Charging"
         }
+      },
+      "dust_bag_health": {
+        "name": "Dust bag health"
+      },
+      "station_activity": {
+        "name": "Station activity",
+        "state": {
+          "idle": "Idle",
+          "mop_washing": "Mop washing",
+          "mop_drying": "Mop drying"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/narwal/translations/en.json
+++ b/custom_components/narwal/translations/en.json
@@ -3,10 +3,11 @@
     "step": {
       "user": {
         "title": "Connect to Narwal Vacuum",
-        "description": "Enter the IP address of your Narwal robot vacuum.",
+        "description": "Enter the IP address of your Narwal robot vacuum and select your model.",
         "data": {
           "host": "IP Address",
-          "port": "Port"
+          "port": "Port",
+          "model": "Model"
         }
       }
     },
@@ -49,6 +50,19 @@
         "state": {
           "on": "Docked",
           "off": "Undocked"
+        }
+      },
+      "charging": {
+        "name": "Charging"
+      }
+    },
+    "select": {
+      "mop_humidity": {
+        "name": "Mop humidity",
+        "state": {
+          "slightly_dry": "Slightly dry",
+          "standard": "Standard",
+          "slightly_wet": "Slightly wet"
         }
       }
     }

--- a/custom_components/narwal/vacuum.py
+++ b/custom_components/narwal/vacuum.py
@@ -60,6 +60,7 @@ class NarwalVacuum(NarwalEntity, StateVacuumEntity):
         | VacuumEntityFeature.RETURN_HOME
         | VacuumEntityFeature.FAN_SPEED
         | VacuumEntityFeature.LOCATE
+        | VacuumEntityFeature.SEND_COMMAND
     ) | (VacuumEntityFeature.CLEAN_AREA if Segment is not None else VacuumEntityFeature(0))
     _attr_fan_speed_list = FAN_SPEED_LIST
 
@@ -184,6 +185,33 @@ class NarwalVacuum(NarwalEntity, StateVacuumEntity):
         """Locate the vacuum — robot says 'Robot is here'."""
         await self._ensure_awake()
         await self.coordinator.client.locate()
+
+    async def async_send_command(
+        self,
+        command: str,
+        params: dict | list | None = None,
+        **kwargs,
+    ) -> None:
+        """Handle vacuum.send_command service calls.
+
+        Supported commands:
+          - "freo_mind" / "freo_mind_start": start a Freo Mind (AI auto)
+            whole-house clean. Flow 2 only.
+        """
+        if command in ("freo_mind", "freo_mind_start"):
+            await self._ensure_awake()
+            resp = await self.coordinator.client.start_freo_mind()
+            _LOGGER.info(
+                "Freo Mind start: code=%s, success=%s",
+                resp.result_code, resp.success,
+            )
+            if not resp.success:
+                _LOGGER.warning(
+                    "Freo Mind start did not succeed (code=%s)",
+                    resp.result_code,
+                )
+            return
+        _LOGGER.warning("Unknown vacuum command: %s", command)
 
     async def async_set_fan_speed(self, fan_speed: str, **kwargs) -> None:
         """Set the fan speed."""

--- a/custom_components/narwal/vacuum.py
+++ b/custom_components/narwal/vacuum.py
@@ -99,10 +99,16 @@ class NarwalVacuum(NarwalEntity, StateVacuumEntity):
     def fan_speed(self) -> str | None:
         """Return the current fan speed.
 
-        The robot protocol does not broadcast the active fan speed setting,
-        so we track the last value set via the integration. Returns None
-        until the user sets a fan speed for the first time.
+        Flow 2 broadcasts the live suction level in robot_base_status
+        field 26 (1-indexed). For Flow 1 the robot does not broadcast it;
+        we fall back to the last value set via the integration.
         """
+        state = self.coordinator.data
+        # Flow 2 1-indexed scale (1=Quiet, 2=Standard, 3=Strong, 4=Super powerful)
+        # mapped onto the existing FAN_SPEED_LIST labels.
+        flow2_levels = {1: "quiet", 2: "normal", 3: "strong", 4: "max"}
+        if state is not None and state.fan_level_raw in flow2_levels:
+            return flow2_levels[state.fan_level_raw]
         return self._last_fan_speed
 
     # Timeout for action commands (start/stop/return) — robot may need

--- a/custom_components/narwal/vacuum.py
+++ b/custom_components/narwal/vacuum.py
@@ -100,14 +100,21 @@ class NarwalVacuum(NarwalEntity, StateVacuumEntity):
         """Return the current fan speed.
 
         Flow 2 broadcasts the live suction level in robot_base_status
-        field 26 (1-indexed). For Flow 1 the robot does not broadcast it;
-        we fall back to the last value set via the integration.
+        field 26 (1-indexed) but only while a clean task is active;
+        when docked/idle the field reverts to a default that doesn't
+        reflect the user's stored preference. So we only trust the
+        broadcast during cleaning, and fall back to the last
+        user-set value otherwise (matches the original behaviour).
         """
         state = self.coordinator.data
-        # Flow 2 1-indexed scale (1=Quiet, 2=Standard, 3=Strong, 4=Super powerful)
-        # mapped onto the existing FAN_SPEED_LIST labels.
         flow2_levels = {1: "quiet", 2: "normal", 3: "strong", 4: "max"}
-        if state is not None and state.fan_level_raw in flow2_levels:
+        if (
+            state is not None
+            and state.working_status in (
+                WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT,
+            )
+            and state.fan_level_raw in flow2_levels
+        ):
             return flow2_levels[state.fan_level_raw]
         return self._last_fan_speed
 

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -408,6 +408,10 @@ class NarwalClient:
             _LOGGER.debug("Failed to decode protobuf for topic %s", short_topic)
             return
 
+        # Log every decoded broadcast at DEBUG so tools/narwal_capture.py
+        # (and ad-hoc protocol RE) can pick them out of `ha core logs`.
+        # Cheap when DEBUG isn't enabled — _LOGGER.debug short-circuits.
+        _LOGGER.debug("DUMP %s: %r", short_topic, decoded)
         if short_topic == "status/working_status":
             self.state.update_from_working_status(decoded)
         elif short_topic == "status/robot_base_status":

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -914,6 +914,64 @@ class NarwalClient:
             timeout=10.0,
         )
 
+    async def start_freo_mind(self, **kwargs) -> CommandResponse:
+        """Start a Freo Mind (AI auto) whole-house clean.
+
+        Flow 2 only. Reverse-engineered from a live capture of an
+        app-initiated Freo Mind clean (firmware v01.07.19.00):
+
+            {1: {2: {}, 5: {1: {1: 4, 2: 2, 3: 1}, 7: {1: {}}}}}
+
+          field 5.1.1 = mode (4 = Vacuum and mop)
+          field 5.1.2 = mop humidity (2 = Standard)
+          field 5.1.3 = "Freo Mind / AI auto" marker (1)
+          field 5.7   = secondary marker also present in Freo Mind cleans
+        """
+        import blackboxprotobuf
+
+        msg = {
+            "1": {
+                "2": {},
+                "5": {
+                    "1": {"1": 4, "2": 2, "3": 1},
+                    "7": {"1": {}},
+                },
+            }
+        }
+        typedef = {
+            "1": {
+                "type": "message",
+                "message_typedef": {
+                    "2": {"type": "message", "message_typedef": {}},
+                    "5": {
+                        "type": "message",
+                        "message_typedef": {
+                            "1": {
+                                "type": "message",
+                                "message_typedef": {
+                                    "1": {"type": "int"},
+                                    "2": {"type": "int"},
+                                    "3": {"type": "int"},
+                                },
+                            },
+                            "7": {
+                                "type": "message",
+                                "message_typedef": {
+                                    "1": {"type": "message", "message_typedef": {}},
+                                },
+                            },
+                        },
+                    },
+                },
+            }
+        }
+        payload = blackboxprotobuf.encode_message(msg, typedef)
+        return await self.send_command(
+            TOPIC_CMD_START_CLEAN,
+            payload=payload,
+            timeout=10.0,
+        )
+
     def _build_room_clean_payload(self, room_ids: list[int]) -> bytes:
         """Build CleanTask protobuf with per-room clean params in field 1.2.
 

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -1144,7 +1144,8 @@ class NarwalClient:
     async def get_map(self) -> MapData:
         """Download the full map data."""
         resp = await self.send_command(TOPIC_CMD_GET_MAP, timeout=15.0)
-        map_data = MapData.from_response(resp.data)
+        product_key = self.state.device_info.product_key if self.state.device_info else None
+        map_data = MapData.from_response(resp.data, product_key=product_key)
         self.state.map_data = map_data
         return map_data
 

--- a/narwal_client/const.py
+++ b/narwal_client/const.py
@@ -169,6 +169,7 @@ class WorkingStatus(IntEnum):
     CLEANING_ALT = 5  # cleaning — observed when robot was physically stuck; may indicate error/stuck state
     DOCKED = 10       # on dock (does NOT reliably indicate charging vs charged)
     CHARGED = 14      # on dock (reported before 100% — use battery_level for charge state)
+    MOP_DRYING = 17   # station is drying the mop (Flow 2, observed live after a clean)
     # PLACEHOLDER: error state value not yet observed live.
     # Trigger a real error (e.g., pick up robot mid-clean) to discover the value.
     ERROR = 99

--- a/narwal_client/const.py
+++ b/narwal_client/const.py
@@ -164,6 +164,7 @@ class WorkingStatus(IntEnum):
 
     UNKNOWN = 0
     STANDBY = 1       # idle / transition state
+    MOP_WASHING = 3   # robot is washing the mop on the station (Flow 2, observed live)
     CLEANING = 4      # active cleaning (stays 4 even while returning to dock)
     CLEANING_ALT = 5  # cleaning — observed when robot was physically stuck; may indicate error/stuck state
     DOCKED = 10       # on dock (does NOT reliably indicate charging vs charged)

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -523,6 +523,14 @@ class NarwalState:
     fan_level_raw: int = 0
     mop_humidity_raw: int = 0
 
+    # Station / consumables. Field 41 is broadcast as a percentage that
+    # tracks dust-bag remaining capacity (100 = healthy/empty bag, drops
+    # toward 0 as it fills). Validated against the app's "Dust bag:
+    # Healthy" indicator at 100. Other tank/solution levels (clean
+    # water, dirty water, cleaning solution, mop pad wear) are not yet
+    # mapped — most appear constant at 1 (=OK) until a fault occurs.
+    dust_bag_health: int = 0
+
     # Device identity
     device_info: DeviceInfo | None = None
 
@@ -710,6 +718,12 @@ class NarwalState:
                 self.mop_humidity_raw = int(decoded["29"])
             except (ValueError, TypeError):
                 self.mop_humidity_raw = 0
+        # Field 41 = dust bag remaining capacity, 0–100.
+        if "41" in decoded:
+            try:
+                self.dust_bag_health = int(decoded["41"])
+            except (ValueError, TypeError):
+                self.dust_bag_health = 0
         # Field 47 = dock indicator (3=docked, 2=undocked)
         if "47" in decoded:
             try:

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -516,6 +516,13 @@ class NarwalState:
     firmware_version: str = ""
     firmware_target: str = ""
 
+    # Current clean settings (Flow 2 — live-broadcast in robot_base_status).
+    # 0 means "not yet observed" (the robot uses 1-indexed values).
+    #   field 26 = suction (1=Quiet, 2=Standard, 3=Strong, 4=Super powerful)
+    #   field 29 = mop humidity (1=Slightly dry, 2=Standard, 3=Slightly wet)
+    fan_level_raw: int = 0
+    mop_humidity_raw: int = 0
+
     # Device identity
     device_info: DeviceInfo | None = None
 
@@ -687,6 +694,22 @@ class NarwalState:
                 self.dock_field11 = int(decoded["11"])
             except (ValueError, TypeError):
                 self.dock_field11 = 0
+        # Field 26 = current suction level (Flow 2 only; live captures from
+        # firmware v01.07.19.00 confirm the 1-indexed scale 1=Quiet,
+        # 2=Standard, 3=Strong, 4=Super powerful). Not observed on Flow 1
+        # — leaves fan_level_raw at 0 there.
+        if "26" in decoded:
+            try:
+                self.fan_level_raw = int(decoded["26"])
+            except (ValueError, TypeError):
+                self.fan_level_raw = 0
+        # Field 29 = current mop humidity (Flow 2). 1=Slightly dry,
+        # 2=Standard, 3=Slightly wet (live-confirmed).
+        if "29" in decoded:
+            try:
+                self.mop_humidity_raw = int(decoded["29"])
+            except (ValueError, TypeError):
+                self.mop_humidity_raw = 0
         # Field 47 = dock indicator (3=docked, 2=undocked)
         if "47" in decoded:
             try:

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -18,17 +18,67 @@ class DeviceInfo:
     firmware_version: str = ""
 
 
+# ROOM_TYPE enum → display name (Flow 1 / AX12, from APK libapp.so strings).
+_FLOW1_ROOM_TYPE_NAMES: dict[int, str] = {
+    0: "Room",
+    1: "Primary Bedroom",
+    2: "Secondary Bedroom",
+    3: "Living Room",
+    4: "Kitchen",
+    5: "Study",
+    6: "Bathroom",
+    7: "Dining Room",
+    8: "Corridor",
+    9: "Balcony",
+    10: "Utility Room",
+    11: "Cloak Room",
+    12: "Nursery",
+    13: "Recreation Room",
+    14: "Shower Room",
+    15: "Other",
+}
+
+# Flow 2 reorders the ROOM_TYPE enum vs Flow 1. Confirmed via live capture
+# (firmware v01.07.19.00, product_key QxMSPG6VSO) by walking every type in
+# the Narwal app's room-type picker. Only deltas are listed; sub_types not
+# present here use the Flow 1 name.
+_FLOW2_ROOM_TYPE_OVERRIDES: dict[int, str] = {
+    1: "Master Bedroom",
+    5: "Bathroom",
+    6: "Toilet",
+    7: "Balcony",
+    8: "Dining Room",
+    9: "Cloakroom",
+    10: "Corridor",
+    11: "Study",
+    14: "Storage Room",
+}
+
+# product_keys that use the Flow 2 mapping. Add more as community confirms.
+_FLOW2_PRODUCT_KEYS: frozenset[str] = frozenset({"QxMSPG6VSO"})
+
+
+def get_room_type_names(product_key: str | None) -> dict[int, str]:
+    """Return the ROOM_TYPE → display-name mapping for a given device.
+
+    Flow 2 (and possibly other newer models) renamed/reordered the ROOM_TYPE
+    enum. We pick the right base mapping from product_key and fall back to
+    Flow 1 for unknown devices.
+    """
+    base = dict(_FLOW1_ROOM_TYPE_NAMES)
+    if product_key and product_key in _FLOW2_PRODUCT_KEYS:
+        base.update(_FLOW2_ROOM_TYPE_OVERRIDES)
+    return base
+
+
 @dataclass
 class RoomInfo:
     """A room on the map.
 
     Fields from get_map / get_editable_map field 2.12:
       field 1: room_id (matches pixel value >> 8 in map grid)
-      field 2: room_sub_type — ROOM_TYPE enum from APK (0=unspecified,
-               1=main bedroom, 2=secondary room, 3=living room, 4=kitchen,
-               5=study, 6=bathroom, 7=dining room, 8=corridor, 9=balcony,
-               10=utility room, 11=cloak room, 12=nursery, 13=recreation,
-               14=shower room, 15=other)
+      field 2: room_sub_type — ROOM_TYPE enum from APK. The string mapping
+               differs between Flow 1 and Flow 2 (see get_room_type_names).
       field 3: user-assigned name (UTF-8, empty if not named by user)
       field 4: category (1=room, 2=utility/small space)
       field 8: instance_index (1-based, for numbering duplicates: Bathroom 1, 2, 3...)
@@ -40,29 +90,13 @@ class RoomInfo:
     category: int = 0  # 1=room, 2=utility (field 4)
     instance_index: int = 0  # numbering for duplicates (field 8)
 
-    # ROOM_TYPE enum → default display name (from APK libapp.so string analysis)
+    # ROOM_TYPE enum → default display name. Set by MapData.from_response
+    # based on the connected device's product_key; defaults to Flow 1 names.
     ROOM_TYPE_NAMES: dict[int, str] = field(default=None, repr=False)
 
     def __post_init__(self):
         if self.ROOM_TYPE_NAMES is None:
-            object.__setattr__(self, "ROOM_TYPE_NAMES", {
-                0: "Room",
-                1: "Primary Bedroom",
-                2: "Secondary Bedroom",
-                3: "Living Room",
-                4: "Kitchen",
-                5: "Study",
-                6: "Bathroom",
-                7: "Dining Room",
-                8: "Corridor",
-                9: "Balcony",
-                10: "Utility Room",
-                11: "Cloak Room",
-                12: "Nursery",
-                13: "Recreation Room",
-                14: "Shower Room",
-                15: "Other",
-            })
+            object.__setattr__(self, "ROOM_TYPE_NAMES", dict(_FLOW1_ROOM_TYPE_NAMES))
 
     @property
     def display_name(self) -> str:
@@ -238,11 +272,21 @@ class MapData:
     raw: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def from_response(cls, decoded: dict[str, Any]) -> MapData:
-        """Parse map data from a get_map field5 response."""
+    def from_response(
+        cls, decoded: dict[str, Any], product_key: str | None = None,
+    ) -> MapData:
+        """Parse map data from a get_map field5 response.
+
+        Args:
+            decoded: bbp-decoded map response payload.
+            product_key: Connected device's product_key. Selects the
+                ROOM_TYPE → display-name mapping (Flow 1 vs Flow 2).
+        """
         payload = decoded.get("2", {})
         if not payload:
             return cls()
+
+        type_names = get_room_type_names(product_key)
 
         rooms = []
         room_list = payload.get("12", [])
@@ -266,6 +310,7 @@ class MapData:
                     room_sub_type=int(room.get("2", 0)),
                     category=int(room.get("4", 0)),
                     instance_index=int(room.get("8", 0)),
+                    ROOM_TYPE_NAMES=type_names,
                 ))
 
         compressed = payload.get("17", b"")


### PR DESCRIPTION
## Summary

Surfaces protocol fields that Flow 2 broadcasts but the integration was throwing away, plus a couple of small UX improvements built on top. All changes were validated live against a Flow 2 (firmware `v01.07.19.00`, `product_key QxMSPG6VSO`) by walking each setting via the Narwal app's Customization tab and diffing the resulting broadcasts.

Stacked on top of #28 (the Flow 2 room-label PR — please merge that first). All five commits keep their Flow 2 logic guarded so Flow 1 behaviour is unchanged.

## What's in here

### Read live suction / mop humidity from `robot_base_status`

| Field | Meaning | Values (1-indexed) |
|-------|---------|--------------------|
| 26 | Suction level | 1 Quiet, 2 Standard, 3 Strong, 4 Super powerful |
| 29 | Mop humidity | 1 Slightly dry, 2 Standard, 3 Slightly wet |
| 41 | Dust-bag remaining capacity | 0–100 (% — 100 matches the app's \"Healthy\" indicator) |

Both 26 and 29 confirmed by changing the value live in the app and capturing the diff. Stored on `NarwalState` as `fan_level_raw`, `mop_humidity_raw`, `dust_bag_health` so other entities can read them.

### `vacuum.fan_speed` becomes readable on Flow 2

Field 26 reverts to a stale default while the robot is docked, so we only trust the live broadcast during `CLEANING` / `CLEANING_ALT` and fall back to the cached \"last value set\" otherwise. That preserves Flow 1's set-only behaviour and avoids the bug where setting fan_speed in HA was instantly overwritten by the next docked-state broadcast.

### `select.mop_humidity` (new Select entity)

Surfaces what was already implemented as `client.set_mop_humidity()` but had no UI. Same broadcast-during-cleaning vs. last-set-otherwise semantics as fan_speed. Adds `Platform.SELECT` to `PLATFORMS` and an `entity.select.mop_humidity` translation block.

### Start Freo Mind from HA

Adds `client.start_freo_mind()` and routes it through `vacuum.send_command`:

```yaml
service: vacuum.send_command
target:
  entity_id: vacuum.narwal_flow_2_vacuum
data:
  command: freo_mind
```

Payload is reverse-engineered from a live capture of an app-initiated Freo Mind clean — the AI-auto marker is `field 5.1.3 = 1` plus a secondary `5.7` message in the clean-task config. Adds `VacuumEntityFeature.SEND_COMMAND` to supported_features.

### Station sensors

The dock can run mop wash / dry cycles while the robot is parked, so the vacuum's own activity isn't enough to surface what's happening at the station:

- `sensor.station_activity` — enum of `idle` / `mop_washing` / `mop_drying`. Driven by two newly-named `WorkingStatus` values (`MOP_WASHING = 3`, `MOP_DRYING = 17`), both observed live during a dock mop-wash cycle.
- `sensor.dust_bag_health` — diagnostic % from field 41. Live state matches the app: 100 = Healthy, drops as the bag fills (no fault states captured yet).

Other consumables (clean/dirty water tank, cleaning solution, mop pad wear) sit at constant `1` across all captures and need a fault state to map — left for a follow-up once we observe one.

## Out of scope (still)

- Room-specific cleaning on Flow 2 (#25). Three iterations of the room-clean payload were tried locally; the robot accepts every variant with `code=1 SUCCESS` but still runs whole-house. Pinning down the right shape needs a packet capture of the app→robot WebSocket — happy to follow up once that's set up.
- Cycle (x1/x2/x3) — not present in any captured broadcast, so the encoding is opaque without packet capture.
- Coverage Precision (Standard/Meticulous) — write-side only. Read-mapping was tentatively `field 34 = 1 (Standard) vs absent (Meticulous)` but I don't trust it enough to ship as a sensor without a second test.

## Testing

- `models.py` parsers verified on captured broadcasts (Quiet/Standard/Strong/Super powerful → 1/2/3/4; Slightly dry/Standard/Slightly wet → 1/2/3).
- Live-tested in HA against a Flow 2:
  - `vacuum.fan_speed` shows the live value during cleaning, last-set value when docked, no longer flickers.
  - `select.mop_humidity` writes propagate via `set_mop_humidity()` and survive across broadcasts.
  - `vacuum.send_command command: freo_mind` starts a Freo Mind clean (verified end-to-end).
  - `sensor.station_activity` reports `idle` / `mop_washing` / `mop_drying` correctly during a station mop cycle.
  - `sensor.dust_bag_health` = 100 on a fresh bag.
- Flow 1 paths unchanged — `fan_level_raw`/`mop_humidity_raw` default to 0 (\"not yet observed\"), so the fan_speed property falls through to the original `_last_fan_speed` behaviour for non-Flow-2 devices.