### PR TITLE
Auto-discovery (Zeroconf + DHCP) + Flow 2 in model picker

### DIFF
--- a/custom_components/narwal/config_flow.py
+++ b/custom_components/narwal/config_flow.py
@@ -8,6 +8,8 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .narwal_client import NarwalClient, NarwalCommandError, NarwalConnectionError
 
@@ -30,6 +32,44 @@ class NarwalConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Narwal vacuum."""
 
     VERSION = 2
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Pre-filled host when discovery (zeroconf / DHCP) finds the
+        # robot before the user starts the flow.
+        self._discovered_host: str | None = None
+
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        """Pick up Narwal robots advertising `_narwal_sweeper._tcp.local.`.
+
+        Robots broadcast an instance name like
+        ``_app_wss_server_<6hex>._narwal_sweeper._tcp.local.`` with a
+        hostname ``NARWAL_<6hex>.local.`` on port 9002. We only use
+        the IP for now — the user still picks the model on the next
+        step, the model name isn't in the mDNS payload.
+        """
+        self._discovered_host = str(discovery_info.host)
+        await self.async_set_unique_id(discovery_info.hostname.rstrip("."))
+        self._abort_if_unique_id_configured(updates={"host": self._discovered_host})
+        self.context["title_placeholders"] = {"host": self._discovered_host}
+        return await self.async_step_user()
+
+    async def async_step_dhcp(
+        self, discovery_info: DhcpServiceInfo
+    ) -> ConfigFlowResult:
+        """Pick up Narwal robots from DHCP hostname matches.
+
+        Backup for when zeroconf is filtered (some routers / VLANs).
+        Hostname pattern ``NARWAL_*`` / ``narwal_*`` is declared in
+        manifest.json.
+        """
+        self._discovered_host = str(discovery_info.ip)
+        await self.async_set_unique_id(discovery_info.hostname or self._discovered_host)
+        self._abort_if_unique_id_configured(updates={"host": self._discovered_host})
+        self.context["title_placeholders"] = {"host": self._discovered_host}
+        return await self.async_step_user()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -85,8 +125,18 @@ class NarwalConfigFlow(ConfigFlow, domain=DOMAIN):
             finally:
                 await client.disconnect()
 
+        # If we got here from a discovery step, pre-fill the host so
+        # the user only has to confirm the model.
+        schema = STEP_USER_DATA_SCHEMA
+        if self._discovered_host and user_input is None:
+            schema = vol.Schema({
+                vol.Required("host", default=self._discovered_host): str,
+                vol.Optional("port", default=DEFAULT_PORT): int,
+                vol.Required(CONF_MODEL, default=MODEL_OPTIONS[0]): vol.In(MODEL_OPTIONS),
+            })
+
         return self.async_show_form(
             step_id="user",
-            data_schema=STEP_USER_DATA_SCHEMA,
+            data_schema=schema,
             errors=errors,
         )

--- a/custom_components/narwal/const.py
+++ b/custom_components/narwal/const.py
@@ -15,6 +15,7 @@ MODEL = "Flow (AX12)"
 # "auto" cycles all known keys during discovery (slower, fallback).
 NARWAL_MODELS: dict[str, str] = {
     "Narwal Flow": "QoEsI5qYXO",
+    "Narwal Flow 2": "QxMSPG6VSO",
     "Narwal Freo Z10 Ultra": "DrzDKQ0MU8",
     "Narwal Freo X10 Pro": "CNbforyZWI",
     "Other / Auto-detect": "auto",

--- a/custom_components/narwal/manifest.json
+++ b/custom_components/narwal/manifest.json
@@ -9,5 +9,18 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/sjmotew/NarwalIntegration/issues",
   "requirements": ["bbpb>=1.4.0", "Pillow>=9.0.0"],
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "zeroconf": [
+    {
+      "type": "_narwal_sweeper._tcp.local."
+    }
+  ],
+  "dhcp": [
+    {
+      "hostname": "narwal_*"
+    },
+    {
+      "hostname": "NARWAL_*"
+    }
+  ]
 }

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -1144,7 +1144,8 @@ class NarwalClient:
     async def get_map(self) -> MapData:
         """Download the full map data."""
         resp = await self.send_command(TOPIC_CMD_GET_MAP, timeout=15.0)
-        map_data = MapData.from_response(resp.data)
+        product_key = self.state.device_info.product_key if self.state.device_info else None
+        map_data = MapData.from_response(resp.data, product_key=product_key)
         self.state.map_data = map_data
         return map_data
 

--- a/custom_components/narwal/narwal_client/const.py
+++ b/custom_components/narwal/narwal_client/const.py
@@ -23,6 +23,7 @@ DEFAULT_TOPIC_PREFIX = "/QoEsI5qYXO"
 KNOWN_PRODUCT_KEYS = [
     # Confirmed working (local WebSocket)
     "QoEsI5qYXO",  # AX12 — Narwal Flow (primary, confirmed)
+    "QxMSPG6VSO",  # — Narwal Flow 2 (confirmed via live capture)
     "DrzDKQ0MU8",   # CX4  — Freo Z10 Ultra (confirmed by @irekkl-maker)
     # Confirmed cloud-only (port 9002 open but no local broadcasts)
     "BYWBPqSxeC",   # CX7  — Freo Z Ultra (cloud-only, confirmed by @gabrielozcomidi)

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -18,17 +18,67 @@ class DeviceInfo:
     firmware_version: str = ""
 
 
+# ROOM_TYPE enum → display name (Flow 1 / AX12, from APK libapp.so strings).
+_FLOW1_ROOM_TYPE_NAMES: dict[int, str] = {
+    0: "Room",
+    1: "Primary Bedroom",
+    2: "Secondary Bedroom",
+    3: "Living Room",
+    4: "Kitchen",
+    5: "Study",
+    6: "Bathroom",
+    7: "Dining Room",
+    8: "Corridor",
+    9: "Balcony",
+    10: "Utility Room",
+    11: "Cloak Room",
+    12: "Nursery",
+    13: "Recreation Room",
+    14: "Shower Room",
+    15: "Other",
+}
+
+# Flow 2 reorders the ROOM_TYPE enum vs Flow 1. Confirmed via live capture
+# (firmware v01.07.19.00, product_key QxMSPG6VSO) by walking every type in
+# the Narwal app's room-type picker. Only deltas are listed; sub_types not
+# present here use the Flow 1 name.
+_FLOW2_ROOM_TYPE_OVERRIDES: dict[int, str] = {
+    1: "Master Bedroom",
+    5: "Bathroom",
+    6: "Toilet",
+    7: "Balcony",
+    8: "Dining Room",
+    9: "Cloakroom",
+    10: "Corridor",
+    11: "Study",
+    14: "Storage Room",
+}
+
+# product_keys that use the Flow 2 mapping. Add more as community confirms.
+_FLOW2_PRODUCT_KEYS: frozenset[str] = frozenset({"QxMSPG6VSO"})
+
+
+def get_room_type_names(product_key: str | None) -> dict[int, str]:
+    """Return the ROOM_TYPE → display-name mapping for a given device.
+
+    Flow 2 (and possibly other newer models) renamed/reordered the ROOM_TYPE
+    enum. We pick the right base mapping from product_key and fall back to
+    Flow 1 for unknown devices.
+    """
+    base = dict(_FLOW1_ROOM_TYPE_NAMES)
+    if product_key and product_key in _FLOW2_PRODUCT_KEYS:
+        base.update(_FLOW2_ROOM_TYPE_OVERRIDES)
+    return base
+
+
 @dataclass
 class RoomInfo:
     """A room on the map.
 
     Fields from get_map / get_editable_map field 2.12:
       field 1: room_id (matches pixel value >> 8 in map grid)
-      field 2: room_sub_type — ROOM_TYPE enum from APK (0=unspecified,
-               1=main bedroom, 2=secondary room, 3=living room, 4=kitchen,
-               5=study, 6=bathroom, 7=dining room, 8=corridor, 9=balcony,
-               10=utility room, 11=cloak room, 12=nursery, 13=recreation,
-               14=shower room, 15=other)
+      field 2: room_sub_type — ROOM_TYPE enum from APK. The string mapping
+               differs between Flow 1 and Flow 2 (see get_room_type_names).
       field 3: user-assigned name (UTF-8, empty if not named by user)
       field 4: category (1=room, 2=utility/small space)
       field 8: instance_index (1-based, for numbering duplicates: Bathroom 1, 2, 3...)
@@ -40,29 +90,13 @@ class RoomInfo:
     category: int = 0  # 1=room, 2=utility (field 4)
     instance_index: int = 0  # numbering for duplicates (field 8)
 
-    # ROOM_TYPE enum → default display name (from APK libapp.so string analysis)
+    # ROOM_TYPE enum → default display name. Set by MapData.from_response
+    # based on the connected device's product_key; defaults to Flow 1 names.
     ROOM_TYPE_NAMES: dict[int, str] = field(default=None, repr=False)
 
     def __post_init__(self):
         if self.ROOM_TYPE_NAMES is None:
-            object.__setattr__(self, "ROOM_TYPE_NAMES", {
-                0: "Room",
-                1: "Primary Bedroom",
-                2: "Secondary Bedroom",
-                3: "Living Room",
-                4: "Kitchen",
-                5: "Study",
-                6: "Bathroom",
-                7: "Dining Room",
-                8: "Corridor",
-                9: "Balcony",
-                10: "Utility Room",
-                11: "Cloak Room",
-                12: "Nursery",
-                13: "Recreation Room",
-                14: "Shower Room",
-                15: "Other",
-            })
+            object.__setattr__(self, "ROOM_TYPE_NAMES", dict(_FLOW1_ROOM_TYPE_NAMES))
 
     @property
     def display_name(self) -> str:
@@ -238,11 +272,21 @@ class MapData:
     raw: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def from_response(cls, decoded: dict[str, Any]) -> MapData:
-        """Parse map data from a get_map field5 response."""
+    def from_response(
+        cls, decoded: dict[str, Any], product_key: str | None = None,
+    ) -> MapData:
+        """Parse map data from a get_map field5 response.
+
+        Args:
+            decoded: bbp-decoded map response payload.
+            product_key: Connected device's product_key. Selects the
+                ROOM_TYPE → display-name mapping (Flow 1 vs Flow 2).
+        """
         payload = decoded.get("2", {})
         if not payload:
             return cls()
+
+        type_names = get_room_type_names(product_key)
 
         rooms = []
         room_list = payload.get("12", [])
@@ -266,6 +310,7 @@ class MapData:
                     room_sub_type=int(room.get("2", 0)),
                     category=int(room.get("4", 0)),
                     instance_index=int(room.get("8", 0)),
+                    ROOM_TYPE_NAMES=type_names,
                 ))
 
         compressed = payload.get("17", b"")

--- a/custom_components/narwal/strings.json
+++ b/custom_components/narwal/strings.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "flow_title": "Narwal Vacuum ({host})",
     "step": {
       "user": {
         "title": "Connect to Narwal Vacuum",

--- a/custom_components/narwal/translations/en.json
+++ b/custom_components/narwal/translations/en.json
@@ -1,12 +1,14 @@
 {
   "config": {
+    "flow_title": "Narwal Vacuum ({host})",
     "step": {
       "user": {
         "title": "Connect to Narwal Vacuum",
-        "description": "Enter the IP address of your Narwal robot vacuum.",
+        "description": "Enter the IP address of your Narwal robot vacuum and select your model.",
         "data": {
           "host": "IP Address",
-          "port": "Port"
+          "port": "Port",
+          "model": "Model"
         }
       }
     },
@@ -50,6 +52,9 @@
           "on": "Docked",
           "off": "Undocked"
         }
+      },
+      "charging": {
+        "name": "Charging"
       }
     }
   }

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -1144,7 +1144,8 @@ class NarwalClient:
     async def get_map(self) -> MapData:
         """Download the full map data."""
         resp = await self.send_command(TOPIC_CMD_GET_MAP, timeout=15.0)
-        map_data = MapData.from_response(resp.data)
+        product_key = self.state.device_info.product_key if self.state.device_info else None
+        map_data = MapData.from_response(resp.data, product_key=product_key)
         self.state.map_data = map_data
         return map_data
 

--- a/narwal_client/const.py
+++ b/narwal_client/const.py
@@ -23,6 +23,7 @@ DEFAULT_TOPIC_PREFIX = "/QoEsI5qYXO"
 KNOWN_PRODUCT_KEYS = [
     # Confirmed working (local WebSocket)
     "QoEsI5qYXO",  # AX12 — Narwal Flow (primary, confirmed)
+    "QxMSPG6VSO",  # — Narwal Flow 2 (confirmed via live capture)
     "DrzDKQ0MU8",   # CX4  — Freo Z10 Ultra (confirmed by @irekkl-maker)
     # Confirmed cloud-only (port 9002 open but no local broadcasts)
     "BYWBPqSxeC",   # CX7  — Freo Z Ultra (cloud-only, confirmed by @gabrielozcomidi)

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -18,17 +18,67 @@ class DeviceInfo:
     firmware_version: str = ""
 
 
+# ROOM_TYPE enum → display name (Flow 1 / AX12, from APK libapp.so strings).
+_FLOW1_ROOM_TYPE_NAMES: dict[int, str] = {
+    0: "Room",
+    1: "Primary Bedroom",
+    2: "Secondary Bedroom",
+    3: "Living Room",
+    4: "Kitchen",
+    5: "Study",
+    6: "Bathroom",
+    7: "Dining Room",
+    8: "Corridor",
+    9: "Balcony",
+    10: "Utility Room",
+    11: "Cloak Room",
+    12: "Nursery",
+    13: "Recreation Room",
+    14: "Shower Room",
+    15: "Other",
+}
+
+# Flow 2 reorders the ROOM_TYPE enum vs Flow 1. Confirmed via live capture
+# (firmware v01.07.19.00, product_key QxMSPG6VSO) by walking every type in
+# the Narwal app's room-type picker. Only deltas are listed; sub_types not
+# present here use the Flow 1 name.
+_FLOW2_ROOM_TYPE_OVERRIDES: dict[int, str] = {
+    1: "Master Bedroom",
+    5: "Bathroom",
+    6: "Toilet",
+    7: "Balcony",
+    8: "Dining Room",
+    9: "Cloakroom",
+    10: "Corridor",
+    11: "Study",
+    14: "Storage Room",
+}
+
+# product_keys that use the Flow 2 mapping. Add more as community confirms.
+_FLOW2_PRODUCT_KEYS: frozenset[str] = frozenset({"QxMSPG6VSO"})
+
+
+def get_room_type_names(product_key: str | None) -> dict[int, str]:
+    """Return the ROOM_TYPE → display-name mapping for a given device.
+
+    Flow 2 (and possibly other newer models) renamed/reordered the ROOM_TYPE
+    enum. We pick the right base mapping from product_key and fall back to
+    Flow 1 for unknown devices.
+    """
+    base = dict(_FLOW1_ROOM_TYPE_NAMES)
+    if product_key and product_key in _FLOW2_PRODUCT_KEYS:
+        base.update(_FLOW2_ROOM_TYPE_OVERRIDES)
+    return base
+
+
 @dataclass
 class RoomInfo:
     """A room on the map.
 
     Fields from get_map / get_editable_map field 2.12:
       field 1: room_id (matches pixel value >> 8 in map grid)
-      field 2: room_sub_type — ROOM_TYPE enum from APK (0=unspecified,
-               1=main bedroom, 2=secondary room, 3=living room, 4=kitchen,
-               5=study, 6=bathroom, 7=dining room, 8=corridor, 9=balcony,
-               10=utility room, 11=cloak room, 12=nursery, 13=recreation,
-               14=shower room, 15=other)
+      field 2: room_sub_type — ROOM_TYPE enum from APK. The string mapping
+               differs between Flow 1 and Flow 2 (see get_room_type_names).
       field 3: user-assigned name (UTF-8, empty if not named by user)
       field 4: category (1=room, 2=utility/small space)
       field 8: instance_index (1-based, for numbering duplicates: Bathroom 1, 2, 3...)
@@ -40,29 +90,13 @@ class RoomInfo:
     category: int = 0  # 1=room, 2=utility (field 4)
     instance_index: int = 0  # numbering for duplicates (field 8)
 
-    # ROOM_TYPE enum → default display name (from APK libapp.so string analysis)
+    # ROOM_TYPE enum → default display name. Set by MapData.from_response
+    # based on the connected device's product_key; defaults to Flow 1 names.
     ROOM_TYPE_NAMES: dict[int, str] = field(default=None, repr=False)
 
     def __post_init__(self):
         if self.ROOM_TYPE_NAMES is None:
-            object.__setattr__(self, "ROOM_TYPE_NAMES", {
-                0: "Room",
-                1: "Primary Bedroom",
-                2: "Secondary Bedroom",
-                3: "Living Room",
-                4: "Kitchen",
-                5: "Study",
-                6: "Bathroom",
-                7: "Dining Room",
-                8: "Corridor",
-                9: "Balcony",
-                10: "Utility Room",
-                11: "Cloak Room",
-                12: "Nursery",
-                13: "Recreation Room",
-                14: "Shower Room",
-                15: "Other",
-            })
+            object.__setattr__(self, "ROOM_TYPE_NAMES", dict(_FLOW1_ROOM_TYPE_NAMES))
 
     @property
     def display_name(self) -> str:
@@ -238,11 +272,21 @@ class MapData:
     raw: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def from_response(cls, decoded: dict[str, Any]) -> MapData:
-        """Parse map data from a get_map field5 response."""
+    def from_response(
+        cls, decoded: dict[str, Any], product_key: str | None = None,
+    ) -> MapData:
+        """Parse map data from a get_map field5 response.
+
+        Args:
+            decoded: bbp-decoded map response payload.
+            product_key: Connected device's product_key. Selects the
+                ROOM_TYPE → display-name mapping (Flow 1 vs Flow 2).
+        """
         payload = decoded.get("2", {})
         if not payload:
             return cls()
+
+        type_names = get_room_type_names(product_key)
 
         rooms = []
         room_list = payload.get("12", [])
@@ -266,6 +310,7 @@ class MapData:
                     room_sub_type=int(room.get("2", 0)),
                     category=int(room.get("4", 0)),
                     instance_index=int(room.get("8", 0)),
+                    ROOM_TYPE_NAMES=type_names,
                 ))
 
         compressed = payload.get("17", b"")


### PR DESCRIPTION
## Summary

Narwal robots already advertise themselves on the LAN — verified live with \`dns-sd\` on a Flow 2:

\`\`\`
_app_wss_server_<6hex>._narwal_sweeper._tcp.local. — port 9002
NARWAL_<6hex>.local.
\`\`\`

Wire up Home Assistant's Zeroconf + DHCP discovery so a robot on the same LAN shows up as a "Discovered: Narwal Vacuum" card automatically — the user only confirms the model. Manual setup is unchanged.

Also adds **Narwal Flow 2** (\`QxMSPG6VSO\`) to the model picker and to the known-product-keys auto-detect list — same content as the still-open #20, included here so the new auto-discovery card resolves to the right model on Flow 2 hardware out of the box. Happy to defer to #20 if you'd rather merge that one first; either way the result is the same.

## What's in here

### \`manifest.json\`
- \`zeroconf\`: \`_narwal_sweeper._tcp.local.\`
- \`dhcp\`: hostname patterns \`NARWAL_*\` / \`narwal_*\`

### \`config_flow.py\`
- \`async_step_zeroconf\`: extracts the IP from the announcement, sets the discovery hostname as \`unique_id\`, falls through to the existing user step with the host pre-filled.
- \`async_step_dhcp\`: same handling for DHCP hostname matches.
- The user step now pre-fills the host when arriving from discovery so the user only confirms the model.

We deliberately **don't** probe the robot during discovery to determine the model — the robot only allows one WebSocket connection at a time, so a probe races with the mobile app / any active integration and tends to fail. The user's manual model pick is more reliable; the only thing the discovery card shows automatically is the IP.

### \`strings.json\` / \`translations/en.json\`
- \`config.flow_title\`: \`"Narwal Vacuum ({host})"\` so the discovery card surfaces the IP.

### \`const.py\` (model picker + auto-detect list)
- \`custom_components/narwal/const.py\`: \`"Narwal Flow 2": "QxMSPG6VSO"\` added to \`NARWAL_MODELS\`.
- \`narwal_client/const.py\`: \`"QxMSPG6VSO"\` added to \`KNOWN_PRODUCT_KEYS\` in the confirmed-working section.

## Testing

- HA 2026.4 picks up the announcement instantly when both robot and HA are on the same LAN segment. Discovery card title reads \`Narwal Vacuum (192.168.178.138)\`.
- Re-discovery of an already-configured host updates the host on the existing entry instead of starting a new flow (\`_abort_if_unique_id_configured(updates=...)\`).
- Manual config flow (no discovery) unchanged — verified by re-adding the integration without DHCP/Zeroconf packets.
- Flow 2 hardware now shows in the picker; previously users had to choose "Other / Auto-detect".