### PR TITLE
feat: Flow 2 diagnostics, discovery, and live-state improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ robot_commands_i18n.txt
 nul
 run_analysis*.py
 prompt.md
+coverage_*.json

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Models marked **Not Compatible** use a different protocol or are cloud-only. Thi
 - **Start / Stop / Pause / Resume** — all commands validated on hardware
 - **Room-specific cleaning** — select rooms from the HA UI (requires HA 2026.3+)
 - **Return to dock** / **Locate** (robot announces "Robot is here")
-- **Fan speed** — Quiet, Normal, Strong, Max (set-only; robot doesn't broadcast current level)
+- **Fan speed** — Quiet, Normal, Strong, Super Powerful (Flow 2 uses 1=Quiet, 2=Normal, 3=Strong, 4=Super Powerful; set-only)
 
 ### Sensors
 - Battery level, cleaning area, cleaning time, firmware version
@@ -77,7 +77,7 @@ Models marked **Not Compatible** use a different protocol or are cloud-only. Thi
 
 - **Wake from deep sleep is unreliable** — robot may not respond after long idle periods. Opening the Narwal app briefly can help.
 - **Single connection** — close the Narwal app before using HA to avoid conflicts.
-- **Fan speed is set-only** — robot doesn't broadcast its current level.
+- **Fan speed is set-only** — robot doesn't broadcast its current level; Flow 2's suction labels are 1..4.
 - **Default clean settings** — start and room-specific clean use max suction, wet mop, single pass. Per-room customization is not yet available.
 - **Map may be stale** — robot can return an old map. A new clean cycle typically refreshes it.
 

--- a/custom_components/narwal/binary_sensor.py
+++ b/custom_components/narwal/binary_sensor.py
@@ -6,12 +6,16 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import NarwalConfigEntry
 from .coordinator import NarwalCoordinator
 from .entity import NarwalEntity
+from .narwal_client import ERROR_CODES
+
+CLEAN_WATER_TANK_ERROR_CODE = 0x01010037
 
 
 async def async_setup_entry(
@@ -23,6 +27,11 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
     async_add_entities([
         NarwalDockedSensor(coordinator),
+        NarwalActiveErrorSensor(coordinator),
+        NarwalStationTankErrorSensor(coordinator),
+        NarwalCleanWaterTankSensor(coordinator),
+        NarwalRemoteControlSensor(coordinator),
+        NarwalUserActionSensor(coordinator),
     ])
 
 
@@ -44,5 +53,209 @@ class NarwalDockedSensor(NarwalEntity, BinarySensorEntity):
         if state is None:
             return None
         return state.is_docked
+
+
+class NarwalStationTankErrorSensor(NarwalEntity, BinarySensorEntity):
+    """On when the base station reports a tank-related fault.
+
+    Flow 2 reports station tank faults through robot_base_status field 25.*,
+    not the generic field 48.1.2 error channel. In live testing,
+    base.25.6={1:1,2:16842806} appeared while the official app highlighted
+    Dirty Water Tank in red.
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_translation_key = "station_tank_error"
+
+    def __init__(self, coordinator: NarwalCoordinator) -> None:
+        super().__init__(coordinator)
+        device_id = coordinator.config_entry.data["device_id"]
+        self._attr_unique_id = f"{device_id}_station_tank_error"
+
+    @property
+    def is_on(self) -> bool | None:
+        state = self.coordinator.data
+        if state is None:
+            return None
+        return state.station_error_code != 0
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | int]:
+        state = self.coordinator.data
+        if state is None or state.station_error_code == 0:
+            return {}
+        return {
+            "code": state.station_error_code,
+            "code_hex": f"0x{state.station_error_code:08x}",
+            "identifier": ERROR_CODES.get(state.station_error_code, "unknown"),
+            "severity": state.station_error_severity,
+            "field25_slot": state.station_error_slot,
+        }
+
+
+class NarwalCleanWaterTankSensor(NarwalEntity, BinarySensorEntity):
+    """On when the base station reports clean-water tank empty/missing.
+
+    Flow 2 live test: starting a mop clean with the clean-water tank removed
+    kept the app green until the station needed water. Then field 48.1.2
+    reported code 16842807 with message "clean water tank empty or not
+    installed (no Hall sensor) while washing mop".
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_translation_key = "clean_water_tank"
+
+    def __init__(self, coordinator: NarwalCoordinator) -> None:
+        super().__init__(coordinator)
+        device_id = coordinator.config_entry.data["device_id"]
+        self._attr_unique_id = f"{device_id}_clean_water_tank"
+
+    @property
+    def is_on(self) -> bool | None:
+        state = self.coordinator.data
+        if state is None:
+            return None
+        return state.error_code == CLEAN_WATER_TANK_ERROR_CODE
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | int]:
+        state = self.coordinator.data
+        if state is None or state.error_code != CLEAN_WATER_TANK_ERROR_CODE:
+            return {}
+        return {
+            "code": state.error_code,
+            "code_hex": f"0x{state.error_code:08x}",
+            "identifier": ERROR_CODES.get(state.error_code, "unknown"),
+            "severity": state.error_severity,
+            "message": state.error_message,
+            "localized_message": state.error_message_localized,
+        }
+
+
+class NarwalRemoteControlSensor(NarwalEntity, BinarySensorEntity):
+    """On while the Flow 2 app live camera / manual control mode is active.
+
+    Live test (2026-05-12): opening the app's robot camera/manual steering
+    mode added robot_base_status.31=1 and field 3.4=15. Both changed back
+    after leaving live mode. The video stream itself is not exposed here;
+    this only reports the robot's local mode flag.
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+    _attr_translation_key = "remote_control"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: NarwalCoordinator) -> None:
+        super().__init__(coordinator)
+        device_id = coordinator.config_entry.data["device_id"]
+        self._attr_unique_id = f"{device_id}_remote_control"
+
+    @property
+    def is_on(self) -> bool | None:
+        state = self.coordinator.data
+        if state is None:
+            return None
+        return state.remote_control_active
+
+    @property
+    def extra_state_attributes(self) -> dict[str, int | bool]:
+        state = self.coordinator.data
+        if state is None:
+            return {}
+        return {
+            "base_31": bool(state.raw_base_status.get("31")),
+            "base_3_4": state.remote_control_sub_state,
+        }
+
+
+class NarwalActiveErrorSensor(NarwalEntity, BinarySensorEntity):
+    """Binary sensor that turns on when the robot reports an active fault.
+
+    Driven by robot_base_status field 48.1.2: empty {} = no error, populated
+    {1, 2, 3} = active fault (e.g. clean water tank empty, mop washer
+    blocked, dock disconnected). Code + message are exposed as separate
+    sensors so users can build automations that react to the specific
+    fault.
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_translation_key = "active_error"
+
+    def __init__(self, coordinator: NarwalCoordinator) -> None:
+        super().__init__(coordinator)
+        device_id = coordinator.config_entry.data["device_id"]
+        self._attr_unique_id = f"{device_id}_active_error"
+
+    @property
+    def is_on(self) -> bool | None:
+        state = self.coordinator.data
+        if state is None:
+            return None
+        return state.error_code != 0
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | int]:
+        state = self.coordinator.data
+        if state is None or state.error_code == 0:
+            return {}
+        return {
+            "code": state.error_code,
+            "code_hex": f"0x{state.error_code:08x}",
+            "identifier": ERROR_CODES.get(state.error_code, "unknown"),
+            "severity": state.error_severity,
+            "message": state.error_message,
+            "localized_message": state.error_message_localized,
+        }
+
+
+# Map base.3.16 to a stable identifier so automations don't depend on
+# the raw integer.
+_USER_ACTION_TYPES: dict[int, str] = {
+    2: "fill_water_tank",
+    3: "return_to_dock_after_clean",
+    4: "carry_to_dock_to_start",
+}
+
+
+class NarwalUserActionSensor(NarwalEntity, BinarySensorEntity):
+    """On while the robot is waiting for the user to do something physical.
+
+    The Flow 2 firmware broadcasts a structured prompt at base.3.16 +
+    a countdown at ws.22 (elapsed/target seconds). When the user does
+    the requested action — fill the tank, carry the robot to the dock,
+    etc. — both clear and the sensor flips back off. extra_state_attributes
+    expose the action type and the seconds left so automations can
+    surface a notification only after a grace period.
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_translation_key = "user_action_required"
+
+    def __init__(self, coordinator: NarwalCoordinator) -> None:
+        super().__init__(coordinator)
+        device_id = coordinator.config_entry.data["device_id"]
+        self._attr_unique_id = f"{device_id}_user_action_required"
+
+    @property
+    def is_on(self) -> bool | None:
+        state = self.coordinator.data
+        if state is None:
+            return None
+        return state.user_action_type != 0
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | int]:
+        state = self.coordinator.data
+        if state is None or state.user_action_type == 0:
+            return {}
+        target = state.user_action_target
+        elapsed = state.user_action_elapsed
+        return {
+            "type": _USER_ACTION_TYPES.get(state.user_action_type, "unknown"),
+            "type_code": state.user_action_type,
+            "elapsed_s": elapsed,
+            "target_s": target,
+            "remaining_s": max(target - elapsed, 0) if target else 0,
+        }
 
 

--- a/custom_components/narwal/config_flow.py
+++ b/custom_components/narwal/config_flow.py
@@ -8,6 +8,8 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .narwal_client import NarwalClient, NarwalCommandError, NarwalConnectionError
 
@@ -30,6 +32,76 @@ class NarwalConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Narwal vacuum."""
 
     VERSION = 2
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Pre-filled host when discovery (zeroconf / DHCP) finds the
+        # robot before the user starts the flow.
+        self._discovered_host: str | None = None
+
+    async def _check_already_configured(
+        self, host: str, fallback_uid: str,
+    ) -> ConfigFlowResult | None:
+        """Return an abort result when this host is already a config
+        entry, otherwise None and seed the discovery unique_id.
+
+        The user step assigns unique_id from the robot's device_id
+        (queried over the WebSocket), which mDNS / DHCP can't see.
+        Without a host-based check the same robot would re-appear as
+        a "Discovered" card forever after a manual add.
+        """
+        for entry in self._async_current_entries(include_ignore=False):
+            if entry.data.get("host") == host:
+                # Update host on the matching entry in case the IP
+                # drifted (DHCP renewal, robot moved subnets) and
+                # abort the discovery flow.
+                self.hass.config_entries.async_update_entry(
+                    entry, data={**entry.data, "host": host},
+                )
+                return self.async_abort(reason="already_configured")
+        await self.async_set_unique_id(fallback_uid)
+        self._abort_if_unique_id_configured(updates={"host": host})
+        return None
+
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        """Pick up Narwal robots advertising `_narwal_sweeper._tcp.local.`.
+
+        Robots broadcast an instance name like
+        ``_app_wss_server_<6hex>._narwal_sweeper._tcp.local.`` with a
+        hostname ``NARWAL_<6hex>.local.`` on port 9002. We only use
+        the IP for now — the user still picks the model on the next
+        step, the model name isn't in the mDNS payload.
+        """
+        host = str(discovery_info.host)
+        already = await self._check_already_configured(
+            host, discovery_info.hostname.rstrip("."),
+        )
+        if already is not None:
+            return already
+        self._discovered_host = host
+        self.context["title_placeholders"] = {"host": host}
+        return await self.async_step_user()
+
+    async def async_step_dhcp(
+        self, discovery_info: DhcpServiceInfo
+    ) -> ConfigFlowResult:
+        """Pick up Narwal robots from DHCP hostname matches.
+
+        Backup for when zeroconf is filtered (some routers / VLANs).
+        Hostname pattern ``NARWAL_*`` / ``narwal_*`` is declared in
+        manifest.json.
+        """
+        host = str(discovery_info.ip)
+        already = await self._check_already_configured(
+            host, discovery_info.hostname or host,
+        )
+        if already is not None:
+            return already
+        self._discovered_host = host
+        self.context["title_placeholders"] = {"host": host}
+        return await self.async_step_user()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -85,8 +157,18 @@ class NarwalConfigFlow(ConfigFlow, domain=DOMAIN):
             finally:
                 await client.disconnect()
 
+        # If we got here from a discovery step, pre-fill the host so
+        # the user only has to confirm the model.
+        schema = STEP_USER_DATA_SCHEMA
+        if self._discovered_host and user_input is None:
+            schema = vol.Schema({
+                vol.Required("host", default=self._discovered_host): str,
+                vol.Optional("port", default=DEFAULT_PORT): int,
+                vol.Required(CONF_MODEL, default=MODEL_OPTIONS[0]): vol.In(MODEL_OPTIONS),
+            })
+
         return self.async_show_form(
             step_id="user",
-            data_schema=STEP_USER_DATA_SCHEMA,
+            data_schema=schema,
             errors=errors,
         )

--- a/custom_components/narwal/const.py
+++ b/custom_components/narwal/const.py
@@ -15,6 +15,7 @@ MODEL = "Flow (AX12)"
 # "auto" cycles all known keys during discovery (slower, fallback).
 NARWAL_MODELS: dict[str, str] = {
     "Narwal Flow": "QoEsI5qYXO",
+    "Narwal Flow 2": "QxMSPG6VSO",
     "Narwal Freo Z10 Ultra": "DrzDKQ0MU8",
     "Narwal Freo X10 Pro": "CNbforyZWI",
     "Other / Auto-detect": "auto",
@@ -28,13 +29,14 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
     Platform.CAMERA,
+    Platform.SELECT,
 ]
 
 FAN_SPEED_MAP: dict[str, FanLevel] = {
-    "quiet": FanLevel.QUIET,
-    "normal": FanLevel.NORMAL,
-    "strong": FanLevel.STRONG,
-    "max": FanLevel.MAX,
+    "Quiet": FanLevel.QUIET,
+    "Normal": FanLevel.NORMAL,
+    "Strong": FanLevel.STRONG,
+    "Super Powerful": FanLevel.MAX,
 }
 
 FAN_SPEED_LIST: list[str] = list(FAN_SPEED_MAP.keys())

--- a/custom_components/narwal/coordinator.py
+++ b/custom_components/narwal/coordinator.py
@@ -60,6 +60,9 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         self._map_fetch_pending = False
         self._last_display_map_resub: float = 0.0
         self._consecutive_failures = 0
+        # Track the active map's identity so we can refresh get_map()
+        # when the user switches in the app.
+        self._prev_map_signature: tuple[int | None, int | None] = (None, None)
         self._max_failures = 5  # 5 * 60s = 5 minutes before entities go unavailable
 
     async def async_setup(self) -> None:
@@ -134,6 +137,29 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
                 self._fetch_missing_map(),
                 f"{DOMAIN}_map_fetch",
             )
+
+        # Detect map switch — base.30 / base.44 flip between saved maps.
+        # Refresh the cached map so the camera + segment list track the
+        # newly-active one. Skip the very first observation (None→x).
+        sig = state.map_signature
+        if (
+            sig != (None, None)
+            and self._prev_map_signature != (None, None)
+            and sig != self._prev_map_signature
+            and not self._map_fetch_pending
+        ):
+            _LOGGER.info(
+                "Active map changed (%s → %s) — re-fetching",
+                self._prev_map_signature, sig,
+            )
+            self._map_fetch_pending = True
+            self.config_entry.async_create_background_task(
+                self.hass,
+                self._fetch_missing_map(),
+                f"{DOMAIN}_map_refresh",
+            )
+        if sig != (None, None):
+            self._prev_map_signature = sig
 
         # Detect return-to-dock transition: CLEANING/CLEANING_ALT → STANDBY.
         # Broadcast dock fields are stale after docking — immediate poll

--- a/custom_components/narwal/manifest.json
+++ b/custom_components/narwal/manifest.json
@@ -9,5 +9,18 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/sjmotew/NarwalIntegration/issues",
   "requirements": ["bbpb>=1.4.0", "Pillow>=9.0.0"],
-  "version": "1.0.0"
+  "version": "1.1.11",
+  "zeroconf": [
+    {
+      "type": "_narwal_sweeper._tcp.local."
+    }
+  ],
+  "dhcp": [
+    {
+      "hostname": "narwal_*"
+    },
+    {
+      "hostname": "NARWAL_*"
+    }
+  ]
 }

--- a/custom_components/narwal/narwal_client/__init__.py
+++ b/custom_components/narwal/narwal_client/__init__.py
@@ -1,7 +1,15 @@
 """Narwal robot vacuum client library — local WebSocket API."""
 
 from .client import NarwalClient, NarwalCommandError, NarwalConnectionError
-from .const import CommandResult, FanLevel, MopHumidity, WorkingStatus
+from .const import (
+    ERROR_CODES,
+    ERROR_MESSAGE_SNIPPETS_EN,
+    ERROR_MESSAGES_EN,
+    CommandResult,
+    FanLevel,
+    MopHumidity,
+    WorkingStatus,
+)
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState, RoomInfo
 from .protocol import build_frame, parse_frame
 
@@ -13,6 +21,9 @@ __all__ = [
     "CommandResponse",
     "CommandResult",
     "DeviceInfo",
+    "ERROR_CODES",
+    "ERROR_MESSAGES_EN",
+    "ERROR_MESSAGE_SNIPPETS_EN",
     "FanLevel",
     "MapData",
     "MapDisplayData",

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -408,6 +408,10 @@ class NarwalClient:
             _LOGGER.debug("Failed to decode protobuf for topic %s", short_topic)
             return
 
+        # Log every decoded broadcast at DEBUG so tools/narwal_capture.py
+        # (and ad-hoc protocol RE) can pick them out of `ha core logs`.
+        # Cheap when DEBUG isn't enabled — _LOGGER.debug short-circuits.
+        _LOGGER.debug("DUMP %s: %r", short_topic, decoded)
         if short_topic == "status/working_status":
             self.state.update_from_working_status(decoded)
         elif short_topic == "status/robot_base_status":
@@ -425,6 +429,15 @@ class NarwalClient:
                 self.state.map_display_data.robot_y,
                 self.state.map_display_data.timestamp,
             )
+        elif short_topic == "status/point_navi_plan_traj":
+            self.state.update_from_plan_traj(decoded)
+        elif short_topic == "report/clean_report":
+            # Empty-payload event marker: the robot finished a cycle.
+            # Reset session-scoped state and log; the coordinator picks
+            # this up via the on_state_update callback and triggers a
+            # fresh map fetch.
+            self.state.last_clean_report_ts = time.time()
+            _LOGGER.info("clean_report received — clean cycle complete")
         if self.on_state_update:
             self.on_state_update(self.state)
 
@@ -862,6 +875,10 @@ class NarwalClient:
                 self.state.update_from_download_status(decoded)
             elif short_topic == "map/display_map":
                 self.state.map_display_data = MapDisplayData.from_broadcast(decoded)
+            elif short_topic == "status/point_navi_plan_traj":
+                self.state.update_from_plan_traj(decoded)
+            elif short_topic == "report/clean_report":
+                self.state.last_clean_report_ts = time.time()
 
         raise NarwalCommandError(
             f"No field5 response within {timeout}s"
@@ -914,6 +931,64 @@ class NarwalClient:
             timeout=10.0,
         )
 
+    async def start_freo_mind(self, **kwargs) -> CommandResponse:
+        """Start a Freo Mind (AI auto) whole-house clean.
+
+        Flow 2 only. Reverse-engineered from a live capture of an
+        app-initiated Freo Mind clean (firmware v01.07.19.00):
+
+            {1: {2: {}, 5: {1: {1: 4, 2: 2, 3: 1}, 7: {1: {}}}}}
+
+          field 5.1.1 = mode (4 = Vacuum and mop)
+          field 5.1.2 = mop humidity (2 = Standard)
+          field 5.1.3 = "Freo Mind / AI auto" marker (1)
+          field 5.7   = secondary marker also present in Freo Mind cleans
+        """
+        import blackboxprotobuf
+
+        msg = {
+            "1": {
+                "2": {},
+                "5": {
+                    "1": {"1": 4, "2": 2, "3": 1},
+                    "7": {"1": {}},
+                },
+            }
+        }
+        typedef = {
+            "1": {
+                "type": "message",
+                "message_typedef": {
+                    "2": {"type": "message", "message_typedef": {}},
+                    "5": {
+                        "type": "message",
+                        "message_typedef": {
+                            "1": {
+                                "type": "message",
+                                "message_typedef": {
+                                    "1": {"type": "int"},
+                                    "2": {"type": "int"},
+                                    "3": {"type": "int"},
+                                },
+                            },
+                            "7": {
+                                "type": "message",
+                                "message_typedef": {
+                                    "1": {"type": "message", "message_typedef": {}},
+                                },
+                            },
+                        },
+                    },
+                },
+            }
+        }
+        payload = blackboxprotobuf.encode_message(msg, typedef)
+        return await self.send_command(
+            TOPIC_CMD_START_CLEAN,
+            payload=payload,
+            timeout=10.0,
+        )
+
     def _build_room_clean_payload(self, room_ids: list[int]) -> bytes:
         """Build CleanTask protobuf with per-room clean params in field 1.2.
 
@@ -936,66 +1011,44 @@ class NarwalClient:
         if not room_ids:
             return self._DEFAULT_CLEAN_PAYLOAD
 
-        import blackboxprotobuf
+        def enc_varint(v: int) -> bytes:
+            out = bytearray()
+            n = int(v)
+            while True:
+                b = n & 0x7F
+                n >>= 7
+                if n:
+                    out.append(b | 0x80)
+                else:
+                    out.append(b)
+                    return bytes(out)
 
-        # Build per-room entries with default clean settings
-        room_entries = []
-        for rid in room_ids:
-            room_entries.append({
-                "1": rid,       # roomId
-                "2": 2,         # cleanMode = sweep+mop
-                "3": 1,         # cleanTimes = 1 pass
-                "6": 3,         # sweepMode = max suction
-                "7": 2,         # mopMode = wet
-            })
+        def enc_field(field_no: int, wire_type: int, value: bytes | int) -> bytes:
+            tag = enc_varint((field_no << 3) | wire_type)
+            if wire_type == 0:
+                return tag + enc_varint(int(value))
+            if wire_type == 2:
+                data = value if isinstance(value, bytes) else enc_varint(int(value))
+                return tag + enc_varint(len(data)) + data
+            raise ValueError(f"unsupported wire type: {wire_type}")
 
-        room_typedef = {
-            "type": "message",
-            "seen_repeated": True,
-            "message_typedef": {
-                "1": {"type": "uint"},
-                "2": {"type": "int"},
-                "3": {"type": "int"},
-                "6": {"type": "int"},
-                "7": {"type": "int"},
-            }
-        }
+        def enc_room_entry(room_id: int) -> bytes:
+            return b"".join([
+                enc_field(1, 0, room_id),
+                enc_field(2, 0, 2),
+                enc_field(3, 0, 1),
+                enc_field(6, 0, 3),
+                enc_field(7, 0, 2),
+            ])
 
-        # Single room: field 1.2 is a message; multiple: repeated message
-        field_2_value = room_entries[0] if len(room_entries) == 1 else room_entries
-
-        msg = {
-            "1": {
-                "2": field_2_value,
-                "5": {
-                    "1": {"1": 3, "2": 2, "3": 1},
-                    "5": {}
-                }
-            }
-        }
-        typedef = {
-            "1": {
-                "type": "message",
-                "message_typedef": {
-                    "2": room_typedef,
-                    "5": {
-                        "type": "message",
-                        "message_typedef": {
-                            "1": {
-                                "type": "message",
-                                "message_typedef": {
-                                    "1": {"type": "int"},
-                                    "2": {"type": "int"},
-                                    "3": {"type": "int"}
-                                }
-                            },
-                            "5": {"type": "message", "message_typedef": {}}
-                        }
-                    }
-                }
-            }
-        }
-        return blackboxprotobuf.encode_message(msg, typedef)
+        room_entries = b"".join(enc_field(2, 2, enc_room_entry(rid)) for rid in room_ids)
+        settings = enc_field(1, 2, b"".join([
+            enc_field(1, 0, 3),
+            enc_field(2, 0, 2),
+            enc_field(3, 0, 1),
+        ])) + enc_field(5, 2, b"")
+        clean_task = enc_field(1, 2, room_entries + enc_field(5, 2, settings))
+        return clean_task
 
     async def start_rooms(self, room_ids: list[int]) -> CommandResponse:
         """Start room-specific cleaning.
@@ -1051,7 +1104,7 @@ class NarwalClient:
         """Set suction fan speed.
 
         Args:
-            level: FanLevel enum or int (0=quiet, 1=normal, 2=strong, 3=max).
+            level: FanLevel enum or int (1=quiet, 2=normal, 3=strong, 4=max).
         """
         payload = b"\x08" + bytes([int(level) & 0x7F])
         return await self.send_command(TOPIC_CMD_SET_FAN_LEVEL, payload)
@@ -1144,7 +1197,8 @@ class NarwalClient:
     async def get_map(self) -> MapData:
         """Download the full map data."""
         resp = await self.send_command(TOPIC_CMD_GET_MAP, timeout=15.0)
-        map_data = MapData.from_response(resp.data)
+        product_key = self.state.device_info.product_key if self.state.device_info else None
+        map_data = MapData.from_response(resp.data, product_key=product_key)
         self.state.map_data = map_data
         return map_data
 

--- a/custom_components/narwal/narwal_client/const.py
+++ b/custom_components/narwal/narwal_client/const.py
@@ -23,6 +23,7 @@ DEFAULT_TOPIC_PREFIX = "/QoEsI5qYXO"
 KNOWN_PRODUCT_KEYS = [
     # Confirmed working (local WebSocket)
     "QoEsI5qYXO",  # AX12 — Narwal Flow (primary, confirmed)
+    "QxMSPG6VSO",  # — Narwal Flow 2 (confirmed via live capture)
     "DrzDKQ0MU8",   # CX4  — Freo Z10 Ultra (confirmed by @irekkl-maker)
     # Confirmed cloud-only (port 9002 open but no local broadcasts)
     "BYWBPqSxeC",   # CX7  — Freo Z Ultra (cloud-only, confirmed by @gabrielozcomidi)
@@ -58,6 +59,13 @@ TOPIC_DOWNLOAD_STATUS = "status/download_status"
 TOPIC_DISPLAY_MAP = "map/display_map"
 TOPIC_TIMELINE_STATUS = "status/time_line_status"
 TOPIC_PLANNING_DEBUG = "developer/planning_debug_info"
+# Forward path the robot is about to drive — list of {1: x, 2: y} float32
+# coordinates encoded as fixed32 ints. Confirmed via local capture.
+TOPIC_POINT_NAVI_PLAN_TRAJ = "status/point_navi_plan_traj"
+# Event-only broadcast: fires once at end of a clean cycle with an empty
+# payload. Used as a trigger to refresh the map snapshot and reset
+# session-scoped state. Confirmed via local capture.
+TOPIC_CLEAN_REPORT = "report/clean_report"
 
 # --- Command topics (client → robot, confirmed working) ---
 # Common
@@ -164,10 +172,14 @@ class WorkingStatus(IntEnum):
 
     UNKNOWN = 0
     STANDBY = 1       # idle / transition state
+    MOP_WASHING = 3   # robot is washing the mop on the station (Flow 2, observed live)
     CLEANING = 4      # active cleaning (stays 4 even while returning to dock)
+    MAPPING = 7       # building / saving a new map (Flow 2 — accompanied by 3.9=1)
     CLEANING_ALT = 5  # cleaning — observed when robot was physically stuck; may indicate error/stuck state
     DOCKED = 10       # on dock (does NOT reliably indicate charging vs charged)
     CHARGED = 14      # on dock (reported before 100% — use battery_level for charge state)
+    MOP_DRYING = 17   # mop drying — observed transitioning into the cycle on Flow 2
+    MOP_DRYING_ACTIVE = 19  # mop drying — main active phase (sub-field 18 counts steps)
     # PLACEHOLDER: error state value not yet observed live.
     # Trigger a real error (e.g., pick up robot mid-clean) to discover the value.
     ERROR = 99
@@ -176,10 +188,10 @@ class WorkingStatus(IntEnum):
 class FanLevel(IntEnum):
     """Suction fan speed levels (SweepMode from APK)."""
 
-    QUIET = 0
-    NORMAL = 1
-    STRONG = 2
-    MAX = 3
+    QUIET = 1
+    NORMAL = 2
+    STRONG = 3
+    MAX = 4
 
 
 class MopHumidity(IntEnum):
@@ -190,23 +202,59 @@ class MopHumidity(IntEnum):
     WET = 2
 
 
+# Known error codes (Flow 2). Codes are packed as 0xCC SS RR XX
+# (category, sub-category, reserved, specific) and stable across
+# firmware updates. Map each one to a snake_case identifier so
+# automations don't need to depend on the localized message.
+ERROR_CODES: dict[int, str] = {
+    0x01010036: "dirty_water_tank_error",  # 16842806 — Flow 2 app shows Dirty Water Tank red
+    0x01010037: "clean_water_tank_empty",  # 16842807 — clean water tank empty / not installed
+    0x02020031: "roller_brush_tangled",    # 33685553 — app code 1044: roller brush tangled
+    0x02310026: "left_rear_drive_wheel_stuck",  # 36765734 — left rear drive wheel stuck
+    0x02310031: "robot_lifted",            # 36765745 — robot picked up / suspended
+}
+
+# English messages for confirmed Flow 2 fault codes. The robot also sends
+# localized firmware text (Chinese on the tested unit); prefer these stable
+# strings in HA so the error sensor is useful independent of robot locale.
+ERROR_MESSAGES_EN: dict[int, str] = {
+    0x01010036: "Dirty water tank problem",
+    0x01010037: "Clean water tank empty or not installed",
+    0x02020031: "The roller brush is tangled. Please check and clear it.",
+    0x02310026: "Left rear drive wheel stuck",
+    0x02310031: "Robot lifted or suspended",
+}
+
+# Fallback translation snippets for localized firmware messages whose numeric
+# code has not been confirmed yet. Keep this conservative: only add strings
+# observed in captures/screenshots.
+ERROR_MESSAGE_SNIPPETS_EN: dict[str, str] = {
+    "左后驱轮卡住": "Left rear drive wheel stuck",
+    "扫地时滚刷过流": "The roller brush is tangled. Please check and clear it.",
+    "扫地时右边刷异常": "Right side brush abnormal while sweeping",
+}
+
+
 # robot_base_status field numbers
 class BaseStatusField(IntEnum):
     """Field numbers in the robot_base_status protobuf message.
 
-    Battery notes (confirmed via 35-min monitor capture, 2026-02-27):
+    Battery / consumable notes:
       Field 2  = real-time battery level as IEEE 754 float32
                  (e.g. 1118175232 → 83.0%, matching app display ~84%)
+      Field 35 = dust bag remaining capacity as IEEE 754 float32 percentage
       Field 38 = static battery health (always 100; design capacity, not SOC)
+      Field 41 = constant 100 on Flow 2; not dust-bag health
     """
 
     BATTERY_LEVEL = 2  # real-time SOC as float32 — CONFIRMED
     MODE_STATE = 3
     SESSION_ID = 13
     SENSOR_DATA = 25
+    DUST_BAG_HEALTH = 35
     TIMESTAMP = 36
     BATTERY_HEALTH = 38  # static, always 100 (design capacity)
-    BATTERY_CAPACITY = 41
+    BATTERY_CAPACITY = 41  # observed constant 100 on Flow 2
 
 
 # upgrade_status field numbers

--- a/custom_components/narwal/narwal_client/map_renderer.py
+++ b/custom_components/narwal/narwal_client/map_renderer.py
@@ -384,24 +384,41 @@ def render_map_png(
                 room_sum_y[room_id] = room_sum_y.get(room_id, 0) + y
                 room_count[room_id] = room_count.get(room_id, 0) + 1
 
-    # Flip vertically BEFORE drawing overlays — pixel data is stored with
-    # Y increasing upward (math coordinates) but images render Y downward.
-    # Overlays (labels, dock, robot) use flipped coordinates so text is right-side up.
+    # Flip vertically BEFORE upscaling/overlays — pixel data is stored
+    # with Y increasing upward (math coordinates) but images render Y
+    # downward. Overlays (labels, dock, robot) use flipped coordinates
+    # so text is right-side up.
     img = img.transpose(Image.FLIP_TOP_BOTTOM)
 
-    draw = ImageDraw.Draw(img)
+    # Upscale the room grid with NEAREST so the colored blocks stay
+    # crisp instead of getting browser-bilinear-blurred. Aim for ~720 px
+    # on the long edge — large enough to look smooth in the HA UI
+    # without bloating the PNG. Overlays are then drawn at the upscaled
+    # resolution so dock / robot / labels look smooth.
+    scale = max(1, min(720 // max(width, height), 12))
+    if scale > 1:
+        img = img.resize((width * scale, height * scale), Image.NEAREST)
 
-    # Draw room labels at flipped centroids
+    draw = ImageDraw.Draw(img)
+    sw = width * scale
+    sh = height * scale
+
+    # Draw room labels at flipped centroids (scaled).
     if room_names:
+        font_size = max(11, 6 * scale)
         try:
-            font = ImageFont.truetype("arial.ttf", 10)
+            font = ImageFont.truetype("arial.ttf", font_size)
         except (IOError, OSError):
-            font = ImageFont.load_default()
+            try:
+                # macOS / Linux fallback fonts
+                font = ImageFont.truetype("DejaVuSans.ttf", font_size)
+            except (IOError, OSError):
+                font = ImageFont.load_default()
         for rid, name in room_names.items():
             if not name or rid not in room_count:
                 continue
-            cx = room_sum_x[rid] // room_count[rid]
-            cy = height - 1 - (room_sum_y[rid] // room_count[rid])
+            cx = (room_sum_x[rid] // room_count[rid]) * scale + scale // 2
+            cy = (height - 1 - (room_sum_y[rid] // room_count[rid])) * scale + scale // 2
             bbox = font.getbbox(name)
             tw = bbox[2] - bbox[0]
             th = bbox[3] - bbox[1]
@@ -412,18 +429,22 @@ def render_map_png(
                 draw.text((tx + ox, ty + oy), name, fill=(0, 0, 0), font=font)
             draw.text((tx, ty), name, fill=(255, 255, 255), font=font)
 
-    # Draw dock position (before robot so robot draws on top)
-    # Flip dock Y to match the flipped image
+    # Draw dock position (before robot so robot draws on top), scaled.
     if dock_x is not None and dock_y is not None:
-        dock_size = max(4, min(width, height) // 60)
-        _draw_dock(draw, int(dock_x), height - 1 - int(dock_y), dock_size)
+        dock_size = max(6, min(sw, sh) // 50)
+        _draw_dock(
+            draw,
+            int(dock_x) * scale + scale // 2,
+            (height - 1 - int(dock_y)) * scale + scale // 2,
+            dock_size,
+        )
 
-    # Draw robot position (flip Y) — skip if out of bounds
+    # Draw robot position (flip Y, scaled) — skip if out of bounds.
     if robot_x is not None and robot_y is not None:
-        rx = int(robot_x)
-        ry = height - 1 - int(robot_y)
-        if 0 <= rx < width and 0 <= ry < height:
-            radius = max(3, min(width, height) // 80)
+        rx = int(robot_x) * scale + scale // 2
+        ry = (height - 1 - int(robot_y)) * scale + scale // 2
+        if 0 <= rx < sw and 0 <= ry < sh:
+            radius = max(5, min(sw, sh) // 60)
             _draw_robot(draw, rx, ry, robot_heading, radius)
 
     buf = io.BytesIO()
@@ -507,18 +528,32 @@ def render_base_map(
                 room_count[room_id] = room_count.get(room_id, 0) + 1
 
     img = img.transpose(Image.FLIP_TOP_BOTTOM)
+
+    # Upscale with NEAREST so the colored room blocks stay crisp.
+    # render_overlay() reads scale via img.info["narwal_scale"] and
+    # transforms grid coords accordingly.
+    scale = max(1, min(720 // max(width, height), 12))
+    if scale > 1:
+        img = img.resize((width * scale, height * scale), Image.NEAREST)
+    img.info["narwal_scale"] = scale
+
     draw = ImageDraw.Draw(img)
+    sw, sh = width * scale, height * scale
 
     if room_names:
+        font_size = max(11, 6 * scale)
         try:
-            font = ImageFont.truetype("arial.ttf", 10)
+            font = ImageFont.truetype("arial.ttf", font_size)
         except (IOError, OSError):
-            font = ImageFont.load_default()
+            try:
+                font = ImageFont.truetype("DejaVuSans.ttf", font_size)
+            except (IOError, OSError):
+                font = ImageFont.load_default()
         for rid, name in room_names.items():
             if not name or rid not in room_count:
                 continue
-            cx = room_sum_x[rid] // room_count[rid]
-            cy = height - 1 - (room_sum_y[rid] // room_count[rid])
+            cx = (room_sum_x[rid] // room_count[rid]) * scale + scale // 2
+            cy = (height - 1 - (room_sum_y[rid] // room_count[rid])) * scale + scale // 2
             bbox = font.getbbox(name)
             tw = bbox[2] - bbox[0]
             th = bbox[3] - bbox[1]
@@ -528,41 +563,48 @@ def render_base_map(
                 draw.text((tx + ox, ty + oy), name, fill=(0, 0, 0), font=font)
             draw.text((tx, ty), name, fill=(255, 255, 255), font=font)
 
-    # Draw obstacle/furniture annotations (static data from get_map field 2.32)
+    # Draw obstacle / furniture annotations (static data from get_map
+    # field 2.32). Coordinates are in grid units, scaled to pixels.
     if obstacles:
+        obs_font_size = max(9, 5 * scale)
         try:
-            obs_font = ImageFont.truetype("arial.ttf", 8)
+            obs_font = ImageFont.truetype("arial.ttf", obs_font_size)
         except (IOError, OSError):
-            obs_font = ImageFont.load_default()
+            try:
+                obs_font = ImageFont.truetype("DejaVuSans.ttf", obs_font_size)
+            except (IOError, OSError):
+                obs_font = ImageFont.load_default()
         for obs in obstacles:
             gx, gy = obs.to_grid_coords(origin_x, origin_y)
-            # Skip out-of-bounds obstacles
             if gx < 0 or gx >= width or gy < 0 or gy >= height:
                 continue
-            img_x = int(gx)
-            img_y = height - 1 - int(gy)
-            half_w = max(1, int(obs.width / 2))
-            half_h = max(1, int(obs.height / 2))
+            img_x = int(gx) * scale + scale // 2
+            img_y = (height - 1 - int(gy)) * scale + scale // 2
+            half_w = max(scale, int(obs.width / 2 * scale))
+            half_h = max(scale, int(obs.height / 2 * scale))
             color = OBSTACLE_COLORS.get(obs.type_id, OBSTACLE_COLOR_DEFAULT)
             draw.rectangle(
                 [img_x - half_w, img_y - half_h, img_x + half_w, img_y + half_h],
-                outline=color, width=1,
+                outline=color, width=max(1, scale // 4),
             )
-            # Draw label centered above the rectangle
             label = obs.display_name
             bbox = obs_font.getbbox(label)
             tw = bbox[2] - bbox[0]
             th = bbox[3] - bbox[1]
             lx = img_x - tw // 2
             ly = img_y - half_h - th - 2
-            # Dark outline for readability
             for ox, oy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
                 draw.text((lx + ox, ly + oy), label, fill=(0, 0, 0), font=obs_font)
             draw.text((lx, ly), label, fill=color, font=obs_font)
 
     if dock_x is not None and dock_y is not None:
-        dock_size = max(4, min(width, height) // 60)
-        _draw_dock(draw, int(dock_x), height - 1 - int(dock_y), dock_size)
+        dock_size = max(6, min(sw, sh) // 50)
+        _draw_dock(
+            draw,
+            int(dock_x) * scale + scale // 2,
+            (height - 1 - int(dock_y)) * scale + scale // 2,
+            dock_size,
+        )
 
     return img
 
@@ -591,27 +633,36 @@ def render_overlay(
     from PIL import ImageDraw
 
     img = base_img.copy()
+    img.info["narwal_scale"] = base_img.info.get("narwal_scale", 1)
     draw = ImageDraw.Draw(img)
-    width = img.width
+    scale = img.info["narwal_scale"]
+    sw, sh = img.width, img.height
+
+    def gx(x: float) -> int:
+        return int(x) * scale + scale // 2
+
+    def gy(y: float) -> int:
+        return (height - 1 - int(y)) * scale + scale // 2
 
     # Draw trail (blue path showing where robot has cleaned)
     if trail and len(trail) >= 2:
         recent_start = max(len(trail) - 200, 0)
+        line_w = max(2, scale // 2)
         for i in range(len(trail) - 1):
             if i >= recent_start:
                 color = (30, 120, 255)  # bright blue for recent
             else:
                 color = (15, 60, 130)  # dim blue for older
-            x1, y1 = int(trail[i][0]), height - 1 - int(trail[i][1])
-            x2, y2 = int(trail[i + 1][0]), height - 1 - int(trail[i + 1][1])
-            draw.line([(x1, y1), (x2, y2)], fill=color, width=2)
+            x1, y1 = gx(trail[i][0]), gy(trail[i][1])
+            x2, y2 = gx(trail[i + 1][0]), gy(trail[i + 1][1])
+            draw.line([(x1, y1), (x2, y2)], fill=color, width=line_w)
 
     # Draw robot
     if robot_x is not None and robot_y is not None:
-        rx = int(robot_x)
-        ry = height - 1 - int(robot_y)
-        if 0 <= rx < width and 0 <= ry < height:
-            radius = max(3, min(width, height) // 80)
+        rx = gx(robot_x)
+        ry = gy(robot_y)
+        if 0 <= rx < sw and 0 <= ry < sh:
+            radius = max(5, min(sw, sh) // 60)
             _draw_robot(draw, rx, ry, robot_heading, radius)
 
     buf = io.BytesIO()

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -6,7 +6,14 @@ import struct
 from dataclasses import dataclass, field
 from typing import Any, ClassVar
 
-from .const import CommandResult, FanLevel, MopHumidity, WorkingStatus
+from .const import (
+    CommandResult,
+    ERROR_MESSAGE_SNIPPETS_EN,
+    ERROR_MESSAGES_EN,
+    FanLevel,
+    MopHumidity,
+    WorkingStatus,
+)
 
 
 @dataclass
@@ -18,17 +25,77 @@ class DeviceInfo:
     firmware_version: str = ""
 
 
+# ROOM_TYPE enum → display name (Flow 1 / AX12, from APK libapp.so strings).
+_FLOW1_ROOM_TYPE_NAMES: dict[int, str] = {
+    0: "Room",
+    1: "Primary Bedroom",
+    2: "Secondary Bedroom",
+    3: "Living Room",
+    4: "Kitchen",
+    5: "Study",
+    6: "Bathroom",
+    7: "Dining Room",
+    8: "Corridor",
+    9: "Balcony",
+    10: "Utility Room",
+    11: "Cloak Room",
+    12: "Nursery",
+    13: "Recreation Room",
+    14: "Shower Room",
+    15: "Other",
+}
+
+# Flow 2 reorders the ROOM_TYPE enum vs Flow 1. Confirmed via live capture
+# (firmware v01.07.19.00, product_key QxMSPG6VSO) by walking every type in
+# the Narwal app's room-type picker. Only deltas are listed; sub_types not
+# present here use the Flow 1 name.
+_FLOW2_ROOM_TYPE_OVERRIDES: dict[int, str] = {
+    1: "Master Bedroom",
+    5: "Bathroom",
+    6: "Toilet",
+    7: "Balcony",
+    8: "Dining Room",
+    9: "Cloakroom",
+    10: "Corridor",
+    11: "Study",
+    14: "Storage Room",
+}
+
+# product_keys that use the Flow 2 mapping. Add more as community confirms.
+_FLOW2_PRODUCT_KEYS: frozenset[str] = frozenset({"QxMSPG6VSO"})
+
+
+def _translate_error_message(code: int, localized_message: str) -> str:
+    """Return an English error message for known Flow 2 faults."""
+    if code in ERROR_MESSAGES_EN:
+        return ERROR_MESSAGES_EN[code]
+    for snippet, message in ERROR_MESSAGE_SNIPPETS_EN.items():
+        if snippet in localized_message:
+            return message
+    return localized_message
+
+
+def get_room_type_names(product_key: str | None) -> dict[int, str]:
+    """Return the ROOM_TYPE → display-name mapping for a given device.
+
+    Flow 2 (and possibly other newer models) renamed/reordered the ROOM_TYPE
+    enum. We pick the right base mapping from product_key and fall back to
+    Flow 1 for unknown devices.
+    """
+    base = dict(_FLOW1_ROOM_TYPE_NAMES)
+    if product_key and product_key in _FLOW2_PRODUCT_KEYS:
+        base.update(_FLOW2_ROOM_TYPE_OVERRIDES)
+    return base
+
+
 @dataclass
 class RoomInfo:
     """A room on the map.
 
     Fields from get_map / get_editable_map field 2.12:
       field 1: room_id (matches pixel value >> 8 in map grid)
-      field 2: room_sub_type — ROOM_TYPE enum from APK (0=unspecified,
-               1=main bedroom, 2=secondary room, 3=living room, 4=kitchen,
-               5=study, 6=bathroom, 7=dining room, 8=corridor, 9=balcony,
-               10=utility room, 11=cloak room, 12=nursery, 13=recreation,
-               14=shower room, 15=other)
+      field 2: room_sub_type — ROOM_TYPE enum from APK. The string mapping
+               differs between Flow 1 and Flow 2 (see get_room_type_names).
       field 3: user-assigned name (UTF-8, empty if not named by user)
       field 4: category (1=room, 2=utility/small space)
       field 8: instance_index (1-based, for numbering duplicates: Bathroom 1, 2, 3...)
@@ -40,29 +107,13 @@ class RoomInfo:
     category: int = 0  # 1=room, 2=utility (field 4)
     instance_index: int = 0  # numbering for duplicates (field 8)
 
-    # ROOM_TYPE enum → default display name (from APK libapp.so string analysis)
+    # ROOM_TYPE enum → default display name. Set by MapData.from_response
+    # based on the connected device's product_key; defaults to Flow 1 names.
     ROOM_TYPE_NAMES: dict[int, str] = field(default=None, repr=False)
 
     def __post_init__(self):
         if self.ROOM_TYPE_NAMES is None:
-            object.__setattr__(self, "ROOM_TYPE_NAMES", {
-                0: "Room",
-                1: "Primary Bedroom",
-                2: "Secondary Bedroom",
-                3: "Living Room",
-                4: "Kitchen",
-                5: "Study",
-                6: "Bathroom",
-                7: "Dining Room",
-                8: "Corridor",
-                9: "Balcony",
-                10: "Utility Room",
-                11: "Cloak Room",
-                12: "Nursery",
-                13: "Recreation Room",
-                14: "Shower Room",
-                15: "Other",
-            })
+            object.__setattr__(self, "ROOM_TYPE_NAMES", dict(_FLOW1_ROOM_TYPE_NAMES))
 
     @property
     def display_name(self) -> str:
@@ -238,11 +289,21 @@ class MapData:
     raw: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def from_response(cls, decoded: dict[str, Any]) -> MapData:
-        """Parse map data from a get_map field5 response."""
+    def from_response(
+        cls, decoded: dict[str, Any], product_key: str | None = None,
+    ) -> MapData:
+        """Parse map data from a get_map field5 response.
+
+        Args:
+            decoded: bbp-decoded map response payload.
+            product_key: Connected device's product_key. Selects the
+                ROOM_TYPE → display-name mapping (Flow 1 vs Flow 2).
+        """
         payload = decoded.get("2", {})
         if not payload:
             return cls()
+
+        type_names = get_room_type_names(product_key)
 
         rooms = []
         room_list = payload.get("12", [])
@@ -266,6 +327,7 @@ class MapData:
                     room_sub_type=int(room.get("2", 0)),
                     category=int(room.get("4", 0)),
                     instance_index=int(room.get("8", 0)),
+                    ROOM_TYPE_NAMES=type_names,
                 ))
 
         compressed = payload.get("17", b"")
@@ -471,6 +533,73 @@ class NarwalState:
     firmware_version: str = ""
     firmware_target: str = ""
 
+    # Current clean settings (Flow 2 — live-broadcast in robot_base_status).
+    # 0 means "not yet observed" (the robot uses 1-indexed values).
+    #   field 26 = suction (1=Quiet, 2=Standard, 3=Strong, 4=Super powerful)
+    #   field 29 = mop humidity (1=Slightly dry, 2=Standard, 3=Slightly wet)
+    fan_level_raw: int = 0
+    mop_humidity_raw: int = 0
+
+    # Station / consumables. Field 35 is dust-bag remaining capacity as
+    # an IEEE 754 float32 percentage (e.g. 1117188891 -> 75.47%). Field
+    # 41 is broadcast as 100 on Flow 2 even when the app shows the dust
+    # bag below 100%, so it is not the dust-bag health value.
+    # Other tank/solution levels (clean water, dirty water, cleaning
+    # solution, mop pad wear) are not yet mapped — most appear constant
+    # at 1 (=OK) until a fault occurs.
+    dust_bag_health: float = 0.0
+
+    # Active fault / error. The robot reports a structured error in
+    # robot_base_status field 48.1.2 — empty `{}` when there is no
+    # active error, or `{1: severity, 2: code, 3: localized_message}`
+    # when a fault halts the current task. The message is broadcast in
+    # whatever locale the robot's firmware was set to (Chinese on the
+    # Flow 2 hardware we tested), so consumers should prefer the
+    # numeric code for logic and use the message for display.
+    error_code: int = 0
+    error_severity: int = 0
+    error_message: str = ""
+    error_message_localized: str = ""
+    # Station/tank faults can be reported through robot_base_status.25.*
+    # instead of the regular 48.1.2 / field 1 channels. Flow 2 test:
+    # base.25.6={1:1,2:16842806} while the app highlighted Dirty Water Tank.
+    station_error_code: int = 0
+    station_error_severity: int = 0
+    station_error_slot: int = 0
+
+    # Station activity flags. Field 48.1 is a (possibly-repeated) list
+    # of currently-active dock tasks. Each entry uses an empty marker
+    # sub-field to identify the task type. Sub-keys verified by capture:
+    #   .10 = dust-bag drying (NOT dust emptying — earlier guess)
+    #   .13 = mop drying
+    #   .14 = dust-cabinet disinfection
+    # Entries without a `1` field are running; `1: 1` marks paused.
+    # WorkingStatus 17 / 19 also indicate mop-drying phases when the
+    # robot itself is the actor — see NarwalStationActivitySensor.
+    station_dust_bag_drying: bool = False
+    station_mop_drying: bool = False
+    station_dust_disinfecting: bool = False
+    # App-started room vacuum capture (2026-05-12) showed f48.5/f48.6
+    # while the dock audibly emptied the robot before undocking.
+    station_dust_emptying: bool = False
+
+    # Dust-bag drying timer. During manual bag drying the station marker
+    # f48.10 is present, and ws.12/ws.13 carry elapsed/target seconds
+    # (observed target 18000 = 5 h). ws.12 is also cleaning elapsed time,
+    # so only treat it as bag-drying progress while f48.10 is active.
+    dust_bag_drying_elapsed: int = 0
+    dust_bag_drying_target: int = 0
+
+    # Disinfection timer. ws.10 = elapsed seconds, ws.11 = target
+    # seconds (constant 2700 = 45 min in observed firmware). Both 0
+    # when disinfection is not running. Earlier we considered these
+    # generic dock-activity fields — they're disinfection-specific:
+    # ws.10/ws.11 vanish from the working_status broadcast as soon as
+    # the disinfection cycle ends, even while dust-bag drying is still
+    # active.
+    dust_disinfection_elapsed: int = 0
+    dust_disinfection_target: int = 0
+
     # Device identity
     device_info: DeviceInfo | None = None
 
@@ -481,9 +610,54 @@ class NarwalState:
     # Position (from map data)
     position: Position | None = None
 
-    # Cleaning stats
-    cleaning_area: int = 0  # cm²
+    # Cleaning stats. Two separate sources:
+    #   * Flow 1: working_status field 13 in cm² (legacy upstream code).
+    #   * Flow 2: working_status fields 1 and 2 carry float32 progress % and
+    #     cleaned-area m² (live captures). Prefer the Flow 2 fields when
+    #     populated; fall back to the legacy cm² value otherwise. Field 13
+    #     is a constant (18000) on Flow 2 and never the actual area.
+    cleaning_area: int = 0  # legacy: working_status.13 in cm² (Flow 1)
+    cleaning_area_m2: float = 0.0  # live: working_status.2 as float32 m² (Flow 2)
+    cleaning_progress_pct: float = 0.0  # live: working_status.1 as float32 % (Flow 2)
     cleaning_time: int = 0  # seconds
+
+    # Rooms reported as completed within the active clean.
+    # Derived from working_status.5 — each entry that gains sub-field
+    # 4 = 1 has been finished. Empty list when not cleaning or all
+    # rooms still pending.
+    rooms_completed: list[int] = field(default_factory=list)
+    current_room_id: int = 0
+    current_room_index: int = 0
+
+    # Mop-drying timer (Flow 2). Live-confirmed by toggling between
+    # drying modes:
+    #   ws.8 = elapsed seconds since the cycle started
+    #   ws.9 = target total seconds for the selected mode
+    #     - 12600 (3.5 h) for default / smart / strong
+    #     - 18000 (5 h)   for silent
+    # Switching modes mid-cycle rescales ws.8 so the percent-complete
+    # stays consistent. Both fields drop to 0 once drying stops.
+    mop_drying_elapsed: int = 0
+    mop_drying_target: int = 0
+
+    # User-action prompt (Flow 2). When the robot needs the user to
+    # do something physical (carry me to dock, refill the tank, etc.)
+    # it broadcasts a structured prompt and starts a countdown. Empty
+    # / 0 when nothing is required:
+    #   user_action_type    = base.3.16 (2=fill tank, 3=return after
+    #                         clean, 4=return before clean — observed)
+    #   user_action_elapsed = ws.22.1 — seconds the user has been
+    #                         asked already
+    #   user_action_target  = ws.22.2 — timeout in seconds (600 / 3600
+    #                         observed)
+    user_action_type: int = 0
+    user_action_elapsed: int = 0
+    user_action_target: int = 0
+
+    # Map-identity signature (Flow 2). Multi-map houses switch
+    # base.30 / base.44 between maps; treat the pair as an opaque
+    # key — when it changes the active map has changed.
+    map_signature: tuple[int | None, int | None] = (None, None)
 
     # Map
     map_data: MapData | None = None
@@ -507,6 +681,12 @@ class NarwalState:
     # Dock activity (field 3 sub-field 12: 2/6 observed when docked)
     dock_activity: int = 0
 
+    # Remote camera/manual-control mode. During a live app camera/manual
+    # steering session, robot_base_status.31=1 and field 3.4=15; both
+    # cleared/changed when the live mode ended.
+    remote_control_active: bool = False
+    remote_control_sub_state: int = 0
+
     # Dock presence (field 3 sub-field 3)
     # Values observed: 1=on dock, 2=off dock, 6=on dock (charged idle)
     dock_presence: int = 0
@@ -529,14 +709,55 @@ class NarwalState:
     raw_base_status: dict[str, Any] = field(default_factory=dict)
     raw_working_status: dict[str, Any] = field(default_factory=dict)
 
+    # Forward path the robot is about to drive — list of (x, y) world
+    # coordinates decoded from status/point_navi_plan_traj. Empty list
+    # when the robot is idle or no path is currently planned.
+    plan_trajectory: list[tuple[float, float]] = field(default_factory=list)
+    # Wall-clock timestamp of the most recent report/clean_report event
+    # (empty-payload broadcast that fires once at end of a clean cycle).
+    last_clean_report_ts: float = 0.0
+
     @property
     def is_cleaning(self) -> bool:
-        """True when actively cleaning (not paused, not returning to dock)."""
+        """True when actively cleaning (not paused, not returning to dock).
+
+        Flow 2 firmware variants do not all report the same
+        robot_base_status.3.1 value while vacuuming. If the base status is
+        unmapped but the robot is off the dock and working_status carries
+        clean-session fields, infer cleaning instead of showing idle.
+        """
+        explicit_cleaning = self.working_status in (
+            WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT,
+        )
+        inferred_cleaning = self._looks_like_active_cleaning_session()
         return (
-            self.working_status in (WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT)
+            (explicit_cleaning or inferred_cleaning)
             and not self.is_paused
             and not self.is_returning_to_dock
         )
+
+    def _looks_like_active_cleaning_session(self) -> bool:
+        """Infer an active clean from session fields when status is unmapped."""
+        if self.working_status in (
+            WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT,
+            WorkingStatus.DOCKED, WorkingStatus.CHARGED,
+            WorkingStatus.MOP_WASHING, WorkingStatus.MOP_DRYING,
+            WorkingStatus.MOP_DRYING_ACTIVE,
+        ):
+            return False
+        if self.dock_sub_state == 1 or self.dock_activity > 0:
+            return False
+        if self.dock_field11 == 2 or self.dock_field47 == 3:
+            return False
+        ws = self.raw_working_status
+        if not isinstance(ws, dict) or not ws:
+            return False
+        # Cleaning broadcasts normally include a room queue/current room,
+        # and may include progress/area/elapsed. Drying broadcasts have
+        # ws.12/ws.13 too, so don't infer from timer fields alone.
+        room_queue = ws.get("5")
+        has_rooms = bool(room_queue) if isinstance(room_queue, (list, dict)) else False
+        return has_rooms or "6" in ws or "1" in ws or "2" in ws
 
     @property
     def is_docked(self) -> bool:
@@ -558,6 +779,12 @@ class NarwalState:
         if self.working_status in (WorkingStatus.DOCKED, WorkingStatus.CHARGED):
             return True
         if self.working_status in (WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT):
+            return False
+        # Dock presence from field 3.3 is the most direct signal we have
+        # on this unit: 1/6 = on dock, 2 = off dock.
+        if self.dock_presence in (1, 6):
+            return True
+        if self.dock_presence == 2:
             return False
         # For STANDBY, UNKNOWN, or any other status: check dock field signals
         if self.dock_sub_state == 1:
@@ -593,23 +820,176 @@ class NarwalState:
             return False
         return self.is_returning_to_dock and self.dock_sub_state == 2
 
+    @property
+    def current_room_name(self) -> str | None:
+        """Return the display name of the room currently being cleaned.
+
+        Uses the current room id resolved from working_status.6 plus the
+        active room queue. Falls back to "Room <id>" when the map does not
+        contain a matching name yet.
+        """
+        if self.current_room_id <= 0:
+            return "unknown"
+        if self.map_data is None:
+            return f"Room {self.current_room_id}"
+        for room in self.map_data.rooms:
+            if room.room_id == self.current_room_id:
+                return room.display_name
+        return f"Room {self.current_room_id}"
+
     def update_from_working_status(self, decoded: dict[str, Any]) -> None:
         """Update state from a decoded working_status message.
 
-        Confirmed via 35-min monitor capture (2026-02-27):
-          Field 3  = current session elapsed time (seconds)
-                     (confirmed: 2136→2159 over 35-min clean)
-          Field 13 = cleaning area (cm²) — CONFIRMED (18000 = 1.8m²)
-          Field 15 = 600 during cleaning (purpose uncertain)
+        Field semantics (re-verified 2026-05 with full Wohnzimmer-Clean
+        capture — earlier mapping had cleaning_time on field 3, which is
+        actually the WorkingStatus enum):
+
+        Field 1   = float32 cleaning progress percent
+        Field 2   = float32 cleaned area in m²
+        Field 3   = WorkingStatus enum (status code, not seconds)
+        Field 5   = list of {1: roomId, 2: completed_flag}; flag == 2
+                    means the room is done. Earlier code used sub-field
+                    4 which never appears in current firmware.
+        Field 6   = index of the room currently being cleaned
+        Field 12  = elapsed seconds for the current session
+        Field 13  = legacy area in cm² (Flow 1 only — constant 18000
+                    on Flow 2, ignored)
+        Field 15  = 600 during cleaning, purpose uncertain
         """
         self.raw_working_status = decoded
-        if "3" in decoded:
+        is_cleaning = self.working_status in (
+            WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT,
+        ) or self._looks_like_active_cleaning_session()
+        # cleaning_time: field 12 is real elapsed seconds during a clean,
+        # but the firmware reuses it as a station-cycle timer during
+        # dust-bag drying. Keep Cleaning time at 0 unless actively cleaning.
+        if is_cleaning and "12" in decoded:
             try:
-                self.cleaning_time = int(decoded["3"])
+                self.cleaning_time = int(decoded["12"])
             except (ValueError, TypeError):
                 pass
-        if "13" in decoded:
-            self.cleaning_area = int(decoded["13"])
+        elif not is_cleaning:
+            self.cleaning_time = 0
+        # Flow 2: float32 progress and area encoded as fixed32 ints.
+        progress = _to_float32(decoded.get("1"))
+        if progress is not None and 0 <= progress <= 200:
+            self.cleaning_progress_pct = progress
+        area = _to_float32(decoded.get("2"))
+        if area is not None and 0 <= area <= 10000:
+            self.cleaning_area_m2 = area
+        # Track which rooms in the queue have been completed.
+        rooms = decoded.get("5")
+        completed: list[int] = []
+        # Each entry is {1: roomId, 2: completion_flag}. Observed values
+        # for flag: missing (queued), 1 (in progress), 2 (done). Earlier
+        # code looked at sub-field 4 which was never populated in any
+        # capture we have.
+        if isinstance(rooms, list):
+            for entry in rooms:
+                if isinstance(entry, dict) and entry.get("2") == 2:
+                    try:
+                        completed.append(int(entry.get("1", 0)))
+                    except (ValueError, TypeError):
+                        pass
+        elif isinstance(rooms, dict) and rooms.get("2") == 2:
+            try:
+                completed.append(int(rooms.get("1", 0)))
+            except (ValueError, TypeError):
+                pass
+        self.rooms_completed = completed
+        self.current_room_index = 0
+        self.current_room_id = 0
+        try:
+            current_hint = int(decoded.get("6", 0) or 0)
+        except (ValueError, TypeError):
+            current_hint = 0
+        self.current_room_index = current_hint
+        if isinstance(rooms, list):
+            # Prefer the room currently in progress.
+            for entry in rooms:
+                if not isinstance(entry, dict):
+                    continue
+                try:
+                    room_id = int(entry.get("1", 0) or 0)
+                except (ValueError, TypeError):
+                    room_id = 0
+                try:
+                    flag = int(entry.get("2", 0) or 0)
+                except (ValueError, TypeError):
+                    flag = 0
+                if room_id > 0 and flag == 1:
+                    self.current_room_id = room_id
+                    break
+            if self.current_room_id == 0 and current_hint > 0 and 1 <= current_hint <= len(rooms):
+                entry = rooms[current_hint - 1]
+                if isinstance(entry, dict):
+                    try:
+                        self.current_room_id = int(entry.get("1", 0) or 0)
+                    except (ValueError, TypeError):
+                        self.current_room_id = 0
+        elif isinstance(rooms, dict):
+            # Single-room broadcasts often collapse to {room_id: flag}.
+            for key, value in rooms.items():
+                try:
+                    room_id = int(key)
+                    flag = int(value or 0)
+                except (ValueError, TypeError):
+                    continue
+                if room_id > 0 and flag == 1:
+                    self.current_room_id = room_id
+                    break
+            if self.current_room_id == 0 and current_hint > 0:
+                self.current_room_id = current_hint
+        # Mop-drying timer (Flow 2 hypothesis from live capture).
+        try:
+            self.mop_drying_elapsed = int(decoded.get("8", 0) or 0)
+        except (ValueError, TypeError):
+            self.mop_drying_elapsed = 0
+        try:
+            self.mop_drying_target = int(decoded.get("9", 0) or 0)
+        except (ValueError, TypeError):
+            self.mop_drying_target = 0
+        # Dust-bag drying timer. Uses ws.12/ws.13, but only while the
+        # f48.10 marker is active; otherwise those fields have other
+        # meanings (notably Cleaning time).
+        if self.station_dust_bag_drying and self.is_docked and not is_cleaning:
+            try:
+                self.dust_bag_drying_elapsed = int(decoded.get("12", 0) or 0)
+            except (ValueError, TypeError):
+                self.dust_bag_drying_elapsed = 0
+            try:
+                self.dust_bag_drying_target = int(decoded.get("13", 0) or 0)
+            except (ValueError, TypeError):
+                self.dust_bag_drying_target = 0
+        else:
+            self.dust_bag_drying_elapsed = 0
+            self.dust_bag_drying_target = 0
+        # Disinfection timer (ws.10 elapsed / ws.11 target). The fields
+        # are absent from the broadcast when no disinfection cycle is
+        # running — `.get("10", 0)` resolves to 0 in that case.
+        try:
+            self.dust_disinfection_elapsed = int(decoded.get("10", 0) or 0)
+        except (ValueError, TypeError):
+            self.dust_disinfection_elapsed = 0
+        try:
+            self.dust_disinfection_target = int(decoded.get("11", 0) or 0)
+        except (ValueError, TypeError):
+            self.dust_disinfection_target = 0
+        # ws.22 = user-action countdown ({1: elapsed, 2: target}). Empty
+        # dict when no action is required.
+        f22 = decoded.get("22")
+        if isinstance(f22, dict) and f22:
+            try:
+                self.user_action_elapsed = int(f22.get("1", 0) or 0)
+            except (ValueError, TypeError):
+                self.user_action_elapsed = 0
+            try:
+                self.user_action_target = int(f22.get("2", 0) or 0)
+            except (ValueError, TypeError):
+                self.user_action_target = 0
+        else:
+            self.user_action_elapsed = 0
+            self.user_action_target = 0
         if "15" in decoded:
             # Field 15 may be cumulative time; prefer field 3 for current session
             pass
@@ -642,6 +1022,136 @@ class NarwalState:
                 self.dock_field11 = int(decoded["11"])
             except (ValueError, TypeError):
                 self.dock_field11 = 0
+        # Field 26 = current suction level (Flow 2 only; live captures from
+        # firmware v01.07.19.00 confirm the 1-indexed scale 1=Quiet,
+        # 2=Normal/Standard, 3=Strong, 4=Super Powerful). Not observed on
+        # Flow 1 — leaves fan_level_raw at 0 there.
+        if "26" in decoded:
+            try:
+                self.fan_level_raw = int(decoded["26"])
+            except (ValueError, TypeError):
+                self.fan_level_raw = 0
+        # Field 29 = current mop humidity (Flow 2). 1=Slightly dry,
+        # 2=Standard, 3=Slightly wet (live-confirmed). Used for UI state
+        # even while docked when the robot keeps broadcasting it.
+        if "29" in decoded:
+            try:
+                self.mop_humidity_raw = int(decoded["29"])
+            except (ValueError, TypeError):
+                self.mop_humidity_raw = 0
+        # Field 35 = dust bag remaining capacity, 0–100, encoded as float32.
+        # Field 41 stays at 100 on Flow 2 even when the app does not.
+        if "35" in decoded:
+            dust_bag = _to_float32(decoded["35"])
+            if dust_bag is not None:
+                self.dust_bag_health = round(dust_bag, 1)
+        # Field 48.1 carries one or more dock activities. It's a single
+        # message during a normal clean, but switches to a repeated list
+        # when multiple activities overlap (e.g. mop drying while a
+        # dust-bag emptying is queued). Normalize to a list so the
+        # parsers below don't need to care.
+        f48_1 = decoded.get("48", {}).get("1")
+        f48_entries: list[dict[str, Any]] = []
+        if isinstance(f48_1, list):
+            f48_entries = [e for e in f48_1 if isinstance(e, dict)]
+        elif isinstance(f48_1, dict):
+            f48_entries = [f48_1]
+
+        # Active error. The robot reports one through two channels:
+        #   * 48.1.*.2 = {1: severity, 2: code, 3: localized_message}
+        #   * field 1 = {1: code, 2: severity, 3: formatted_message}
+        # Field 1 also carries the formatted "错误码:0xCCSSRRXX\n等级:..."
+        # banner string. Either or both can be populated; whichever
+        # appears first wins. Empty/absent on both = no active error.
+        err = next(
+            (e["2"] for e in f48_entries
+             if isinstance(e.get("2"), dict) and e["2"]),
+            None,
+        )
+        f1 = decoded.get("1")
+        field25 = decoded.get("25")
+        station_err: tuple[int, dict[str, Any]] | None = None
+        if isinstance(field25, dict):
+            for raw_slot, payload in field25.items():
+                if isinstance(payload, dict) and payload:
+                    try:
+                        slot = int(raw_slot)
+                    except (ValueError, TypeError):
+                        slot = 0
+                    station_err = (slot, payload)
+                    break
+
+        if station_err is not None:
+            slot, payload = station_err
+            self.station_error_slot = slot
+            try:
+                self.station_error_severity = int(payload.get("1", 0))
+            except (ValueError, TypeError):
+                self.station_error_severity = 0
+            try:
+                self.station_error_code = int(payload.get("2", 0))
+            except (ValueError, TypeError):
+                self.station_error_code = 0
+        else:
+            self.station_error_slot = 0
+            self.station_error_severity = 0
+            self.station_error_code = 0
+
+        if isinstance(err, dict) and err:
+            try:
+                self.error_severity = int(err.get("1", 0))
+            except (ValueError, TypeError):
+                self.error_severity = 0
+            try:
+                self.error_code = int(err.get("2", 0))
+            except (ValueError, TypeError):
+                self.error_code = 0
+            raw_msg = err.get("3", "")
+            if isinstance(raw_msg, bytes):
+                self.error_message_localized = raw_msg.decode("utf-8", errors="replace")
+            else:
+                self.error_message_localized = str(raw_msg)
+            self.error_message = _translate_error_message(self.error_code, self.error_message_localized)
+        elif isinstance(f1, dict) and f1:
+            # Secondary channel — note the swapped fields: 1 is the code.
+            try:
+                self.error_code = int(f1.get("1", 0))
+            except (ValueError, TypeError):
+                self.error_code = 0
+            try:
+                self.error_severity = int(f1.get("2", 0))
+            except (ValueError, TypeError):
+                self.error_severity = 0
+            raw_msg = f1.get("3", "")
+            if isinstance(raw_msg, bytes):
+                self.error_message_localized = raw_msg.decode("utf-8", errors="replace")
+            else:
+                self.error_message_localized = str(raw_msg)
+            self.error_message = _translate_error_message(self.error_code, self.error_message_localized)
+        elif self.station_error_code:
+            # Station/tank faults observed on Flow 2 arrive via field 25.*
+            # with no text message. Promote them to the generic error
+            # sensors as well so users get one consistent fault surface.
+            self.error_code = self.station_error_code
+            self.error_severity = self.station_error_severity
+            self.error_message_localized = ""
+            self.error_message = ERROR_MESSAGES_EN.get(self.error_code, "")
+        else:
+            self.error_code = 0
+            self.error_severity = 0
+            self.error_message = ""
+            self.error_message_localized = ""
+
+        # Station-activity markers within 48.1.*. Each entry carries an
+        # empty `{}` sub-field whose key identifies the task type. See
+        # the field declarations above for the verified key map.
+        self.station_dust_bag_drying = any("10" in e for e in f48_entries)
+        self.station_mop_drying = any("13" in e for e in f48_entries)
+        self.station_dust_disinfecting = any("14" in e for e in f48_entries)
+        # App-started room vacuum capture (2026-05-12): the dock audibly
+        # emptied the robot before it undocked while f48.5/f48.6 were
+        # present. Treat either marker as active dust-bin emptying.
+        self.station_dust_emptying = any("5" in e or "6" in e for e in f48_entries)
         # Field 47 = dock indicator (3=docked, 2=undocked)
         if "47" in decoded:
             try:
@@ -669,17 +1179,54 @@ class NarwalState:
                 self.dock_activity = int(field3.get("12", 0))
             except (ValueError, TypeError):
                 self.dock_activity = 0
+            # Sub-field 4 = sub-state. Observed value 15 during remote
+            # camera/manual steering mode while base.31=1.
+            try:
+                self.remote_control_sub_state = int(field3.get("4", 0))
+            except (ValueError, TypeError):
+                self.remote_control_sub_state = 0
+            self.remote_control_active = bool(decoded.get("31"))
             # Sub-field 3 = dock presence (1/6=on dock, 2=off dock)
             try:
                 self.dock_presence = int(field3.get("3", 0))
             except (ValueError, TypeError):
                 self.dock_presence = 0
+            # Sub-field 16 = user-action prompt type (Flow 2):
+            #   2 = fill water tank / problem solved
+            #   3 = bring robot to dock after clean done
+            #   4 = bring robot to dock to start clean
+            try:
+                self.user_action_type = int(field3.get("16", 0) or 0)
+            except (ValueError, TypeError):
+                self.user_action_type = 0
+        else:
+            self.user_action_type = 0
+            self.remote_control_active = bool(decoded.get("31"))
+            self.remote_control_sub_state = 0
+
+        # Map identity (Flow 2). base.30 + base.44 form an opaque
+        # signature that flips between saved maps; track them so the
+        # coordinator can refresh get_map() when the user switches.
+        try:
+            sig30 = int(decoded["30"]) if "30" in decoded else None
+        except (ValueError, TypeError):
+            sig30 = None
+        try:
+            sig44 = int(decoded["44"]) if "44" in decoded else None
+        except (ValueError, TypeError):
+            sig44 = None
+        self.map_signature = (sig30, sig44)
         if "2" in decoded:
             # Field 2 = real-time battery SOC as float32
             # (e.g. 1118175232 → 83.0%; bbp may return int or float)
             bat = _to_float32(decoded["2"])
             if bat is not None:
                 self.battery_level = round(bat)
+        if "35" in decoded:
+            # Field 35 = dust bag remaining capacity as float32 percentage.
+            dust_bag = _to_float32(decoded["35"])
+            if dust_bag is not None:
+                self.dust_bag_health = round(dust_bag, 1)
         if "38" in decoded:
             # Field 38 = static battery health (always 100, design capacity)
             self.battery_health = int(decoded["38"])
@@ -707,10 +1254,37 @@ class NarwalState:
             bat = _to_float32(decoded["2"])
             if bat is not None:
                 self.battery_level = round(bat)
+        if "35" in decoded:
+            dust_bag = _to_float32(decoded["35"])
+            if dust_bag is not None:
+                self.dust_bag_health = round(dust_bag, 1)
         if "38" in decoded:
             self.battery_health = int(decoded["38"])
         if "36" in decoded:
             self.timestamp = int(decoded["36"])
+
+    def update_from_plan_traj(self, decoded: dict[str, Any]) -> None:
+        """Update state from a status/point_navi_plan_traj broadcast.
+
+        Field 1 is a repeated list of {1: x, 2: y} where each coordinate
+        is a float32 packed into a fixed32 int (same encoding as the
+        battery and area fields elsewhere in the protocol).
+
+        Empty / missing field 1 → robot has no planned path → clear the
+        cached trajectory. Bad encodings are dropped silently rather
+        than poisoning the whole list.
+        """
+        points: list[tuple[float, float]] = []
+        raw = decoded.get("1")
+        if isinstance(raw, list):
+            for entry in raw:
+                if not isinstance(entry, dict):
+                    continue
+                x = _to_float32(entry.get("1"))
+                y = _to_float32(entry.get("2"))
+                if x is not None and y is not None:
+                    points.append((x, y))
+        self.plan_trajectory = points
 
     def update_from_upgrade_status(self, decoded: dict[str, Any]) -> None:
         """Update state from a decoded upgrade_status message."""

--- a/custom_components/narwal/select.py
+++ b/custom_components/narwal/select.py
@@ -1,0 +1,84 @@
+"""Select entities for Narwal vacuum."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import NarwalConfigEntry
+from .coordinator import NarwalCoordinator
+from .entity import NarwalEntity
+from .narwal_client import MopHumidity
+
+_LOGGER = logging.getLogger(__name__)
+
+# Flow 2 broadcasts the live mop humidity in robot_base_status field 29
+# using a 1-indexed scale (1=Slightly dry, 2=Standard, 3=Slightly wet).
+_MOP_HUMIDITY_BROADCAST_TO_NAME: dict[int, str] = {
+    1: "slightly_dry",
+    2: "standard",
+    3: "slightly_wet",
+}
+
+# Maps the HA select option name to the MopHumidity enum value sent over
+# the wire by client.set_mop_humidity().
+_MOP_HUMIDITY_NAME_TO_ENUM: dict[str, MopHumidity] = {
+    "slightly_dry": MopHumidity.DRY,
+    "standard": MopHumidity.NORMAL,
+    "slightly_wet": MopHumidity.WET,
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: NarwalConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Narwal select entities."""
+    coordinator = entry.runtime_data
+    async_add_entities([NarwalMopHumiditySelect(coordinator)])
+
+
+class NarwalMopHumiditySelect(NarwalEntity, SelectEntity):
+    """Select entity for the vacuum's mop humidity setting."""
+
+    _attr_translation_key = "mop_humidity"
+    _attr_options = list(_MOP_HUMIDITY_NAME_TO_ENUM.keys())
+    _attr_icon = "mdi:water-percent"
+
+    def __init__(self, coordinator: NarwalCoordinator) -> None:
+        super().__init__(coordinator)
+        device_id = coordinator.config_entry.data["device_id"]
+        self._attr_unique_id = f"{device_id}_mop_humidity"
+        self._last_set: str | None = None
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current mop humidity setting.
+
+        Prefer the live broadcast whenever the robot provides one;
+        otherwise fall back to the last user-set value.
+        """
+        state = self.coordinator.data
+        if state is not None:
+            if state.mop_humidity_raw in _MOP_HUMIDITY_BROADCAST_TO_NAME:
+                return _MOP_HUMIDITY_BROADCAST_TO_NAME[state.mop_humidity_raw]
+        return self._last_set
+
+    async def async_select_option(self, option: str) -> None:
+        """Set the mop humidity on the robot."""
+        level = _MOP_HUMIDITY_NAME_TO_ENUM.get(option)
+        if level is None:
+            _LOGGER.warning("Unknown mop humidity option: %s", option)
+            return
+        resp = await self.coordinator.client.set_mop_humidity(level)
+        _LOGGER.info(
+            "Set mop humidity %s (enum=%d): code=%s, success=%s",
+            option, int(level), resp.result_code, resp.success,
+        )
+        if resp.success:
+            self._last_set = option
+            self.async_write_ha_state()

--- a/custom_components/narwal/sensor.py
+++ b/custom_components/narwal/sensor.py
@@ -15,7 +15,8 @@ from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfArea, UnitOfTi
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .narwal_client import NarwalState
+from .narwal_client import NarwalState, WorkingStatus
+from .narwal_client.map_renderer import lookup_room_at_grid
 
 from . import NarwalConfigEntry
 from .coordinator import NarwalCoordinator
@@ -27,6 +28,25 @@ class NarwalSensorEntityDescription(SensorEntityDescription):
     """Describes a Narwal sensor entity."""
 
     value_fn: Callable[[NarwalState], float | str | None]
+
+
+
+def _remaining_cleaning_seconds(state: NarwalState) -> int:
+    """Estimate remaining cleaning time in seconds.
+
+    Uses elapsed cleaning time and cleaning progress percent:
+      remaining ≈ elapsed * (100 - progress) / progress
+    Returns 0 when the estimate can't be made yet.
+    """
+    if not state.is_cleaning:
+        return 0
+    progress = state.cleaning_progress_pct
+    elapsed = state.cleaning_time
+    if progress <= 0 or elapsed <= 0:
+        return 0
+    remaining = round(elapsed * max(100.0 - min(progress, 100.0), 0.0) / progress)
+    # Snap to 30-second buckets to avoid UI jitter from frequent broadcasts.
+    return max(int(round(remaining / 30.0) * 30), 0)
 
 
 SENSOR_DESCRIPTIONS: tuple[NarwalSensorEntityDescription, ...] = (
@@ -43,29 +63,143 @@ SENSOR_DESCRIPTIONS: tuple[NarwalSensorEntityDescription, ...] = (
         translation_key="cleaning_area",
         native_unit_of_measurement=UnitOfArea.SQUARE_METERS,
         state_class=SensorStateClass.MEASUREMENT,
-        # working_status field 13 is cm²; divide by 10000 for m².
-        # NEEDS LIVE VALIDATION: only populated during active cleaning.
-        value_fn=lambda state: round(state.cleaning_area / 10000, 2)
-        if state.cleaning_area > 0
-        else None,
+        # Float32 m² from working_status.2 (Flow 2). Reports the last
+        # measured value — sticks at the previous clean's total when
+        # idle, resets when a new clean starts. The legacy ws.13 cm²
+        # fallback was removed: it's a stuck 18000 constant on Flow 2
+        # and produced confusing 1.8 m² values.
+        value_fn=lambda state: round(state.cleaning_area_m2, 2),
+    ),
+    NarwalSensorEntityDescription(
+        key="cleaning_progress",
+        translation_key="cleaning_progress",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        # Float32 % from working_status.1 (Flow 2). 0 when idle.
+        # Expose whole percentages to match the app and avoid noisy decimals.
+        value_fn=lambda state: round(state.cleaning_progress_pct),
+    ),
+    NarwalSensorEntityDescription(
+        key="mop_drying_progress",
+        translation_key="mop_drying_progress",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        # ws.8 elapsed / ws.9 target. 0 when no cycle is running.
+        value_fn=lambda state: (
+            round(state.mop_drying_elapsed * 100 / state.mop_drying_target)
+            if state.mop_drying_target > 0 else 0
+        ),
+    ),
+    NarwalSensorEntityDescription(
+        key="dust_bag_drying_progress",
+        translation_key="dust_bag_drying_progress",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        # Manual dust-bag drying publishes f48.10 plus ws.12 elapsed /
+        # ws.13 target (18000 s = 5 h). Only expose it while f48.10 is
+        # active and the robot is not cleaning, because ws.12 is also
+        # used as cleaning elapsed time and f48.10 can remain present
+        # while a new clean starts.
+        value_fn=lambda state: (
+            round(state.dust_bag_drying_elapsed * 100 / state.dust_bag_drying_target)
+            if state.dust_bag_drying_target > 0 and state.is_docked and not state.is_cleaning else 0
+        ),
+    ),
+    NarwalSensorEntityDescription(
+        key="dust_disinfection_progress",
+        translation_key="dust_disinfection_progress",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        # ws.10 elapsed / ws.11 target (constant 2700 = 45 min). 0
+        # when no disinfection cycle is running.
+        value_fn=lambda state: (
+            round(state.dust_disinfection_elapsed * 100 / state.dust_disinfection_target)
+            if state.dust_disinfection_target > 0 else 0
+        ),
+    ),
+    NarwalSensorEntityDescription(
+        key="user_action_seconds_left",
+        translation_key="user_action_seconds_left",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        suggested_display_precision=0,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        # Mirrors `remaining_s` from binary_sensor.user_action_required
+        # so it can be graphed / used in automations directly. 0 when
+        # no action is required.
+        value_fn=lambda state: int(
+            max(state.user_action_target - state.user_action_elapsed, 0)
+            if state.user_action_type != 0 and state.user_action_target > 0
+            else 0
+        ),
     ),
     NarwalSensorEntityDescription(
         key="cleaning_time",
         translation_key="cleaning_time",
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.SECONDS,
+        suggested_display_precision=0,
         state_class=SensorStateClass.MEASUREMENT,
-        # working_status field 3 is session elapsed seconds.
-        # NEEDS LIVE VALIDATION: only populated during active cleaning.
-        value_fn=lambda state: state.cleaning_time
-        if state.cleaning_time > 0
-        else None,
+        # working_status.12, but only during active cleaning. The same
+        # field is reused as a station-cycle timer during drying.
+        value_fn=lambda state: int(state.cleaning_time),
+    ),
+    NarwalSensorEntityDescription(
+        key="cleaning_time_remaining",
+        translation_key="cleaning_time_remaining",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        suggested_display_precision=0,
+        state_class=SensorStateClass.MEASUREMENT,
+        # Approximation from elapsed cleaning time + completion %.
+        value_fn=_remaining_cleaning_seconds,
     ),
     NarwalSensorEntityDescription(
         key="firmware_version",
         translation_key="firmware_version",
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda state: state.firmware_version or None,
+    ),
+    NarwalSensorEntityDescription(
+        key="dust_bag_health",
+        translation_key="dust_bag_health",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        # robot_base_status field 35: dust bag remaining capacity as a
+        # float32 percentage. Field 41 stays at 100 on Flow 2.
+        value_fn=lambda state: round(state.dust_bag_health) if state.dust_bag_health else None,
+    ),
+    NarwalSensorEntityDescription(
+        key="error_code",
+        translation_key="error_code",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        # Numeric error code; 0 when no fault is active. Codes are
+        # packed as 0xCC SS RR XX (category, sub, reserved, specific).
+        value_fn=lambda state: state.error_code,
+    ),
+    NarwalSensorEntityDescription(
+        key="error_message",
+        translation_key="error_message",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        # English fault message for known codes; falls back to the robot's
+        # localized firmware text when the code is not mapped yet.
+        value_fn=lambda state: state.error_message or "",
+    ),
+    NarwalSensorEntityDescription(
+        key="current_room",
+        translation_key="current_room",
+        # Shows the active room name during room cleaning. Returns
+        # "unknown" when the room can't be resolved.
+        value_fn=lambda state: state.current_room_name or "unknown",
+    ),
+    NarwalSensorEntityDescription(
+        key="station_error_code",
+        translation_key="station_error_code",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        # Station/tank fault code from robot_base_status.25.*; 0 when clear.
+        value_fn=lambda state: state.station_error_code,
     ),
 )
 
@@ -81,6 +215,7 @@ async def async_setup_entry(
         NarwalSensor(coordinator, description) for description in SENSOR_DESCRIPTIONS
     ]
     entities.append(NarwalChargingStateSensor(coordinator))
+    entities.append(NarwalStationActivitySensor(coordinator))
     async_add_entities(entities)
 
 
@@ -106,6 +241,33 @@ class NarwalSensor(NarwalEntity, SensorEntity):
         state = self.coordinator.data
         if state is None:
             return None
+        if self.entity_description.key == "current_room":
+            if state.current_room_id > 0:
+                if state.map_data is not None:
+                    for room in state.map_data.rooms:
+                        if room.room_id == state.current_room_id:
+                            return room.display_name
+                return f"Room {state.current_room_id}"
+            if state.map_data is not None and state.map_display_data is not None:
+                grid = state.map_display_data.to_grid_coords(
+                    state.map_data.resolution,
+                    state.map_data.origin_x,
+                    state.map_data.origin_y,
+                )
+                if grid is not None:
+                    room_id, _room_desc = lookup_room_at_grid(
+                        state.map_data.compressed_map,
+                        state.map_data.width,
+                        state.map_data.height,
+                        grid[0],
+                        grid[1],
+                    )
+                    if room_id > 0:
+                        for room in state.map_data.rooms:
+                            if room.room_id == room_id:
+                                return room.display_name
+                        return f"Room {room_id}"
+            return "unknown"
         return self.entity_description.value_fn(state)
 
 
@@ -147,3 +309,61 @@ class NarwalChargingStateSensor(NarwalEntity, SensorEntity):
         if self.native_value == "not_charging":
             return "mdi:battery-off-outline"
         return "mdi:battery-unknown"
+
+
+class NarwalStationActivitySensor(NarwalEntity, SensorEntity):
+    """Reports what the dock station is currently doing.
+
+    Derived from the robot's working_status. Distinct from the vacuum's
+    own activity because the station can run mop wash/dry cycles while
+    the robot itself is parked on it.
+    """
+
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_translation_key = "station_activity"
+    _attr_options = [
+        "idle", "mop_washing", "mop_drying",
+        "dust_emptying", "dust_bag_drying", "dust_disinfection",
+    ]
+    _attr_icon = "mdi:dishwasher"
+
+    def __init__(self, coordinator: NarwalCoordinator) -> None:
+        super().__init__(coordinator)
+        device_id = coordinator.config_entry.data["device_id"]
+        self._attr_unique_id = f"{device_id}_station_activity"
+
+    @property
+    def native_value(self) -> str | None:
+        state = self.coordinator.data
+        if state is None:
+            return None
+        # Field 48 station markers can remain present while the robot has
+        # already left the dock. In that case the user-facing vacuum state
+        # should be cleaning/off-dock, not a stale station drying activity.
+        if state.is_cleaning or not state.is_docked:
+            return "idle"
+        # Mop wash takes priority — the robot is physically engaged
+        # with the basin so other activities can't really overlap.
+        if state.working_status == WorkingStatus.MOP_WASHING:
+            return "mop_washing"
+        # Trust the field 48 sub-key signals exclusively for dock-side
+        # activities. Earlier code used WorkingStatus 17 / 19 as a
+        # fallback for mop_drying, but capture showed the firmware sets
+        # working_status = 19 even during dust-bag drying — that
+        # mislabelled bag-drying cycles as mop_drying.
+        #
+        # Capture also showed multiple station markers can be present at
+        # once. Dust emptying is a short, audible dock action and should
+        # win while the robot is still docked. When disinfection is active,
+        # f48.10 can remain present as the queued next dust-bag-drying
+        # step, so disinfection must win over dust-bag drying. Otherwise
+        # prefer dust-bag drying over generic mop drying.
+        if state.station_dust_emptying:
+            return "dust_emptying"
+        if state.station_dust_disinfecting:
+            return "dust_disinfection"
+        if state.station_dust_bag_drying:
+            return "dust_bag_drying"
+        if state.station_mop_drying:
+            return "mop_drying"
+        return "idle"

--- a/custom_components/narwal/strings.json
+++ b/custom_components/narwal/strings.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "flow_title": "Narwal Vacuum ({host})",
     "step": {
       "user": {
         "title": "Connect to Narwal Vacuum",
@@ -29,8 +30,26 @@
       "cleaning_area": {
         "name": "Cleaning area"
       },
+      "cleaning_progress": {
+        "name": "Cleaning progress"
+      },
+      "mop_drying_progress": {
+        "name": "Mop drying progress"
+      },
+      "dust_bag_drying_progress": {
+        "name": "Dust bag drying progress"
+      },
+      "dust_disinfection_progress": {
+        "name": "Dust disinfection progress"
+      },
       "cleaning_time": {
         "name": "Cleaning time"
+      },
+      "cleaning_time_remaining": {
+        "name": "Estimated remaining cleaning time"
+      },
+      "current_room": {
+        "name": "Current room"
       },
       "firmware_version": {
         "name": "Firmware version"
@@ -42,6 +61,32 @@
           "fully_charged": "Fully Charged",
           "not_charging": "Not Charging"
         }
+      },
+      "dust_bag_health": {
+        "name": "Dust bag health"
+      },
+      "station_activity": {
+        "name": "Station activity",
+        "state": {
+          "idle": "Idle",
+          "mop_washing": "Mop washing",
+          "mop_drying": "Mop drying",
+          "dust_emptying": "Dust emptying",
+          "dust_bag_drying": "Dust bag drying",
+          "dust_disinfection": "Dust cabinet disinfection"
+        }
+      },
+      "error_code": {
+        "name": "Error code"
+      },
+      "error_message": {
+        "name": "Error message"
+      },
+      "station_error_code": {
+        "name": "Dirty water tank code"
+      },
+      "user_action_seconds_left": {
+        "name": "User action seconds left"
       }
     },
     "binary_sensor": {
@@ -54,6 +99,31 @@
       },
       "charging": {
         "name": "Charging"
+      },
+      "active_error": {
+        "name": "Active error"
+      },
+      "station_tank_error": {
+        "name": "Dirty water tank"
+      },
+      "clean_water_tank": {
+        "name": "Clean water tank"
+      },
+      "remote_control": {
+        "name": "Remote control"
+      },
+      "user_action_required": {
+        "name": "User action required"
+      }
+    },
+    "select": {
+      "mop_humidity": {
+        "name": "Mop humidity",
+        "state": {
+          "slightly_dry": "Slightly dry",
+          "standard": "Standard",
+          "slightly_wet": "Slightly wet"
+        }
       }
     }
   }

--- a/custom_components/narwal/translations/en.json
+++ b/custom_components/narwal/translations/en.json
@@ -1,12 +1,14 @@
 {
   "config": {
+    "flow_title": "Narwal Vacuum ({host})",
     "step": {
       "user": {
         "title": "Connect to Narwal Vacuum",
-        "description": "Enter the IP address of your Narwal robot vacuum.",
+        "description": "Enter the IP address of your Narwal robot vacuum and select your model.",
         "data": {
           "host": "IP Address",
-          "port": "Port"
+          "port": "Port",
+          "model": "Model"
         }
       }
     },
@@ -28,8 +30,26 @@
       "cleaning_area": {
         "name": "Cleaning area"
       },
+      "cleaning_progress": {
+        "name": "Cleaning progress"
+      },
+      "mop_drying_progress": {
+        "name": "Mop drying progress"
+      },
+      "dust_bag_drying_progress": {
+        "name": "Dust bag drying progress"
+      },
+      "dust_disinfection_progress": {
+        "name": "Dust disinfection progress"
+      },
       "cleaning_time": {
         "name": "Cleaning time"
+      },
+      "cleaning_time_remaining": {
+        "name": "Estimated remaining cleaning time"
+      },
+      "current_room": {
+        "name": "Current room"
       },
       "firmware_version": {
         "name": "Firmware version"
@@ -41,6 +61,32 @@
           "fully_charged": "Fully Charged",
           "not_charging": "Not Charging"
         }
+      },
+      "dust_bag_health": {
+        "name": "Dust bag health"
+      },
+      "station_activity": {
+        "name": "Station activity",
+        "state": {
+          "idle": "Idle",
+          "mop_washing": "Mop washing",
+          "mop_drying": "Mop drying",
+          "dust_emptying": "Dust emptying",
+          "dust_bag_drying": "Dust bag drying",
+          "dust_disinfection": "Dust cabinet disinfection"
+        }
+      },
+      "error_code": {
+        "name": "Error code"
+      },
+      "error_message": {
+        "name": "Error message"
+      },
+      "station_error_code": {
+        "name": "Dirty water tank code"
+      },
+      "user_action_seconds_left": {
+        "name": "User action seconds left"
       }
     },
     "binary_sensor": {
@@ -49,6 +95,34 @@
         "state": {
           "on": "Docked",
           "off": "Undocked"
+        }
+      },
+      "charging": {
+        "name": "Charging"
+      },
+      "active_error": {
+        "name": "Active error"
+      },
+      "station_tank_error": {
+        "name": "Dirty water tank"
+      },
+      "clean_water_tank": {
+        "name": "Clean water tank"
+      },
+      "remote_control": {
+        "name": "Remote control"
+      },
+      "user_action_required": {
+        "name": "User action required"
+      }
+    },
+    "select": {
+      "mop_humidity": {
+        "name": "Mop humidity",
+        "state": {
+          "slightly_dry": "Slightly dry",
+          "standard": "Standard",
+          "slightly_wet": "Slightly wet"
         }
       }
     }

--- a/custom_components/narwal/translations/fr.json
+++ b/custom_components/narwal/translations/fr.json
@@ -31,6 +31,9 @@
       "cleaning_time": {
         "name": "Temps de nettoyage"
       },
+      "cleaning_time_remaining": {
+        "name": "Temps de nettoyage restant estimé"
+      },
       "firmware_version": {
         "name": "Version du firmware"
       },

--- a/custom_components/narwal/vacuum.py
+++ b/custom_components/narwal/vacuum.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import logging
+from pathlib import Path
 
 from typing import Any
 
@@ -23,10 +25,13 @@ from .narwal_client import CommandResult, FanLevel, NarwalCommandError, WorkingS
 
 from . import NarwalConfigEntry
 from .const import FAN_SPEED_LIST, FAN_SPEED_MAP
+
 from .coordinator import NarwalCoordinator
 from .entity import NarwalEntity
 
 _LOGGER = logging.getLogger(__name__)
+_AREA_REGISTRY_PATH = Path("/config/.storage/core.area_registry")
+_ENTITY_REGISTRY_PATH = Path("/config/.storage/core.entity_registry")
 
 WORKING_STATUS_TO_ACTIVITY: dict[WorkingStatus, VacuumActivity] = {
     WorkingStatus.DOCKED: VacuumActivity.DOCKED,
@@ -60,8 +65,14 @@ class NarwalVacuum(NarwalEntity, StateVacuumEntity):
         | VacuumEntityFeature.RETURN_HOME
         | VacuumEntityFeature.FAN_SPEED
         | VacuumEntityFeature.LOCATE
+        | VacuumEntityFeature.SEND_COMMAND
     ) | (VacuumEntityFeature.CLEAN_AREA if Segment is not None else VacuumEntityFeature(0))
     _attr_fan_speed_list = FAN_SPEED_LIST
+
+    @property
+    def supported_features(self) -> VacuumEntityFeature:
+        """Return supported features for this specific Narwal model."""
+        return self._attr_supported_features
 
     def __init__(self, coordinator: NarwalCoordinator) -> None:
         """Initialize the vacuum entity."""
@@ -99,10 +110,20 @@ class NarwalVacuum(NarwalEntity, StateVacuumEntity):
     def fan_speed(self) -> str | None:
         """Return the current fan speed.
 
-        The robot protocol does not broadcast the active fan speed setting,
-        so we track the last value set via the integration. Returns None
-        until the user sets a fan speed for the first time.
+        Flow 2 broadcasts the live suction level in robot_base_status
+        field 26 as 1=Quiet, 2=Normal, 3=Strong, 4=Super Powerful.
+        If the robot broadcasts a non-zero value, show it directly;
+        otherwise fall back to the last user-set value.
         """
+        state = self.coordinator.data
+        flow2_levels = {
+            1: "Quiet",
+            2: "Normal",
+            3: "Strong",
+            4: "Super Powerful",
+        }
+        if state is not None and state.fan_level_raw in flow2_levels:
+            return flow2_levels[state.fan_level_raw]
         return self._last_fan_speed
 
     # Timeout for action commands (start/stop/return) — robot may need
@@ -171,6 +192,33 @@ class NarwalVacuum(NarwalEntity, StateVacuumEntity):
         """Locate the vacuum — robot says 'Robot is here'."""
         await self._ensure_awake()
         await self.coordinator.client.locate()
+
+    async def async_send_command(
+        self,
+        command: str,
+        params: dict | list | None = None,
+        **kwargs,
+    ) -> None:
+        """Handle vacuum.send_command service calls.
+
+        Supported commands:
+          - "freo_mind" / "freo_mind_start": start a Freo Mind (AI auto)
+            whole-house clean. Flow 2 only.
+        """
+        if command in ("freo_mind", "freo_mind_start"):
+            await self._ensure_awake()
+            resp = await self.coordinator.client.start_freo_mind()
+            _LOGGER.info(
+                "Freo Mind start: code=%s, success=%s",
+                resp.result_code, resp.success,
+            )
+            if not resp.success:
+                _LOGGER.warning(
+                    "Freo Mind start did not succeed (code=%s)",
+                    resp.result_code,
+                )
+            return
+        _LOGGER.warning("Unknown vacuum command: %s", command)
 
     async def async_set_fan_speed(self, fan_speed: str, **kwargs) -> None:
         """Set the fan speed."""
@@ -241,8 +289,63 @@ class NarwalVacuum(NarwalEntity, StateVacuumEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        self._sync_room_area_mapping()
         self._check_segment_changes()
         super()._handle_coordinator_update()
+
+    def _sync_room_area_mapping(self) -> None:
+        """Cache HA area names for each segment id.
+
+        Home Assistant stores the room->area assignment in the vacuum
+        entity registry options as `vacuum.area_mapping`. The mapping is
+        keyed by area slug, so resolve the slug to the human-readable area
+        name from the area registry and cache the final segment-id mapping
+        on the coordinator.
+        """
+        try:
+            area_mtime = _AREA_REGISTRY_PATH.stat().st_mtime_ns
+            entity_mtime = _ENTITY_REGISTRY_PATH.stat().st_mtime_ns
+        except OSError:
+            return
+        cache_key = (area_mtime, entity_mtime)
+        if getattr(self.coordinator, "_room_mapping_cache_key", None) == cache_key:
+            return
+        try:
+            area_data = json.loads(_AREA_REGISTRY_PATH.read_text())
+            entity_data = json.loads(_ENTITY_REGISTRY_PATH.read_text())
+            area_names = {
+                area.get("id"): area.get("name")
+                for area in area_data.get("data", {}).get("areas", [])
+                if isinstance(area, dict)
+            }
+            device_id = self.coordinator.config_entry.data.get("device_id")
+            vacuum_entry = next(
+                (
+                    entry
+                    for entry in entity_data.get("data", {}).get("entities", [])
+                    if isinstance(entry, dict)
+                    and entry.get("platform") == "narwal"
+                    and entry.get("device_id") == device_id
+                    and str(entry.get("entity_id", "")).startswith("vacuum.")
+                ),
+                None,
+            )
+            area_mapping = {}
+            if vacuum_entry:
+                area_map = vacuum_entry.get("options", {}).get("vacuum", {}).get("area_mapping", {})
+                if isinstance(area_map, dict):
+                    for area_slug, segment_ids in area_map.items():
+                        area_name = area_names.get(area_slug)
+                        if not area_name:
+                            continue
+                        if isinstance(segment_ids, list):
+                            for segment_id in segment_ids:
+                                area_mapping[str(segment_id)] = area_name
+            self.coordinator.room_area_mapping = area_mapping
+            self.coordinator._room_mapping_cache_key = cache_key
+            _LOGGER.debug("Synced room area mapping: %s", area_mapping)
+        except Exception:
+            _LOGGER.debug("Failed to sync room->area mapping", exc_info=True)
 
     def _check_segment_changes(self) -> None:
         """Detect segment changes and raise repair issue if needed.

--- a/narwal_client/__init__.py
+++ b/narwal_client/__init__.py
@@ -1,7 +1,7 @@
 """Narwal robot vacuum client library — local WebSocket API."""
 
 from .client import NarwalClient, NarwalCommandError, NarwalConnectionError
-from .const import CommandResult, FanLevel, MopHumidity, WorkingStatus
+from .const import ERROR_CODES, CommandResult, FanLevel, MopHumidity, WorkingStatus
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState, RoomInfo
 from .protocol import build_frame, parse_frame
 
@@ -13,6 +13,7 @@ __all__ = [
     "CommandResponse",
     "CommandResult",
     "DeviceInfo",
+    "ERROR_CODES",
     "FanLevel",
     "MapData",
     "MapDisplayData",

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -408,6 +408,10 @@ class NarwalClient:
             _LOGGER.debug("Failed to decode protobuf for topic %s", short_topic)
             return
 
+        # Log every decoded broadcast at DEBUG so tools/narwal_capture.py
+        # (and ad-hoc protocol RE) can pick them out of `ha core logs`.
+        # Cheap when DEBUG isn't enabled — _LOGGER.debug short-circuits.
+        _LOGGER.debug("DUMP %s: %r", short_topic, decoded)
         if short_topic == "status/working_status":
             self.state.update_from_working_status(decoded)
         elif short_topic == "status/robot_base_status":
@@ -425,6 +429,15 @@ class NarwalClient:
                 self.state.map_display_data.robot_y,
                 self.state.map_display_data.timestamp,
             )
+        elif short_topic == "status/point_navi_plan_traj":
+            self.state.update_from_plan_traj(decoded)
+        elif short_topic == "report/clean_report":
+            # Empty-payload event marker: the robot finished a cycle.
+            # Reset session-scoped state and log; the coordinator picks
+            # this up via the on_state_update callback and triggers a
+            # fresh map fetch.
+            self.state.last_clean_report_ts = time.time()
+            _LOGGER.info("clean_report received — clean cycle complete")
         if self.on_state_update:
             self.on_state_update(self.state)
 
@@ -862,6 +875,10 @@ class NarwalClient:
                 self.state.update_from_download_status(decoded)
             elif short_topic == "map/display_map":
                 self.state.map_display_data = MapDisplayData.from_broadcast(decoded)
+            elif short_topic == "status/point_navi_plan_traj":
+                self.state.update_from_plan_traj(decoded)
+            elif short_topic == "report/clean_report":
+                self.state.last_clean_report_ts = time.time()
 
         raise NarwalCommandError(
             f"No field5 response within {timeout}s"
@@ -914,6 +931,64 @@ class NarwalClient:
             timeout=10.0,
         )
 
+    async def start_freo_mind(self, **kwargs) -> CommandResponse:
+        """Start a Freo Mind (AI auto) whole-house clean.
+
+        Flow 2 only. Reverse-engineered from a live capture of an
+        app-initiated Freo Mind clean (firmware v01.07.19.00):
+
+            {1: {2: {}, 5: {1: {1: 4, 2: 2, 3: 1}, 7: {1: {}}}}}
+
+          field 5.1.1 = mode (4 = Vacuum and mop)
+          field 5.1.2 = mop humidity (2 = Standard)
+          field 5.1.3 = "Freo Mind / AI auto" marker (1)
+          field 5.7   = secondary marker also present in Freo Mind cleans
+        """
+        import blackboxprotobuf
+
+        msg = {
+            "1": {
+                "2": {},
+                "5": {
+                    "1": {"1": 4, "2": 2, "3": 1},
+                    "7": {"1": {}},
+                },
+            }
+        }
+        typedef = {
+            "1": {
+                "type": "message",
+                "message_typedef": {
+                    "2": {"type": "message", "message_typedef": {}},
+                    "5": {
+                        "type": "message",
+                        "message_typedef": {
+                            "1": {
+                                "type": "message",
+                                "message_typedef": {
+                                    "1": {"type": "int"},
+                                    "2": {"type": "int"},
+                                    "3": {"type": "int"},
+                                },
+                            },
+                            "7": {
+                                "type": "message",
+                                "message_typedef": {
+                                    "1": {"type": "message", "message_typedef": {}},
+                                },
+                            },
+                        },
+                    },
+                },
+            }
+        }
+        payload = blackboxprotobuf.encode_message(msg, typedef)
+        return await self.send_command(
+            TOPIC_CMD_START_CLEAN,
+            payload=payload,
+            timeout=10.0,
+        )
+
     def _build_room_clean_payload(self, room_ids: list[int]) -> bytes:
         """Build CleanTask protobuf with per-room clean params in field 1.2.
 
@@ -936,66 +1011,44 @@ class NarwalClient:
         if not room_ids:
             return self._DEFAULT_CLEAN_PAYLOAD
 
-        import blackboxprotobuf
+        def enc_varint(v: int) -> bytes:
+            out = bytearray()
+            n = int(v)
+            while True:
+                b = n & 0x7F
+                n >>= 7
+                if n:
+                    out.append(b | 0x80)
+                else:
+                    out.append(b)
+                    return bytes(out)
 
-        # Build per-room entries with default clean settings
-        room_entries = []
-        for rid in room_ids:
-            room_entries.append({
-                "1": rid,       # roomId
-                "2": 2,         # cleanMode = sweep+mop
-                "3": 1,         # cleanTimes = 1 pass
-                "6": 3,         # sweepMode = max suction
-                "7": 2,         # mopMode = wet
-            })
+        def enc_field(field_no: int, wire_type: int, value: bytes | int) -> bytes:
+            tag = enc_varint((field_no << 3) | wire_type)
+            if wire_type == 0:
+                return tag + enc_varint(int(value))
+            if wire_type == 2:
+                data = value if isinstance(value, bytes) else enc_varint(int(value))
+                return tag + enc_varint(len(data)) + data
+            raise ValueError(f"unsupported wire type: {wire_type}")
 
-        room_typedef = {
-            "type": "message",
-            "seen_repeated": True,
-            "message_typedef": {
-                "1": {"type": "uint"},
-                "2": {"type": "int"},
-                "3": {"type": "int"},
-                "6": {"type": "int"},
-                "7": {"type": "int"},
-            }
-        }
+        def enc_room_entry(room_id: int) -> bytes:
+            return b"".join([
+                enc_field(1, 0, room_id),
+                enc_field(2, 0, 2),
+                enc_field(3, 0, 1),
+                enc_field(6, 0, 3),
+                enc_field(7, 0, 2),
+            ])
 
-        # Single room: field 1.2 is a message; multiple: repeated message
-        field_2_value = room_entries[0] if len(room_entries) == 1 else room_entries
-
-        msg = {
-            "1": {
-                "2": field_2_value,
-                "5": {
-                    "1": {"1": 3, "2": 2, "3": 1},
-                    "5": {}
-                }
-            }
-        }
-        typedef = {
-            "1": {
-                "type": "message",
-                "message_typedef": {
-                    "2": room_typedef,
-                    "5": {
-                        "type": "message",
-                        "message_typedef": {
-                            "1": {
-                                "type": "message",
-                                "message_typedef": {
-                                    "1": {"type": "int"},
-                                    "2": {"type": "int"},
-                                    "3": {"type": "int"}
-                                }
-                            },
-                            "5": {"type": "message", "message_typedef": {}}
-                        }
-                    }
-                }
-            }
-        }
-        return blackboxprotobuf.encode_message(msg, typedef)
+        room_entries = b"".join(enc_field(2, 2, enc_room_entry(rid)) for rid in room_ids)
+        settings = enc_field(1, 2, b"".join([
+            enc_field(1, 0, 3),
+            enc_field(2, 0, 2),
+            enc_field(3, 0, 1),
+        ])) + enc_field(5, 2, b"")
+        clean_task = enc_field(1, 2, room_entries + enc_field(5, 2, settings))
+        return clean_task
 
     async def start_rooms(self, room_ids: list[int]) -> CommandResponse:
         """Start room-specific cleaning.
@@ -1051,7 +1104,7 @@ class NarwalClient:
         """Set suction fan speed.
 
         Args:
-            level: FanLevel enum or int (0=quiet, 1=normal, 2=strong, 3=max).
+            level: FanLevel enum or int (1=quiet, 2=normal, 3=strong, 4=Super Powerful).
         """
         payload = b"\x08" + bytes([int(level) & 0x7F])
         return await self.send_command(TOPIC_CMD_SET_FAN_LEVEL, payload)
@@ -1144,7 +1197,8 @@ class NarwalClient:
     async def get_map(self) -> MapData:
         """Download the full map data."""
         resp = await self.send_command(TOPIC_CMD_GET_MAP, timeout=15.0)
-        map_data = MapData.from_response(resp.data)
+        product_key = self.state.device_info.product_key if self.state.device_info else None
+        map_data = MapData.from_response(resp.data, product_key=product_key)
         self.state.map_data = map_data
         return map_data
 

--- a/narwal_client/const.py
+++ b/narwal_client/const.py
@@ -23,6 +23,7 @@ DEFAULT_TOPIC_PREFIX = "/QoEsI5qYXO"
 KNOWN_PRODUCT_KEYS = [
     # Confirmed working (local WebSocket)
     "QoEsI5qYXO",  # AX12 — Narwal Flow (primary, confirmed)
+    "QxMSPG6VSO",  # — Narwal Flow 2 (confirmed via live capture)
     "DrzDKQ0MU8",   # CX4  — Freo Z10 Ultra (confirmed by @irekkl-maker)
     # Confirmed cloud-only (port 9002 open but no local broadcasts)
     "BYWBPqSxeC",   # CX7  — Freo Z Ultra (cloud-only, confirmed by @gabrielozcomidi)
@@ -58,6 +59,13 @@ TOPIC_DOWNLOAD_STATUS = "status/download_status"
 TOPIC_DISPLAY_MAP = "map/display_map"
 TOPIC_TIMELINE_STATUS = "status/time_line_status"
 TOPIC_PLANNING_DEBUG = "developer/planning_debug_info"
+# Forward path the robot is about to drive — list of {1: x, 2: y} float32
+# coordinates encoded as fixed32 ints. Confirmed via local capture.
+TOPIC_POINT_NAVI_PLAN_TRAJ = "status/point_navi_plan_traj"
+# Event-only broadcast: fires once at end of a clean cycle with an empty
+# payload. Used as a trigger to refresh the map snapshot and reset
+# session-scoped state. Confirmed via local capture.
+TOPIC_CLEAN_REPORT = "report/clean_report"
 
 # --- Command topics (client → robot, confirmed working) ---
 # Common
@@ -164,10 +172,14 @@ class WorkingStatus(IntEnum):
 
     UNKNOWN = 0
     STANDBY = 1       # idle / transition state
+    MOP_WASHING = 3   # robot is washing the mop on the station (Flow 2, observed live)
     CLEANING = 4      # active cleaning (stays 4 even while returning to dock)
+    MAPPING = 7       # building / saving a new map (Flow 2 — accompanied by 3.9=1)
     CLEANING_ALT = 5  # cleaning — observed when robot was physically stuck; may indicate error/stuck state
     DOCKED = 10       # on dock (does NOT reliably indicate charging vs charged)
     CHARGED = 14      # on dock (reported before 100% — use battery_level for charge state)
+    MOP_DRYING = 17   # mop drying — observed transitioning into the cycle on Flow 2
+    MOP_DRYING_ACTIVE = 19  # mop drying — main active phase (sub-field 18 counts steps)
     # PLACEHOLDER: error state value not yet observed live.
     # Trigger a real error (e.g., pick up robot mid-clean) to discover the value.
     ERROR = 99
@@ -176,10 +188,10 @@ class WorkingStatus(IntEnum):
 class FanLevel(IntEnum):
     """Suction fan speed levels (SweepMode from APK)."""
 
-    QUIET = 0
-    NORMAL = 1
-    STRONG = 2
-    MAX = 3
+    QUIET = 1
+    NORMAL = 2
+    STRONG = 3
+    MAX = 4
 
 
 class MopHumidity(IntEnum):
@@ -188,6 +200,17 @@ class MopHumidity(IntEnum):
     DRY = 0
     NORMAL = 1
     WET = 2
+
+
+# Known error codes (Flow 2). Codes are packed as 0xCC SS RR XX
+# (category, sub-category, reserved, specific) and stable across
+# firmware updates. Map each one to a snake_case identifier so
+# automations don't need to depend on the localized message.
+ERROR_CODES: dict[int, str] = {
+    0x01010036: "clean_water_dirty_tank_anomaly",  # 16842806 — dirty water tank issue during mop wash
+    0x01010137: "clean_water_tank_empty",          # 16842807 — clean water tank empty / not installed
+    0x02310031: "robot_lifted",                     # 36765745 — robot picked up / suspended
+}
 
 
 # robot_base_status field numbers

--- a/narwal_client/map_renderer.py
+++ b/narwal_client/map_renderer.py
@@ -384,24 +384,41 @@ def render_map_png(
                 room_sum_y[room_id] = room_sum_y.get(room_id, 0) + y
                 room_count[room_id] = room_count.get(room_id, 0) + 1
 
-    # Flip vertically BEFORE drawing overlays — pixel data is stored with
-    # Y increasing upward (math coordinates) but images render Y downward.
-    # Overlays (labels, dock, robot) use flipped coordinates so text is right-side up.
+    # Flip vertically BEFORE upscaling/overlays — pixel data is stored
+    # with Y increasing upward (math coordinates) but images render Y
+    # downward. Overlays (labels, dock, robot) use flipped coordinates
+    # so text is right-side up.
     img = img.transpose(Image.FLIP_TOP_BOTTOM)
 
-    draw = ImageDraw.Draw(img)
+    # Upscale the room grid with NEAREST so the colored blocks stay
+    # crisp instead of getting browser-bilinear-blurred. Aim for ~720 px
+    # on the long edge — large enough to look smooth in the HA UI
+    # without bloating the PNG. Overlays are then drawn at the upscaled
+    # resolution so dock / robot / labels look smooth.
+    scale = max(1, min(720 // max(width, height), 12))
+    if scale > 1:
+        img = img.resize((width * scale, height * scale), Image.NEAREST)
 
-    # Draw room labels at flipped centroids
+    draw = ImageDraw.Draw(img)
+    sw = width * scale
+    sh = height * scale
+
+    # Draw room labels at flipped centroids (scaled).
     if room_names:
+        font_size = max(11, 6 * scale)
         try:
-            font = ImageFont.truetype("arial.ttf", 10)
+            font = ImageFont.truetype("arial.ttf", font_size)
         except (IOError, OSError):
-            font = ImageFont.load_default()
+            try:
+                # macOS / Linux fallback fonts
+                font = ImageFont.truetype("DejaVuSans.ttf", font_size)
+            except (IOError, OSError):
+                font = ImageFont.load_default()
         for rid, name in room_names.items():
             if not name or rid not in room_count:
                 continue
-            cx = room_sum_x[rid] // room_count[rid]
-            cy = height - 1 - (room_sum_y[rid] // room_count[rid])
+            cx = (room_sum_x[rid] // room_count[rid]) * scale + scale // 2
+            cy = (height - 1 - (room_sum_y[rid] // room_count[rid])) * scale + scale // 2
             bbox = font.getbbox(name)
             tw = bbox[2] - bbox[0]
             th = bbox[3] - bbox[1]
@@ -412,18 +429,22 @@ def render_map_png(
                 draw.text((tx + ox, ty + oy), name, fill=(0, 0, 0), font=font)
             draw.text((tx, ty), name, fill=(255, 255, 255), font=font)
 
-    # Draw dock position (before robot so robot draws on top)
-    # Flip dock Y to match the flipped image
+    # Draw dock position (before robot so robot draws on top), scaled.
     if dock_x is not None and dock_y is not None:
-        dock_size = max(4, min(width, height) // 60)
-        _draw_dock(draw, int(dock_x), height - 1 - int(dock_y), dock_size)
+        dock_size = max(6, min(sw, sh) // 50)
+        _draw_dock(
+            draw,
+            int(dock_x) * scale + scale // 2,
+            (height - 1 - int(dock_y)) * scale + scale // 2,
+            dock_size,
+        )
 
-    # Draw robot position (flip Y) — skip if out of bounds
+    # Draw robot position (flip Y, scaled) — skip if out of bounds.
     if robot_x is not None and robot_y is not None:
-        rx = int(robot_x)
-        ry = height - 1 - int(robot_y)
-        if 0 <= rx < width and 0 <= ry < height:
-            radius = max(3, min(width, height) // 80)
+        rx = int(robot_x) * scale + scale // 2
+        ry = (height - 1 - int(robot_y)) * scale + scale // 2
+        if 0 <= rx < sw and 0 <= ry < sh:
+            radius = max(5, min(sw, sh) // 60)
             _draw_robot(draw, rx, ry, robot_heading, radius)
 
     buf = io.BytesIO()
@@ -507,18 +528,32 @@ def render_base_map(
                 room_count[room_id] = room_count.get(room_id, 0) + 1
 
     img = img.transpose(Image.FLIP_TOP_BOTTOM)
+
+    # Upscale with NEAREST so the colored room blocks stay crisp.
+    # render_overlay() reads scale via img.info["narwal_scale"] and
+    # transforms grid coords accordingly.
+    scale = max(1, min(720 // max(width, height), 12))
+    if scale > 1:
+        img = img.resize((width * scale, height * scale), Image.NEAREST)
+    img.info["narwal_scale"] = scale
+
     draw = ImageDraw.Draw(img)
+    sw, sh = width * scale, height * scale
 
     if room_names:
+        font_size = max(11, 6 * scale)
         try:
-            font = ImageFont.truetype("arial.ttf", 10)
+            font = ImageFont.truetype("arial.ttf", font_size)
         except (IOError, OSError):
-            font = ImageFont.load_default()
+            try:
+                font = ImageFont.truetype("DejaVuSans.ttf", font_size)
+            except (IOError, OSError):
+                font = ImageFont.load_default()
         for rid, name in room_names.items():
             if not name or rid not in room_count:
                 continue
-            cx = room_sum_x[rid] // room_count[rid]
-            cy = height - 1 - (room_sum_y[rid] // room_count[rid])
+            cx = (room_sum_x[rid] // room_count[rid]) * scale + scale // 2
+            cy = (height - 1 - (room_sum_y[rid] // room_count[rid])) * scale + scale // 2
             bbox = font.getbbox(name)
             tw = bbox[2] - bbox[0]
             th = bbox[3] - bbox[1]
@@ -528,41 +563,48 @@ def render_base_map(
                 draw.text((tx + ox, ty + oy), name, fill=(0, 0, 0), font=font)
             draw.text((tx, ty), name, fill=(255, 255, 255), font=font)
 
-    # Draw obstacle/furniture annotations (static data from get_map field 2.32)
+    # Draw obstacle / furniture annotations (static data from get_map
+    # field 2.32). Coordinates are in grid units, scaled to pixels.
     if obstacles:
+        obs_font_size = max(9, 5 * scale)
         try:
-            obs_font = ImageFont.truetype("arial.ttf", 8)
+            obs_font = ImageFont.truetype("arial.ttf", obs_font_size)
         except (IOError, OSError):
-            obs_font = ImageFont.load_default()
+            try:
+                obs_font = ImageFont.truetype("DejaVuSans.ttf", obs_font_size)
+            except (IOError, OSError):
+                obs_font = ImageFont.load_default()
         for obs in obstacles:
             gx, gy = obs.to_grid_coords(origin_x, origin_y)
-            # Skip out-of-bounds obstacles
             if gx < 0 or gx >= width or gy < 0 or gy >= height:
                 continue
-            img_x = int(gx)
-            img_y = height - 1 - int(gy)
-            half_w = max(1, int(obs.width / 2))
-            half_h = max(1, int(obs.height / 2))
+            img_x = int(gx) * scale + scale // 2
+            img_y = (height - 1 - int(gy)) * scale + scale // 2
+            half_w = max(scale, int(obs.width / 2 * scale))
+            half_h = max(scale, int(obs.height / 2 * scale))
             color = OBSTACLE_COLORS.get(obs.type_id, OBSTACLE_COLOR_DEFAULT)
             draw.rectangle(
                 [img_x - half_w, img_y - half_h, img_x + half_w, img_y + half_h],
-                outline=color, width=1,
+                outline=color, width=max(1, scale // 4),
             )
-            # Draw label centered above the rectangle
             label = obs.display_name
             bbox = obs_font.getbbox(label)
             tw = bbox[2] - bbox[0]
             th = bbox[3] - bbox[1]
             lx = img_x - tw // 2
             ly = img_y - half_h - th - 2
-            # Dark outline for readability
             for ox, oy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
                 draw.text((lx + ox, ly + oy), label, fill=(0, 0, 0), font=obs_font)
             draw.text((lx, ly), label, fill=color, font=obs_font)
 
     if dock_x is not None and dock_y is not None:
-        dock_size = max(4, min(width, height) // 60)
-        _draw_dock(draw, int(dock_x), height - 1 - int(dock_y), dock_size)
+        dock_size = max(6, min(sw, sh) // 50)
+        _draw_dock(
+            draw,
+            int(dock_x) * scale + scale // 2,
+            (height - 1 - int(dock_y)) * scale + scale // 2,
+            dock_size,
+        )
 
     return img
 
@@ -591,27 +633,36 @@ def render_overlay(
     from PIL import ImageDraw
 
     img = base_img.copy()
+    img.info["narwal_scale"] = base_img.info.get("narwal_scale", 1)
     draw = ImageDraw.Draw(img)
-    width = img.width
+    scale = img.info["narwal_scale"]
+    sw, sh = img.width, img.height
+
+    def gx(x: float) -> int:
+        return int(x) * scale + scale // 2
+
+    def gy(y: float) -> int:
+        return (height - 1 - int(y)) * scale + scale // 2
 
     # Draw trail (blue path showing where robot has cleaned)
     if trail and len(trail) >= 2:
         recent_start = max(len(trail) - 200, 0)
+        line_w = max(2, scale // 2)
         for i in range(len(trail) - 1):
             if i >= recent_start:
                 color = (30, 120, 255)  # bright blue for recent
             else:
                 color = (15, 60, 130)  # dim blue for older
-            x1, y1 = int(trail[i][0]), height - 1 - int(trail[i][1])
-            x2, y2 = int(trail[i + 1][0]), height - 1 - int(trail[i + 1][1])
-            draw.line([(x1, y1), (x2, y2)], fill=color, width=2)
+            x1, y1 = gx(trail[i][0]), gy(trail[i][1])
+            x2, y2 = gx(trail[i + 1][0]), gy(trail[i + 1][1])
+            draw.line([(x1, y1), (x2, y2)], fill=color, width=line_w)
 
     # Draw robot
     if robot_x is not None and robot_y is not None:
-        rx = int(robot_x)
-        ry = height - 1 - int(robot_y)
-        if 0 <= rx < width and 0 <= ry < height:
-            radius = max(3, min(width, height) // 80)
+        rx = gx(robot_x)
+        ry = gy(robot_y)
+        if 0 <= rx < sw and 0 <= ry < sh:
+            radius = max(5, min(sw, sh) // 60)
             _draw_robot(draw, rx, ry, robot_heading, radius)
 
     buf = io.BytesIO()

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -18,17 +18,67 @@ class DeviceInfo:
     firmware_version: str = ""
 
 
+# ROOM_TYPE enum → display name (Flow 1 / AX12, from APK libapp.so strings).
+_FLOW1_ROOM_TYPE_NAMES: dict[int, str] = {
+    0: "Room",
+    1: "Primary Bedroom",
+    2: "Secondary Bedroom",
+    3: "Living Room",
+    4: "Kitchen",
+    5: "Study",
+    6: "Bathroom",
+    7: "Dining Room",
+    8: "Corridor",
+    9: "Balcony",
+    10: "Utility Room",
+    11: "Cloak Room",
+    12: "Nursery",
+    13: "Recreation Room",
+    14: "Shower Room",
+    15: "Other",
+}
+
+# Flow 2 reorders the ROOM_TYPE enum vs Flow 1. Confirmed via live capture
+# (firmware v01.07.19.00, product_key QxMSPG6VSO) by walking every type in
+# the Narwal app's room-type picker. Only deltas are listed; sub_types not
+# present here use the Flow 1 name.
+_FLOW2_ROOM_TYPE_OVERRIDES: dict[int, str] = {
+    1: "Master Bedroom",
+    5: "Bathroom",
+    6: "Toilet",
+    7: "Balcony",
+    8: "Dining Room",
+    9: "Cloakroom",
+    10: "Corridor",
+    11: "Study",
+    14: "Storage Room",
+}
+
+# product_keys that use the Flow 2 mapping. Add more as community confirms.
+_FLOW2_PRODUCT_KEYS: frozenset[str] = frozenset({"QxMSPG6VSO"})
+
+
+def get_room_type_names(product_key: str | None) -> dict[int, str]:
+    """Return the ROOM_TYPE → display-name mapping for a given device.
+
+    Flow 2 (and possibly other newer models) renamed/reordered the ROOM_TYPE
+    enum. We pick the right base mapping from product_key and fall back to
+    Flow 1 for unknown devices.
+    """
+    base = dict(_FLOW1_ROOM_TYPE_NAMES)
+    if product_key and product_key in _FLOW2_PRODUCT_KEYS:
+        base.update(_FLOW2_ROOM_TYPE_OVERRIDES)
+    return base
+
+
 @dataclass
 class RoomInfo:
     """A room on the map.
 
     Fields from get_map / get_editable_map field 2.12:
       field 1: room_id (matches pixel value >> 8 in map grid)
-      field 2: room_sub_type — ROOM_TYPE enum from APK (0=unspecified,
-               1=main bedroom, 2=secondary room, 3=living room, 4=kitchen,
-               5=study, 6=bathroom, 7=dining room, 8=corridor, 9=balcony,
-               10=utility room, 11=cloak room, 12=nursery, 13=recreation,
-               14=shower room, 15=other)
+      field 2: room_sub_type — ROOM_TYPE enum from APK. The string mapping
+               differs between Flow 1 and Flow 2 (see get_room_type_names).
       field 3: user-assigned name (UTF-8, empty if not named by user)
       field 4: category (1=room, 2=utility/small space)
       field 8: instance_index (1-based, for numbering duplicates: Bathroom 1, 2, 3...)
@@ -40,29 +90,13 @@ class RoomInfo:
     category: int = 0  # 1=room, 2=utility (field 4)
     instance_index: int = 0  # numbering for duplicates (field 8)
 
-    # ROOM_TYPE enum → default display name (from APK libapp.so string analysis)
+    # ROOM_TYPE enum → default display name. Set by MapData.from_response
+    # based on the connected device's product_key; defaults to Flow 1 names.
     ROOM_TYPE_NAMES: dict[int, str] = field(default=None, repr=False)
 
     def __post_init__(self):
         if self.ROOM_TYPE_NAMES is None:
-            object.__setattr__(self, "ROOM_TYPE_NAMES", {
-                0: "Room",
-                1: "Primary Bedroom",
-                2: "Secondary Bedroom",
-                3: "Living Room",
-                4: "Kitchen",
-                5: "Study",
-                6: "Bathroom",
-                7: "Dining Room",
-                8: "Corridor",
-                9: "Balcony",
-                10: "Utility Room",
-                11: "Cloak Room",
-                12: "Nursery",
-                13: "Recreation Room",
-                14: "Shower Room",
-                15: "Other",
-            })
+            object.__setattr__(self, "ROOM_TYPE_NAMES", dict(_FLOW1_ROOM_TYPE_NAMES))
 
     @property
     def display_name(self) -> str:
@@ -238,11 +272,21 @@ class MapData:
     raw: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def from_response(cls, decoded: dict[str, Any]) -> MapData:
-        """Parse map data from a get_map field5 response."""
+    def from_response(
+        cls, decoded: dict[str, Any], product_key: str | None = None,
+    ) -> MapData:
+        """Parse map data from a get_map field5 response.
+
+        Args:
+            decoded: bbp-decoded map response payload.
+            product_key: Connected device's product_key. Selects the
+                ROOM_TYPE → display-name mapping (Flow 1 vs Flow 2).
+        """
         payload = decoded.get("2", {})
         if not payload:
             return cls()
+
+        type_names = get_room_type_names(product_key)
 
         rooms = []
         room_list = payload.get("12", [])
@@ -266,6 +310,7 @@ class MapData:
                     room_sub_type=int(room.get("2", 0)),
                     category=int(room.get("4", 0)),
                     instance_index=int(room.get("8", 0)),
+                    ROOM_TYPE_NAMES=type_names,
                 ))
 
         compressed = payload.get("17", b"")
@@ -471,6 +516,59 @@ class NarwalState:
     firmware_version: str = ""
     firmware_target: str = ""
 
+    # Current clean settings (Flow 2 — live-broadcast in robot_base_status).
+    # 0 means "not yet observed" (the robot uses 1-indexed values).
+    #   field 26 = suction (1=Quiet, 2=Standard, 3=Strong, 4=Super powerful)
+    #   field 29 = mop humidity (1=Slightly dry, 2=Standard, 3=Slightly wet)
+    fan_level_raw: int = 0
+    mop_humidity_raw: int = 0
+
+    # Station / consumables. Field 41 is broadcast as a percentage that
+    # tracks dust-bag remaining capacity (100 = healthy/empty bag, drops
+    # toward 0 as it fills). Validated against the app's "Dust bag:
+    # Healthy" indicator at 100. Other tank/solution levels (clean
+    # water, dirty water, cleaning solution, mop pad wear) are not yet
+    # mapped — most appear constant at 1 (=OK) until a fault occurs.
+    dust_bag_health: int = 0
+
+    # Active fault / error. The robot reports a structured error in
+    # robot_base_status field 48.1.2 — empty `{}` when there is no
+    # active error, or `{1: severity, 2: code, 3: localized_message}`
+    # when a fault halts the current task. The message is broadcast in
+    # whatever locale the robot's firmware was set to (Chinese on the
+    # Flow 2 hardware we tested), so consumers should prefer the
+    # numeric code for logic and use the message for display.
+    error_code: int = 0
+    error_severity: int = 0
+    error_message: str = ""
+
+    # Station activity flags. Field 48.1 is a (possibly-repeated) list
+    # of currently-active dock tasks. Each entry uses an empty marker
+    # sub-field to identify the task type. Sub-keys verified by capture:
+    #   .10 = dust-bag drying (NOT dust emptying — earlier guess)
+    #   .13 = mop drying
+    #   .14 = dust-cabinet disinfection
+    # Entries without a `1` field are running; `1: 1` marks paused.
+    # WorkingStatus 17 / 19 also indicate mop-drying phases when the
+    # robot itself is the actor — see NarwalStationActivitySensor.
+    station_dust_bag_drying: bool = False
+    station_mop_drying: bool = False
+    station_dust_disinfecting: bool = False
+    # Kept for backwards compatibility while sensors transition. Always
+    # False under the corrected mapping — real "dust emptying" sub-key
+    # has not yet been observed in capture.
+    station_dust_emptying: bool = False
+
+    # Disinfection timer. ws.10 = elapsed seconds, ws.11 = target
+    # seconds (constant 2700 = 45 min in observed firmware). Both 0
+    # when disinfection is not running. Earlier we considered these
+    # generic dock-activity fields — they're disinfection-specific:
+    # ws.10/ws.11 vanish from the working_status broadcast as soon as
+    # the disinfection cycle ends, even while dust-bag drying is still
+    # active. No timer for bag drying has been identified yet.
+    dust_disinfection_elapsed: int = 0
+    dust_disinfection_target: int = 0
+
     # Device identity
     device_info: DeviceInfo | None = None
 
@@ -481,9 +579,54 @@ class NarwalState:
     # Position (from map data)
     position: Position | None = None
 
-    # Cleaning stats
-    cleaning_area: int = 0  # cm²
+    # Cleaning stats. Two separate sources:
+    #   * Flow 1: working_status field 13 in cm² (legacy upstream code).
+    #   * Flow 2: working_status fields 1 and 2 carry float32 progress % and
+    #     cleaned-area m² (live captures). Prefer the Flow 2 fields when
+    #     populated; fall back to the legacy cm² value otherwise. Field 13
+    #     is a constant (18000) on Flow 2 and never the actual area.
+    cleaning_area: int = 0  # legacy: working_status.13 in cm² (Flow 1)
+    cleaning_area_m2: float = 0.0  # live: working_status.2 as float32 m² (Flow 2)
+    cleaning_progress_pct: float = 0.0  # live: working_status.1 as float32 % (Flow 2)
     cleaning_time: int = 0  # seconds
+
+    # Rooms reported as completed within the active clean.
+    # Derived from working_status.5 — each entry that gains sub-field
+    # 4 = 1 has been finished. Empty list when not cleaning or all
+    # rooms still pending.
+    rooms_completed: list[int] = field(default_factory=list)
+    current_room_id: int = 0
+    current_room_index: int = 0
+
+    # Mop-drying timer (Flow 2). Live-confirmed by toggling between
+    # drying modes:
+    #   ws.8 = elapsed seconds since the cycle started
+    #   ws.9 = target total seconds for the selected mode
+    #     - 12600 (3.5 h) for default / smart / strong
+    #     - 18000 (5 h)   for silent
+    # Switching modes mid-cycle rescales ws.8 so the percent-complete
+    # stays consistent. Both fields drop to 0 once drying stops.
+    mop_drying_elapsed: int = 0
+    mop_drying_target: int = 0
+
+    # User-action prompt (Flow 2). When the robot needs the user to
+    # do something physical (carry me to dock, refill the tank, etc.)
+    # it broadcasts a structured prompt and starts a countdown. Empty
+    # / 0 when nothing is required:
+    #   user_action_type    = base.3.16 (2=fill tank, 3=return after
+    #                         clean, 4=return before clean — observed)
+    #   user_action_elapsed = ws.22.1 — seconds the user has been
+    #                         asked already
+    #   user_action_target  = ws.22.2 — timeout in seconds (600 / 3600
+    #                         observed)
+    user_action_type: int = 0
+    user_action_elapsed: int = 0
+    user_action_target: int = 0
+
+    # Map-identity signature (Flow 2). Multi-map houses switch
+    # base.30 / base.44 between maps; treat the pair as an opaque
+    # key — when it changes the active map has changed.
+    map_signature: tuple[int | None, int | None] = (None, None)
 
     # Map
     map_data: MapData | None = None
@@ -529,6 +672,14 @@ class NarwalState:
     raw_base_status: dict[str, Any] = field(default_factory=dict)
     raw_working_status: dict[str, Any] = field(default_factory=dict)
 
+    # Forward path the robot is about to drive — list of (x, y) world
+    # coordinates decoded from status/point_navi_plan_traj. Empty list
+    # when the robot is idle or no path is currently planned.
+    plan_trajectory: list[tuple[float, float]] = field(default_factory=list)
+    # Wall-clock timestamp of the most recent report/clean_report event
+    # (empty-payload broadcast that fires once at end of a clean cycle).
+    last_clean_report_ts: float = 0.0
+
     @property
     def is_cleaning(self) -> bool:
         """True when actively cleaning (not paused, not returning to dock)."""
@@ -558,6 +709,12 @@ class NarwalState:
         if self.working_status in (WorkingStatus.DOCKED, WorkingStatus.CHARGED):
             return True
         if self.working_status in (WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT):
+            return False
+        # Dock presence from field 3.3 is the most direct signal we have
+        # on this unit: 1/6 = on dock, 2 = off dock.
+        if self.dock_presence in (1, 6):
+            return True
+        if self.dock_presence == 2:
             return False
         # For STANDBY, UNKNOWN, or any other status: check dock field signals
         if self.dock_sub_state == 1:
@@ -593,23 +750,156 @@ class NarwalState:
             return False
         return self.is_returning_to_dock and self.dock_sub_state == 2
 
+    @property
+    def current_room_name(self) -> str | None:
+        """Return the display name of the room currently being cleaned.
+
+        Uses the current room id resolved from working_status.6 plus the
+        active room queue. Falls back to "Room <id>" when the map does not
+        contain a matching name yet.
+        """
+        if self.current_room_id <= 0:
+            return "unknown"
+        if self.map_data is None:
+            return f"Room {self.current_room_id}"
+        for room in self.map_data.rooms:
+            if room.room_id == self.current_room_id:
+                return room.display_name
+        return f"Room {self.current_room_id}"
+
     def update_from_working_status(self, decoded: dict[str, Any]) -> None:
         """Update state from a decoded working_status message.
 
-        Confirmed via 35-min monitor capture (2026-02-27):
-          Field 3  = current session elapsed time (seconds)
-                     (confirmed: 2136→2159 over 35-min clean)
-          Field 13 = cleaning area (cm²) — CONFIRMED (18000 = 1.8m²)
-          Field 15 = 600 during cleaning (purpose uncertain)
+        Field semantics (re-verified 2026-05 with full Wohnzimmer-Clean
+        capture — earlier mapping had cleaning_time on field 3, which is
+        actually the WorkingStatus enum):
+
+        Field 1   = float32 cleaning progress percent
+        Field 2   = float32 cleaned area in m²
+        Field 3   = WorkingStatus enum (status code, not seconds)
+        Field 5   = list of {1: roomId, 2: completed_flag}; flag == 2
+                    means the room is done. Earlier code used sub-field
+                    4 which never appears in current firmware.
+        Field 6   = index of the room currently being cleaned
+        Field 12  = elapsed seconds for the current session
+        Field 13  = legacy area in cm² (Flow 1 only — constant 18000
+                    on Flow 2, ignored)
+        Field 15  = 600 during cleaning, purpose uncertain
         """
         self.raw_working_status = decoded
-        if "3" in decoded:
+        # cleaning_time: prefer field 12 (real elapsed seconds). Field 3
+        # is the WorkingStatus enum and was the source of a previous bug
+        # where the "Cleaning time" sensor showed status codes.
+        if "12" in decoded:
             try:
-                self.cleaning_time = int(decoded["3"])
+                self.cleaning_time = int(decoded["12"])
             except (ValueError, TypeError):
                 pass
-        if "13" in decoded:
-            self.cleaning_area = int(decoded["13"])
+        # Flow 2: float32 progress and area encoded as fixed32 ints.
+        progress = _to_float32(decoded.get("1"))
+        if progress is not None and 0 <= progress <= 200:
+            self.cleaning_progress_pct = progress
+        area = _to_float32(decoded.get("2"))
+        if area is not None and 0 <= area <= 10000:
+            self.cleaning_area_m2 = area
+        # Track which rooms in the queue have been completed.
+        rooms = decoded.get("5")
+        completed: list[int] = []
+        # Each entry is {1: roomId, 2: completion_flag}. Observed values
+        # for flag: missing (queued), 1 (in progress), 2 (done). Earlier
+        # code looked at sub-field 4 which was never populated in any
+        # capture we have.
+        if isinstance(rooms, list):
+            for entry in rooms:
+                if isinstance(entry, dict) and entry.get("2") == 2:
+                    try:
+                        completed.append(int(entry.get("1", 0)))
+                    except (ValueError, TypeError):
+                        pass
+        elif isinstance(rooms, dict) and rooms.get("2") == 2:
+            try:
+                completed.append(int(rooms.get("1", 0)))
+            except (ValueError, TypeError):
+                pass
+        self.rooms_completed = completed
+        self.current_room_index = 0
+        self.current_room_id = 0
+        try:
+            current_hint = int(decoded.get("6", 0) or 0)
+        except (ValueError, TypeError):
+            current_hint = 0
+        self.current_room_index = current_hint
+        if isinstance(rooms, list):
+            # Prefer the room currently in progress.
+            for entry in rooms:
+                if not isinstance(entry, dict):
+                    continue
+                try:
+                    room_id = int(entry.get("1", 0) or 0)
+                except (ValueError, TypeError):
+                    room_id = 0
+                try:
+                    flag = int(entry.get("2", 0) or 0)
+                except (ValueError, TypeError):
+                    flag = 0
+                if room_id > 0 and flag == 1:
+                    self.current_room_id = room_id
+                    break
+            if self.current_room_id == 0 and current_hint > 0 and 1 <= current_hint <= len(rooms):
+                entry = rooms[current_hint - 1]
+                if isinstance(entry, dict):
+                    try:
+                        self.current_room_id = int(entry.get("1", 0) or 0)
+                    except (ValueError, TypeError):
+                        self.current_room_id = 0
+        elif isinstance(rooms, dict):
+            # Single-room broadcasts often collapse to {room_id: flag}.
+            for key, value in rooms.items():
+                try:
+                    room_id = int(key)
+                    flag = int(value or 0)
+                except (ValueError, TypeError):
+                    continue
+                if room_id > 0 and flag == 1:
+                    self.current_room_id = room_id
+                    break
+            if self.current_room_id == 0 and current_hint > 0:
+                self.current_room_id = current_hint
+        # Mop-drying timer (Flow 2 hypothesis from live capture).
+        try:
+            self.mop_drying_elapsed = int(decoded.get("8", 0) or 0)
+        except (ValueError, TypeError):
+            self.mop_drying_elapsed = 0
+        try:
+            self.mop_drying_target = int(decoded.get("9", 0) or 0)
+        except (ValueError, TypeError):
+            self.mop_drying_target = 0
+        # Disinfection timer (ws.10 elapsed / ws.11 target). The fields
+        # are absent from the broadcast when no disinfection cycle is
+        # running — `.get("10", 0)` resolves to 0 in that case.
+        try:
+            self.dust_disinfection_elapsed = int(decoded.get("10", 0) or 0)
+        except (ValueError, TypeError):
+            self.dust_disinfection_elapsed = 0
+        try:
+            self.dust_disinfection_target = int(decoded.get("11", 0) or 0)
+        except (ValueError, TypeError):
+            self.dust_disinfection_target = 0
+        # ws.22 = user-action countdown ({1: elapsed, 2: target}). Empty
+        # dict when no action is required.
+        f22 = decoded.get("22")
+        if isinstance(f22, dict) and f22:
+            try:
+                self.user_action_elapsed = int(f22.get("1", 0) or 0)
+            except (ValueError, TypeError):
+                self.user_action_elapsed = 0
+            try:
+                self.user_action_target = int(f22.get("2", 0) or 0)
+            except (ValueError, TypeError):
+                self.user_action_target = 0
+        else:
+            self.user_action_elapsed = 0
+            self.user_action_target = 0
         if "15" in decoded:
             # Field 15 may be cumulative time; prefer field 3 for current session
             pass
@@ -642,6 +932,95 @@ class NarwalState:
                 self.dock_field11 = int(decoded["11"])
             except (ValueError, TypeError):
                 self.dock_field11 = 0
+        # Field 26 = current suction level (Flow 2 only; live captures from
+        # firmware v01.07.19.00 confirm the 1-indexed scale 1=Quiet,
+        # 2=Standard, 3=Strong, 4=Super powerful). Not observed on Flow 1
+        # — leaves fan_level_raw at 0 there.
+        if "26" in decoded:
+            try:
+                self.fan_level_raw = int(decoded["26"])
+            except (ValueError, TypeError):
+                self.fan_level_raw = 0
+        # Field 29 = current mop humidity (Flow 2). 1=Slightly dry,
+        # 2=Standard, 3=Slightly wet (live-confirmed).
+        if "29" in decoded:
+            try:
+                self.mop_humidity_raw = int(decoded["29"])
+            except (ValueError, TypeError):
+                self.mop_humidity_raw = 0
+        # Field 41 = dust bag remaining capacity, 0–100.
+        if "41" in decoded:
+            try:
+                self.dust_bag_health = int(decoded["41"])
+            except (ValueError, TypeError):
+                self.dust_bag_health = 0
+        # Field 48.1 carries one or more dock activities. It's a single
+        # message during a normal clean, but switches to a repeated list
+        # when multiple activities overlap (e.g. mop drying while a
+        # dust-bag emptying is queued). Normalize to a list so the
+        # parsers below don't need to care.
+        f48_1 = decoded.get("48", {}).get("1")
+        f48_entries: list[dict[str, Any]] = []
+        if isinstance(f48_1, list):
+            f48_entries = [e for e in f48_1 if isinstance(e, dict)]
+        elif isinstance(f48_1, dict):
+            f48_entries = [f48_1]
+
+        # Active error. The robot reports one through two channels:
+        #   * 48.1.*.2 = {1: severity, 2: code, 3: localized_message}
+        #   * field 1 = {1: code, 2: severity, 3: formatted_message}
+        # Field 1 also carries the formatted "错误码:0xCCSSRRXX\n等级:..."
+        # banner string. Either or both can be populated; whichever
+        # appears first wins. Empty/absent on both = no active error.
+        err = next(
+            (e["2"] for e in f48_entries
+             if isinstance(e.get("2"), dict) and e["2"]),
+            None,
+        )
+        f1 = decoded.get("1")
+        if isinstance(err, dict) and err:
+            try:
+                self.error_severity = int(err.get("1", 0))
+            except (ValueError, TypeError):
+                self.error_severity = 0
+            try:
+                self.error_code = int(err.get("2", 0))
+            except (ValueError, TypeError):
+                self.error_code = 0
+            raw_msg = err.get("3", "")
+            if isinstance(raw_msg, bytes):
+                self.error_message = raw_msg.decode("utf-8", errors="replace")
+            else:
+                self.error_message = str(raw_msg)
+        elif isinstance(f1, dict) and f1:
+            # Secondary channel — note the swapped fields: 1 is the code.
+            try:
+                self.error_code = int(f1.get("1", 0))
+            except (ValueError, TypeError):
+                self.error_code = 0
+            try:
+                self.error_severity = int(f1.get("2", 0))
+            except (ValueError, TypeError):
+                self.error_severity = 0
+            raw_msg = f1.get("3", "")
+            if isinstance(raw_msg, bytes):
+                self.error_message = raw_msg.decode("utf-8", errors="replace")
+            else:
+                self.error_message = str(raw_msg)
+        else:
+            self.error_code = 0
+            self.error_severity = 0
+            self.error_message = ""
+
+        # Station-activity markers within 48.1.*. Each entry carries an
+        # empty `{}` sub-field whose key identifies the task type. See
+        # the field declarations above for the verified key map.
+        self.station_dust_bag_drying = any("10" in e for e in f48_entries)
+        self.station_mop_drying = any("13" in e for e in f48_entries)
+        self.station_dust_disinfecting = any("14" in e for e in f48_entries)
+        # No sub-key for actual dust-bin emptying observed yet — leave
+        # the legacy flag wired off.
+        self.station_dust_emptying = False
         # Field 47 = dock indicator (3=docked, 2=undocked)
         if "47" in decoded:
             try:
@@ -674,6 +1053,29 @@ class NarwalState:
                 self.dock_presence = int(field3.get("3", 0))
             except (ValueError, TypeError):
                 self.dock_presence = 0
+            # Sub-field 16 = user-action prompt type (Flow 2):
+            #   2 = fill water tank / problem solved
+            #   3 = bring robot to dock after clean done
+            #   4 = bring robot to dock to start clean
+            try:
+                self.user_action_type = int(field3.get("16", 0) or 0)
+            except (ValueError, TypeError):
+                self.user_action_type = 0
+        else:
+            self.user_action_type = 0
+
+        # Map identity (Flow 2). base.30 + base.44 form an opaque
+        # signature that flips between saved maps; track them so the
+        # coordinator can refresh get_map() when the user switches.
+        try:
+            sig30 = int(decoded["30"]) if "30" in decoded else None
+        except (ValueError, TypeError):
+            sig30 = None
+        try:
+            sig44 = int(decoded["44"]) if "44" in decoded else None
+        except (ValueError, TypeError):
+            sig44 = None
+        self.map_signature = (sig30, sig44)
         if "2" in decoded:
             # Field 2 = real-time battery SOC as float32
             # (e.g. 1118175232 → 83.0%; bbp may return int or float)
@@ -711,6 +1113,29 @@ class NarwalState:
             self.battery_health = int(decoded["38"])
         if "36" in decoded:
             self.timestamp = int(decoded["36"])
+
+    def update_from_plan_traj(self, decoded: dict[str, Any]) -> None:
+        """Update state from a status/point_navi_plan_traj broadcast.
+
+        Field 1 is a repeated list of {1: x, 2: y} where each coordinate
+        is a float32 packed into a fixed32 int (same encoding as the
+        battery and area fields elsewhere in the protocol).
+
+        Empty / missing field 1 → robot has no planned path → clear the
+        cached trajectory. Bad encodings are dropped silently rather
+        than poisoning the whole list.
+        """
+        points: list[tuple[float, float]] = []
+        raw = decoded.get("1")
+        if isinstance(raw, list):
+            for entry in raw:
+                if not isinstance(entry, dict):
+                    continue
+                x = _to_float32(entry.get("1"))
+                y = _to_float32(entry.get("2"))
+                if x is not None and y is not None:
+                    points.append((x, y))
+        self.plan_trajectory = points
 
     def update_from_upgrade_status(self, decoded: dict[str, Any]) -> None:
         """Update state from a decoded upgrade_status message."""

--- a/tests/test_fan_speed.py
+++ b/tests/test_fan_speed.py
@@ -1,0 +1,30 @@
+"""Tests for fan speed mapping."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from narwal_client.client import NarwalClient
+from narwal_client.const import FanLevel, TOPIC_CMD_SET_FAN_LEVEL
+
+
+def test_fan_level_enum_is_one_indexed() -> None:
+    assert int(FanLevel.QUIET) == 1
+    assert int(FanLevel.NORMAL) == 2
+    assert int(FanLevel.STRONG) == 3
+    assert int(FanLevel.MAX) == 4
+
+
+def test_set_fan_speed_encodes_one_indexed_level() -> None:
+    client = NarwalClient("127.0.0.1")
+    client._ws = AsyncMock()
+    client._connected = True
+
+    with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+        mock_send.return_value = AsyncMock()
+        asyncio.get_event_loop().run_until_complete(client.set_fan_speed(FanLevel.MAX))
+
+        mock_send.assert_awaited_once()
+        args, kwargs = mock_send.call_args
+        assert args == (TOPIC_CMD_SET_FAN_LEVEL, b"\x08\x04")

--- a/tools/CAPTURE_GUIDE.md
+++ b/tools/CAPTURE_GUIDE.md
@@ -1,0 +1,133 @@
+# Capturing app → robot traffic for protocol RE
+
+The Narwal local protocol on TCP/9002 is plaintext WebSocket (`ws://`,
+not `wss://`). That means we don't need TLS interception — passive
+sniffing is enough to read every byte the official Narwal mobile app
+sends to the robot. This guide describes the simplest setup that
+works on a Mac.
+
+## Why we need this
+
+`narwal_capture.py` records *broadcasts* (robot → world). Most Flow 2
+protocol gaps left after the v1.0.0 reverse-engineering pass — single
+room cleaning (#25), cleaning cycles (x1/x2/x3), a few clean-task
+sub-fields — sit in the *opposite* direction (app → robot) and never
+appear in broadcasts. The only way to learn that wire format is to
+watch the app talk.
+
+## The setup: Mac as Wi-Fi hotspot
+
+Phone connects to a hotspot the Mac broadcasts; Mac is uplinked to the
+real home network over Ethernet. All phone traffic passes through the
+Mac, so Wireshark on the Mac sees the plaintext WebSocket frames the
+app sends to the robot at `192.168.178.x:9002`.
+
+```
+   ┌─────────┐  ws://   ┌────────────┐  ws://   ┌────────┐
+   │  Phone  │─────────▶│    Mac     │─────────▶│ Robot  │
+   │ (Narwal │          │ (Wireshark │          │  9002  │
+   │   app)  │          │   here)    │          └────────┘
+   └─────────┘          └─────┬──────┘
+                              │ ethernet
+                              ▼
+                       Fritzbox / home router
+```
+
+### One-time setup
+
+1. **Install Wireshark** on the Mac:
+   ```sh
+   brew install --cask wireshark
+   ```
+   On first launch it asks to install the privileged helper for live
+   capture — say yes.
+
+2. **Enable Internet Sharing** on the Mac:
+   System Settings → General → Sharing → Internet Sharing.
+   Share your connection from **Ethernet** to **Wi-Fi**.
+   Click Wi-Fi Options, set a network name + password.
+
+3. **Connect the phone** to the Mac's Wi-Fi.
+   Robot stays on the home Wi-Fi.
+
+### Per session
+
+1. Open Wireshark, start a capture on the **`bridge100`** interface
+   (this is the hotspot bridge — won't exist until Internet Sharing
+   has been on at least once).
+
+2. Apply this display filter:
+   ```
+   tcp.port == 9002 && ip.addr == 192.168.178.138
+   ```
+   Replace `192.168.178.138` with the robot's IP.
+
+3. **Important**: close Home Assistant's Narwal connection before
+   starting the test (the robot only allows one WebSocket connection
+   at a time). Easiest: temporarily disable the integration in
+   Settings → Devices & Services, or stop the HA core.
+
+4. Open the Narwal app on the phone, perform the action you want to
+   capture (e.g. start a single-room clean on Toilet). The app's
+   first frames after connecting will be the WebSocket handshake;
+   then `clean/...` topic frames.
+
+5. In Wireshark: right-click the first WebSocket packet of the
+   session → Follow → TCP Stream. Save the stream as raw bytes.
+
+## Decoding the captured frames
+
+WebSocket framing is documented (RFC 6455). For our purposes each
+text/binary frame holds a Narwal protocol message:
+
+```
++------+--------+----------+--------+
+| 0x01 | topic  | length   | proto  |
+| (1B) | (NUL-  | (uint32) | bytes  |
+|      | term'd |          |        |
+|      | string)|          |        |
++------+--------+----------+--------+
+```
+
+(see `narwal_client/protocol.py` for the exact frame parser).
+
+To decode the protobuf bytes, use the integration's own decoder:
+
+```python
+import blackboxprotobuf
+from narwal_client.protocol import parse_frame
+
+# `frame` = raw bytes copy-pasted out of Wireshark
+msg = parse_frame(frame)
+print("topic:", msg.full_topic)
+decoded, typedef = blackboxprotobuf.decode_message(msg.payload)
+print("payload:", decoded)
+print("typedef:", typedef)
+```
+
+A short helper script lives at `tools/decode_frame.py` (TODO once we
+need it).
+
+## What to capture for each open question
+
+| Question | Action to perform in the app | What to look for |
+|---|---|---|
+| #25 single-room | Tap one room on the map → Customization → Start | Topic for the start command, payload structure with the room ID |
+| Cycle x1/x2/x3 | Customization → toggle cycle, Start | Differences between three otherwise-identical starts |
+| Coverage Precision | Customization → toggle Standard/Meticulous, Start | Differences between two otherwise-identical starts |
+| Tank states | Remove a water tank or empty cleaning solution while connected | Which broadcast field jumps from 1 to something else |
+
+Save each capture (Wireshark → File → Save As, `.pcapng`) so we have
+a record beyond the live session.
+
+## Fallbacks if Mac hotspot isn't available
+
+- **OpenWrt / managed switch with port mirroring**: tcpdump on the
+  router (`tcpdump -i br-lan -w capture.pcap port 9002`) — no client
+  reconfiguration. Cleanest if you have it.
+- **`arpspoof` or `bettercap`**: trick the phone into routing through
+  the Mac on the same Wi-Fi. Sketchier and easy to mess up; only do
+  this if you understand the implications for the rest of your
+  network.
+- **Rooted phone with `tcpdump`**: capture directly on the device.
+  Fine if the phone's already rooted, otherwise too much friction.

--- a/tools/coverage_probe.py
+++ b/tools/coverage_probe.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Coverage probe: catalogue everything the robot broadcasts locally.
+
+Streams `ha core logs --follow` over SSH, parses every `DUMP` line, and
+keeps a running set of:
+
+  • topics ever seen
+  • per-topic field IDs ever populated (top-level dict keys of the
+    decoded protobuf)
+  • per-topic field values that ever changed (so we can spot dynamic
+    vs constant fields)
+
+Workflow: start the probe, then in the official Narwal app trigger a
+feature (single-room, schedule edit, voice pack switch, …). Hit RETURN
+in the probe terminal and type a short label — it gets saved as a
+"marker" together with the diff of broadcasts since the previous
+marker. At exit (Ctrl-C) the probe prints a coverage report:
+
+  • all topics observed
+  • for each topic, fields that mutated at least once
+  • topics in const.py that never appeared (probably command-only or
+    cloud-only)
+  • topics that appeared but are not listed in const.py (new!)
+
+Usage::
+
+    python3 tools/coverage_probe.py homeassistant.local
+    # … click around in the app, hit RETURN, type "single-room toilet" …
+    # Ctrl-C to print report
+
+Output is written to ``coverage_<timestamp>.json`` in the current
+directory for offline inspection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import select
+import signal
+import subprocess
+import sys
+import threading
+import time
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+# ANSI escape stripper — `ha core logs` may colourise output depending on tty.
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*[mGKHF]")
+DUMP_RE = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}) "
+    r"DEBUG .* DUMP (?P<topic>\S+): (?P<payload>.+)$"
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONST_FILE = REPO_ROOT / "narwal_client" / "const.py"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _iter_log_stream(host: str) -> Iterator[str]:
+    """Yield log lines from `ha core logs --follow` over SSH."""
+    cmd = ["ssh", host, "ha core logs --follow"]
+    # Pipe stderr through so SSH connection errors / "ha: command not
+    # found" surface immediately instead of silently producing an empty
+    # stream — the latter looks identical to "robot is silent".
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=sys.stderr,
+        bufsize=1, text=True,
+    )
+    assert proc.stdout is not None
+    try:
+        for line in proc.stdout:
+            yield ANSI_RE.sub("", line.rstrip("\n"))
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def _parse_payload(raw: str) -> Any:
+    # DUMP payloads are repr()'d Python dicts — ast.literal_eval is safe.
+    try:
+        return ast.literal_eval(raw)
+    except (ValueError, SyntaxError):
+        return None
+
+
+def _load_known_topics() -> set[str]:
+    """Parse TOPIC_* string constants out of const.py."""
+    topics: set[str] = set()
+    pat = re.compile(r'^TOPIC_[A-Z_]+\s*=\s*"([^"]+)"')
+    for line in CONST_FILE.read_text().splitlines():
+        m = pat.match(line)
+        if m:
+            topics.add(m.group(1))
+    return topics
+
+
+class Coverage:
+    def __init__(self) -> None:
+        # topic → { "first_seen": iso, "last_seen": iso, "count": int,
+        #          "fields": { fid → {"values": set(), "changed": bool} } }
+        self.topics: dict[str, dict[str, Any]] = {}
+        self.markers: list[dict[str, Any]] = []
+        # Snapshot of {topic: {field: value}} at last marker, for diffing.
+        self._marker_baseline: dict[str, dict[str, Any]] = defaultdict(dict)
+        self._latest_payload: dict[str, dict[str, Any]] = {}
+        self._lock = threading.Lock()
+
+    def observe(self, topic: str, payload: Any, ts: str) -> None:
+        with self._lock:
+            entry = self.topics.setdefault(topic, {
+                "first_seen": ts, "last_seen": ts, "count": 0,
+                "fields": defaultdict(lambda: {"changed": False, "samples": []}),
+            })
+            entry["last_seen"] = ts
+            entry["count"] += 1
+
+            if isinstance(payload, dict):
+                self._latest_payload[topic] = payload
+                for fid, val in payload.items():
+                    f = entry["fields"][str(fid)]
+                    samples = f["samples"]
+                    if val not in samples:
+                        if samples:
+                            f["changed"] = True
+                        # Cap to 5 distinct samples per field — enough to
+                        # tell "constant" vs "varies" without ballooning.
+                        if len(samples) < 5:
+                            samples.append(val)
+
+    def add_marker(self, label: str) -> dict[str, Any]:
+        """Snapshot what changed since the last marker, save it, return summary."""
+        with self._lock:
+            ts = _now_iso()
+            diff: dict[str, dict[str, list[Any]]] = {}
+            for topic, latest in self._latest_payload.items():
+                baseline = self._marker_baseline.get(topic, {})
+                changes = {}
+                for fid, val in latest.items():
+                    fid_s = str(fid)
+                    if baseline.get(fid_s) != val:
+                        changes[fid_s] = [baseline.get(fid_s), val]
+                if changes:
+                    diff[topic] = changes
+                self._marker_baseline[topic] = dict(latest)
+
+            marker = {
+                "ts": ts, "label": label, "diff": diff,
+                "topics_changed": sorted(diff.keys()),
+            }
+            self.markers.append(marker)
+            return marker
+
+    def serialise(self) -> dict[str, Any]:
+        with self._lock:
+            out_topics = {}
+            for t, e in self.topics.items():
+                out_topics[t] = {
+                    "first_seen": e["first_seen"],
+                    "last_seen": e["last_seen"],
+                    "count": e["count"],
+                    "fields": {
+                        fid: {
+                            "changed": f["changed"],
+                            "samples": [_safe(s) for s in f["samples"]],
+                        }
+                        for fid, f in e["fields"].items()
+                    },
+                }
+            return {"topics": out_topics, "markers": self.markers}
+
+
+def _safe(v: Any) -> Any:
+    """Make value JSON-serialisable; truncate long bytes/strings."""
+    if isinstance(v, bytes):
+        return f"<{len(v)}B>"
+    if isinstance(v, str) and len(v) > 80:
+        return v[:77] + "..."
+    if isinstance(v, list):
+        return [_safe(x) for x in v[:5]] + (["…"] if len(v) > 5 else [])
+    if isinstance(v, dict):
+        return {k: _safe(val) for k, val in list(v.items())[:10]}
+    return v
+
+
+def _stream_thread(
+    host: str, cov: Coverage, stop: threading.Event,
+) -> None:
+    for line in _iter_log_stream(host):
+        if stop.is_set():
+            break
+        m = DUMP_RE.match(line)
+        if not m:
+            continue
+        payload = _parse_payload(m.group("payload"))
+        # client.py logs `DUMP <short_topic>: <decoded>` — already the
+        # `category/name` short form, no prefix stripping needed.
+        cov.observe(
+            topic=m.group("topic"),
+            payload=payload,
+            ts=m.group("ts"),
+        )
+
+
+def _print_report(cov: Coverage, known: set[str]) -> None:
+    data = cov.serialise()
+    seen = set(data["topics"].keys())
+
+    print()
+    print("=" * 70)
+    print("COVERAGE REPORT")
+    print("=" * 70)
+    print(f"Topics seen:    {len(seen)}")
+    print(f"Markers logged: {len(data['markers'])}")
+    print()
+
+    print("--- Topics observed ---")
+    for t in sorted(seen):
+        e = data["topics"][t]
+        mutating = sum(1 for f in e["fields"].values() if f["changed"])
+        flag = "" if t in known else "  [NEW]"
+        print(f"  {t:<40s} count={e['count']:>5d}  "
+              f"fields={len(e['fields'])} (mutating={mutating}){flag}")
+
+    print()
+    print("--- Known topics never broadcast (probably command-only or cloud-only) ---")
+    missing = sorted(known - seen)
+    if not missing:
+        print("  (none — every known topic was seen at least once)")
+    for t in missing:
+        print(f"  {t}")
+
+    print()
+    print("--- Markers ---")
+    for m in data["markers"]:
+        topics = ", ".join(m["topics_changed"]) or "(no broadcasts changed)"
+        print(f"  [{m['ts']}] {m['label']}")
+        print(f"      → {topics}")
+
+
+def cmd_probe(args: argparse.Namespace) -> int:
+    known = _load_known_topics()
+    cov = Coverage()
+    stop = threading.Event()
+
+    print(f"[probe] streaming logs from {args.host} (Ctrl-C to stop)")
+    print(f"[probe] {len(known)} known topics loaded from const.py")
+    print("[probe] type a label and press ENTER to mark an event")
+    print()
+
+    t = threading.Thread(
+        target=_stream_thread, args=(args.host, cov, stop), daemon=True,
+    )
+    t.start()
+
+    def _on_sigint(signum: int, frame: Any) -> None:  # noqa: ARG001
+        stop.set()
+        raise KeyboardInterrupt
+
+    signal.signal(signal.SIGINT, _on_sigint)
+
+    try:
+        while not stop.is_set():
+            # Non-blocking stdin so the streamer keeps running.
+            r, _, _ = select.select([sys.stdin], [], [], 0.5)
+            if not r:
+                continue
+            label = sys.stdin.readline().strip()
+            if not label:
+                continue
+            marker = cov.add_marker(label)
+            n = len(marker["topics_changed"])
+            print(f"  [marker] '{label}' → {n} topic(s) changed since previous marker")
+    except KeyboardInterrupt:
+        pass
+
+    stop.set()
+    time.sleep(0.3)
+
+    out_path = Path(f"coverage_{int(time.time())}.json")
+    out_path.write_text(json.dumps(cov.serialise(), indent=2, default=str))
+    print(f"\n[probe] saved raw data → {out_path}")
+    _print_report(cov, known)
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("host", help="SSH target running Home Assistant")
+    args = p.parse_args()
+    return cmd_probe(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/narwal_capture.py
+++ b/tools/narwal_capture.py
@@ -1,0 +1,842 @@
+#!/usr/bin/env python3
+"""Record + watch annotated Narwal broadcasts for protocol RE.
+
+Streams `ha core logs --follow` from a Home Assistant host over SSH,
+filters for `DUMP <topic>: <decoded>` lines emitted by the integration
+when run with debug logging, and interleaves user-typed annotations
+into the output. Captures land in JSONL so they're trivially diffable
+and replayable.
+
+Two complementary subcommands, made to run in two separate terminals:
+
+    # Terminal A — annotations + capture (low-latency typing)
+    python3 narwal_capture.py record --host root@192.168.178.3 \
+        --ssh-key ~/.ssh/openclaw_ha_ed25519 \
+        --out captures/session.jsonl
+
+    # Terminal B — live decoded-state dashboard
+    python3 narwal_capture.py dashboard --host root@192.168.178.3 \
+        --ssh-key ~/.ssh/openclaw_ha_ed25519
+
+Plus offline analysis helpers:
+
+    python3 narwal_capture.py diff captures/before.jsonl captures/after.jsonl
+    python3 narwal_capture.py replay captures/session.jsonl
+
+The integration must already be running with debug logging:
+    service: logger.set_level
+    data:
+      custom_components.narwal: debug
+      custom_components.narwal.narwal_client: debug
+
+This works because the client logs every decoded broadcast as
+`DUMP <topic>: <repr>` at DEBUG level, which `ha core logs --follow`
+streams over the supervisor API.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import datetime as dt
+import json
+import re
+import shlex
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Any, Iterator, TextIO
+
+# Strips the ANSI colour codes that `ha core logs` wraps each line in.
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+# Matches lines like:
+#   2026-05-04 23:55:38.917 DEBUG (MainThread) [custom_components.narwal.narwal_client.client] DUMP status/working_status: {...}
+DUMP_RE = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}) "
+    r"DEBUG .*?\[custom_components\.narwal\.[\w.]+\] "
+    r"DUMP (?P<topic>\S+): (?P<payload>.+)$"
+)
+
+
+def _now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat(timespec="milliseconds")
+
+
+def _parse_payload(raw: str) -> Any:
+    """Best-effort parse of the broadcast repr.
+
+    blackboxprotobuf decodes broadcasts to dicts of int/str/bytes; the
+    integration logs them with `%r`, which is a Python literal we can
+    round-trip via ast.literal_eval. Falls back to the raw string if
+    something more exotic shows up.
+    """
+    try:
+        return ast.literal_eval(raw)
+    except (SyntaxError, ValueError):
+        return raw
+
+
+def _iter_log_stream(host: str, ssh_key: str | None = None) -> Iterator[str]:
+    """Yield decoded log lines from `ha core logs --follow` over SSH."""
+    cmd = ["ssh"]
+    if ssh_key:
+        cmd.extend(["-i", str(Path(ssh_key).expanduser())])
+    cmd.extend([host, "ha core logs --follow"])
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        bufsize=1, text=True,
+    )
+    assert proc.stdout is not None
+    try:
+        for line in proc.stdout:
+            yield ANSI_RE.sub("", line.rstrip("\n"))
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+# Topics whose changes we never report — they're either pure noise
+# (display_map fires every ~1.5s during cleaning, download_status is
+# usually a constant `2`) or reach the change-detector via a different
+# topic (working_status duplicates many robot_base_status sub-fields).
+_NOISY_TOPICS: frozenset[str] = frozenset({
+    "map/display_map",
+    "status/download_status",
+    "upgrade/upgrade_status",
+})
+
+# Top-level robot_base_status keys whose values change every broadcast
+# without anything semantic happening (battery jitter, monotonic
+# timestamps, session ids). Filtering them keeps the change-hint
+# signal-to-noise ratio high.
+_NOISE_BASE_KEYS: frozenset[str] = frozenset({
+    "2",   # battery float32 — jitters slightly each tick
+    "13",  # session id (string)
+    "35",  # secondary battery / charging value
+    "36",  # last-update timestamp (ms epoch)
+})
+
+# Working-status fields that tick every broadcast during a clean
+# (elapsed time, area, the always-600 cumulative-time-ish field).
+_NOISE_WS_KEYS: frozenset[str] = frozenset({"3", "12", "13", "15"})
+
+
+def _diff_dict(
+    a: dict[str, Any] | None,
+    b: dict[str, Any] | None,
+    skip: frozenset[str],
+) -> list[str]:
+    """Return short 'k: x → y' strings for non-noise key changes."""
+    if not isinstance(a, dict) or not isinstance(b, dict):
+        return []
+    keys = (set(a) | set(b)) - skip
+    out = []
+    for k in sorted(keys, key=lambda x: int(x) if x.isdigit() else 999):
+        va, vb = a.get(k), b.get(k)
+        if va == vb:
+            continue
+        # Truncate long values so the hint fits one line.
+        sa = repr(va)
+        sb = repr(vb)
+        if len(sa) > 40:
+            sa = sa[:37] + "…"
+        if len(sb) > 40:
+            sb = sb[:37] + "…"
+        out.append(f"{k}: {sa}→{sb}")
+    return out
+
+
+def _writer_thread(
+    host: str, out_fp: TextIO, lock: threading.Lock,
+    stop: threading.Event, verbose: bool, counter: list[int], ssh_key: str | None = None,
+) -> None:
+    """Read SSH log stream, write parsed DUMP lines to the JSONL output."""
+    last_payload: dict[str, dict[str, Any]] = {}
+    for line in _iter_log_stream(host, ssh_key):
+        if stop.is_set():
+            break
+        m = DUMP_RE.match(line)
+        if not m:
+            continue
+        topic = m.group("topic")
+        payload = _parse_payload(m.group("payload"))
+        record = {
+            "kind": "broadcast",
+            "ts": _now_iso(),
+            "log_ts": m.group("ts"),
+            "topic": topic,
+            "payload": payload,
+        }
+
+        # Detect notable change vs last seen payload on the same topic.
+        notable_diff: list[str] = []
+        if topic == "status/robot_base_status":
+            notable_diff = _diff_dict(
+                last_payload.get(topic), payload if isinstance(payload, dict) else None,
+                _NOISE_BASE_KEYS,
+            )
+        elif topic == "status/working_status":
+            notable_diff = _diff_dict(
+                last_payload.get(topic), payload if isinstance(payload, dict) else None,
+                _NOISE_WS_KEYS,
+            )
+        if isinstance(payload, dict):
+            last_payload[topic] = payload
+
+        with lock:
+            out_fp.write(json.dumps(record, default=str) + "\n")
+            out_fp.flush()
+            counter[0] += 1
+            if verbose:
+                # Verbose mode shares the terminal with the input prompt,
+                # so the cursor jumps as broadcasts arrive. Default is
+                # silent — `tail -f <out>.jsonl` in another window if
+                # you want to watch the stream.
+                print(f"  [{record['log_ts']}] {topic}",
+                      file=sys.stderr)
+            elif notable_diff and topic not in _NOISY_TOPICS:
+                # Bell + one-line hint so the user notices an
+                # interesting change but can keep typing. Doesn't
+                # interrupt the input line — readline redraws on the
+                # next keystroke.
+                short_topic = topic.rsplit("/", 1)[-1]
+                hint = ", ".join(notable_diff[:4])
+                if len(notable_diff) > 4:
+                    hint += f" (+{len(notable_diff) - 4} more)"
+                print(f"\a\n[*] {short_topic}: {hint}",
+                      file=sys.stderr, flush=True)
+                # Persist the diff alongside the broadcast for replay.
+                out_fp.write(json.dumps({
+                    "kind": "change",
+                    "ts": record["ts"],
+                    "log_ts": record["log_ts"],
+                    "topic": topic,
+                    "diff": notable_diff,
+                }) + "\n")
+                out_fp.flush()
+
+
+# --- Decoder for known protocol fields ---------------------------------
+#
+# What we already understand about Flow 2 broadcasts (validated live).
+# Everything else we surface as raw key→value so the user can spot new
+# patterns. Keep these dicts in sync with narwal_client.
+
+_WORKING_STATUS = {
+    0: "UNKNOWN", 1: "STANDBY", 3: "MOP_WASHING", 4: "CLEANING",
+    5: "CLEANING_ALT", 7: "MAPPING", 10: "DOCKED", 14: "CHARGED",
+    17: "MOP_DRYING", 19: "MOP_DRYING_ACTIVE", 99: "ERROR",
+}
+_ERROR_CODES = {
+    0x01010036: "clean_water_dirty_tank_anomaly",
+    0x01010137: "clean_water_tank_empty",
+    0x02310031: "robot_lifted",
+}
+_SUCTION = {1: "Quiet", 2: "Standard", 3: "Strong", 4: "Super powerful"}
+_MOP_HUMIDITY = {1: "Slightly dry", 2: "Standard", 3: "Slightly wet"}
+_CLEAN_MODE = {
+    1: "Vacuum", 2: "Mop", 3: "Vacuum then mop",
+    4: "Vacuum and mop", 5: "Adaptive (Raumanpassung)",
+}
+
+# Decoded keys are tracked dynamically by _decode_state — anything it
+# consumes is excluded from the "Unknown fields" section. This keeps
+# the dashboard honest: if a row appears decoded above, the raw key
+# disappears from the bottom; new firmware fields show up immediately.
+
+
+def _f32(val: Any) -> float | None:
+    """Decode a float32 stored as int bits (or already a float)."""
+    if isinstance(val, float):
+        return val
+    if isinstance(val, int):
+        try:
+            import struct
+            return struct.unpack("f", struct.pack("I", val & 0xFFFFFFFF))[0]
+        except Exception:
+            return None
+    return None
+
+
+def _f48_entries(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Normalize robot_base_status field 48.1 to a list of dicts."""
+    f1 = payload.get("48", {}).get("1") if isinstance(payload.get("48"), dict) else None
+    if isinstance(f1, list):
+        return [e for e in f1 if isinstance(e, dict)]
+    if isinstance(f1, dict):
+        return [f1]
+    return []
+
+
+def _decode_state(
+    latest: dict[str, dict[str, Any]],
+    consumed_base: set[str] | None = None,
+    consumed_ws: set[str] | None = None,
+) -> list[tuple[str, str, str]]:
+    """Build (label, value, raw_field) rows from the latest broadcasts.
+
+    Mirrors what `narwal_client` actually pulls out of each broadcast,
+    plus the Flow-2 specific fields we discovered. Anything we touch
+    is added to consumed_{base,ws}; whatever's left is shown as
+    raw/unknown by the caller. That keeps the dashboard honest:
+    a row appearing here means the integration sees the value, not
+    just that we logged the key.
+    """
+    bs = latest.get("status/robot_base_status") or {}
+    ws = latest.get("status/working_status") or {}
+    if consumed_base is None:
+        consumed_base = set()
+    if consumed_ws is None:
+        consumed_ws = set()
+    rows: list[tuple[str, str, str]] = []
+
+    # Working status (3.1)
+    f3 = bs.get("3") if isinstance(bs.get("3"), dict) else {}
+    ws_id = f3.get("1") if isinstance(f3, dict) else None
+    rows.append((
+        "Status",
+        f"{_WORKING_STATUS.get(ws_id, '?')} ({ws_id})" if ws_id is not None else "-",
+        f"3.1={ws_id}",
+    ))
+    consumed_base.add("3")  # the whole nested message is decoded below
+
+    # Battery (% from float32 in field 2)
+    bat = _f32(bs.get("2"))
+    rows.append(("Battery", f"{bat:.1f}%" if bat is not None else "-", "2 (float32)"))
+    consumed_base.add("2")
+
+    # Battery health (38, design capacity — always 100 in observed data)
+    bh = bs.get("38")
+    rows.append(("Battery health", f"{bh}" if bh is not None else "-", "38"))
+    consumed_base.add("38")
+
+    # Suction
+    s = bs.get("26")
+    rows.append(("Suction", f"{_SUCTION.get(s, '?')} ({s})" if s else "-", "26"))
+    consumed_base.add("26")
+
+    # Mop humidity
+    h = bs.get("29")
+    rows.append((
+        "Mop humidity",
+        f"{_MOP_HUMIDITY.get(h, '?')} ({h})" if h else "-",
+        "29",
+    ))
+    consumed_base.add("29")
+
+    # Dust bag
+    db = bs.get("41")
+    rows.append(("Dust bag", f"{db}%" if db is not None else "-", "41"))
+    consumed_base.add("41")
+
+    # Coverage precision (1 = Standard, absent = Meticulous; tentative)
+    cp = bs.get("34")
+    if cp == 1:
+        rows.append(("Coverage", "Standard (tentative)", "34=1"))
+    elif cp is None:
+        rows.append(("Coverage", "Meticulous? (34 absent)", "34=∅"))
+    else:
+        rows.append(("Coverage", f"unknown (34={cp})", "34"))
+    consumed_base.add("34")
+
+    # Sub-state from field 3 (paused / returning / dock indicators)
+    if isinstance(f3, dict):
+        paused = f3.get("2") == 1
+        returning = f3.get("7") == 1
+        sub = []
+        if paused:
+            sub.append("paused")
+        if returning:
+            sub.append("returning")
+        rows.append((
+            "Sub-state", ", ".join(sub) or "-",
+            f"3.2={f3.get('2')} 3.7={f3.get('7')}",
+        ))
+        rows.append((
+            "Dock 3.x",
+            f"presence={f3.get('3')} sub={f3.get('10')} activity={f3.get('12')}",
+            "3.3 / 3.10 / 3.12",
+        ))
+
+    # Top-level dock indicators (mirrors of field 3 sub-fields)
+    rows.append((
+        "Dock 11/47",
+        f"f11={bs.get('11')} (2=docked) f47={bs.get('47')} (3=docked)",
+        "11, 47",
+    ))
+    consumed_base.update({"11", "47"})
+
+    # Field 48: parse markers + clean-task config + error
+    entries = _f48_entries(bs)
+    markers: list[str] = []
+    err_info: dict[str, Any] | None = None
+    clean_cfg: dict[str, Any] | None = None
+    for e in entries:
+        if "10" in e:
+            markers.append("dust_bag_drying")
+        if "13" in e:
+            markers.append("mop_drying")
+        if "15" in e:
+            markers.append("legacy_15?")
+        if "5" in e and isinstance(e.get("5"), dict):
+            clean_cfg = e["5"].get("1") if isinstance(e["5"].get("1"), dict) else None
+        if "2" in e and isinstance(e.get("2"), dict) and e["2"]:
+            err_info = e["2"]
+    rows.append(("Station markers", ", ".join(markers) or "-", "48.1.*"))
+
+    # Active clean task config (when running)
+    if clean_cfg:
+        mode = clean_cfg.get("1")
+        mh = clean_cfg.get("2")
+        passes = clean_cfg.get("3")
+        cfg_str = (
+            f"{_CLEAN_MODE.get(mode, '?')} ({mode}), mop={_MOP_HUMIDITY.get(mh, mh)}"
+            + (f", passes={passes}" if passes else "")
+        )
+        rows.append(("Active task", cfg_str, "48.1.*.5.1"))
+    else:
+        rows.append(("Active task", "-", "48.1.*.5.1"))
+
+    # Error — also check the secondary channel at base.1 (different
+    # field order: 1=code, 2=severity, 3=formatted message banner).
+    if not err_info and isinstance(bs.get("1"), dict) and bs.get("1"):
+        f1 = bs["1"]
+        err_info = {
+            "1": f1.get("2"),
+            "2": f1.get("1"),
+            "3": f1.get("3", ""),
+        }
+    if err_info:
+        code = err_info.get("2")
+        msg = err_info.get("3", "")
+        sev = err_info.get("1", "?")
+        ident = _ERROR_CODES.get(code, "unknown") if isinstance(code, int) else "?"
+        rows.append((
+            "ERROR",
+            f"{ident} sev={sev} code={code} ({code:#010x})  «{str(msg)[:30]}»"
+            if isinstance(code, int) else f"sev={sev} {err_info!r}",
+            "48.1.*.2 / base.1",
+        ))
+    else:
+        rows.append(("Error", "none", "48.1.*.2"))
+    consumed_base.add("48")
+
+    # Session id (13) + last-update timestamp (36)
+    sid = bs.get("13")
+    if sid is not None:
+        sid_short = str(sid)[:24] + ("…" if len(str(sid)) > 24 else "")
+        rows.append(("Session ID", sid_short, "13"))
+        consumed_base.add("13")
+    ts36 = bs.get("36")
+    if ts36 is not None:
+        rows.append(("Timestamp (ms)", str(ts36), "36"))
+        consumed_base.add("36")
+
+    # Map signature: base.30 + base.44 form an opaque pair that flips
+    # between saved maps (live-confirmed by the multi-map test).
+    sig30 = bs.get("30")
+    sig44 = bs.get("44")
+    if sig30 is not None or sig44 is not None:
+        rows.append((
+            "Map signature",
+            f"30={sig30!s} 44={sig44!s}",
+            "30, 44",
+        ))
+    consumed_base.add("30")
+    consumed_base.add("44")
+
+    # User-action prompt: base.3.16 + ws.22 ({1: elapsed, 2: target}).
+    # Live-observed prompt types: 2=fill_water, 3=return_to_dock_after_clean,
+    # 4=carry_to_dock_to_start. Targets: 600 s (10 min) for fill / start,
+    # 3600 s (1 h) for end-of-clean return.
+    ua_type = f3.get("16") if isinstance(f3, dict) else None
+    f22 = ws.get("22") if isinstance(ws, dict) else None
+    if ua_type or (isinstance(f22, dict) and f22):
+        ua_names = {
+            2: "fill_water_tank",
+            3: "return_to_dock_after_clean",
+            4: "carry_to_dock_to_start",
+        }
+        elapsed = f22.get("1", 0) if isinstance(f22, dict) else 0
+        target = f22.get("2", 0) if isinstance(f22, dict) else 0
+        try:
+            elapsed_i = int(elapsed) if elapsed else 0
+            target_i = int(target) if target else 0
+        except (ValueError, TypeError):
+            elapsed_i = target_i = 0
+        if target_i > 0:
+            remaining = max(target_i - elapsed_i, 0)
+            timer = f"{elapsed_i}/{target_i}s ({remaining}s left)"
+        else:
+            timer = "-"
+        rows.append((
+            "User action",
+            f"{ua_names.get(ua_type, '?')} ({ua_type}) {timer}",
+            "3.16 + ws.22",
+        ))
+    else:
+        rows.append(("User action", "-", "3.16 + ws.22"))
+    consumed_ws.add("22")
+
+    # working_status: room queue (with completion flags) + current
+    # room + cleaning telemetry. Flow 2 ws.5[i].2 = 2 marks a finished room.
+    wf5 = ws.get("5") if isinstance(ws, dict) else None
+    queue_entries: list[dict[str, Any]] = []
+    if isinstance(wf5, list):
+        queue_entries = [e for e in wf5 if isinstance(e, dict)]
+    elif isinstance(wf5, dict):
+        queue_entries = [wf5]
+    if queue_entries:
+        rendered = [
+            f"{e.get('1')}{'✓' if e.get('2') == 2 else ''}"
+            for e in queue_entries
+        ]
+        rows.append(("Room queue", ", ".join(rendered), "ws.5 (✓=done)"))
+        done = [str(e.get("1")) for e in queue_entries if e.get("2") == 2]
+        rows.append(("Rooms done", ", ".join(done) or "-", "ws.5[*].2=2"))
+    else:
+        rows.append(("Room queue", "-", "ws.5"))
+        rows.append(("Rooms done", "-", "ws.5[*].2=2"))
+    consumed_ws.add("5")
+
+    cur = ws.get("6")
+    rows.append(("Current room", str(cur) if cur is not None else "-", "ws.6"))
+    consumed_ws.add("6")
+
+    # Flow 2: progress % (ws.1 float32) + cleaned area m² (ws.2 float32).
+    # Field 13 is a constant 18000 there, so prefer the float values.
+    progress = _f32(ws.get("1")) if "1" in ws else None
+    if progress is not None and 0 <= progress <= 200:
+        rows.append(("Cleaning progress", f"{progress:.1f} %", "ws.1 (float32)"))
+        consumed_ws.add("1")
+    area = _f32(ws.get("2")) if "2" in ws else None
+    if area is not None and 0 <= area <= 10000:
+        rows.append(("Clean area", f"{area:.2f} m²", "ws.2 (float32)"))
+        consumed_ws.add("2")
+    elif "13" in ws:
+        # Flow 1 fallback (cm²)
+        try:
+            area_m2 = int(ws["13"]) / 10000
+            rows.append(("Clean area (legacy)", f"{area_m2:.2f} m²", "ws.13"))
+        except (ValueError, TypeError):
+            pass
+        consumed_ws.add("13")
+
+    if "12" in ws:
+        rows.append(("Elapsed", f"{ws['12']} s", "ws.12"))
+        consumed_ws.add("12")
+
+    # Mop-drying timer (live-confirmed): ws.8 = elapsed seconds since
+    # drying started, ws.9 = total target seconds. Silent mode targets
+    # 18000 s (5 h); default / smart / strong target 12600 s (3.5 h).
+    if "8" in ws or "9" in ws:
+        elapsed = ws.get("8", 0)
+        target = ws.get("9", 0)
+        try:
+            elapsed_i = int(elapsed) if elapsed else 0
+            target_i = int(target) if target else 0
+        except (ValueError, TypeError):
+            elapsed_i = target_i = 0
+        if target_i > 0:
+            pct = (elapsed_i / target_i) * 100
+            rows.append((
+                "Mop drying",
+                f"{elapsed_i//60}:{elapsed_i%60:02} / {target_i//60}:{target_i%60:02} ({pct:.0f}%)",
+                "ws.8 / ws.9",
+            ))
+        elif elapsed_i:
+            rows.append(("Mop drying", f"{elapsed_i//60}:{elapsed_i%60:02} elapsed", "ws.8"))
+        consumed_ws.add("8")
+        consumed_ws.add("9")
+
+    return rows
+
+
+def _unknown_keys(
+    latest: dict[str, dict[str, Any]],
+    consumed_base: set[str],
+    consumed_ws: set[str],
+) -> list[tuple[str, str, str]]:
+    """Return (topic, key, raw repr) for fields not consumed by the decoder."""
+    out: list[tuple[str, str, str]] = []
+    bs = latest.get("status/robot_base_status") or {}
+    for k in sorted(bs.keys(), key=lambda x: int(x) if x.isdigit() else 999):
+        if k in consumed_base:
+            continue
+        out.append(("base", k, repr(bs[k])[:60]))
+    ws = latest.get("status/working_status") or {}
+    for k in sorted(ws.keys(), key=lambda x: int(x) if x.isdigit() else 999):
+        if k in consumed_ws:
+            continue
+        out.append(("working", k, repr(ws[k])[:60]))
+    return out
+
+
+
+def cmd_dashboard(args: argparse.Namespace) -> int:
+    """Live decoded-state dashboard (view only, no input handling).
+
+    Streams `ha core logs --follow` over SSH, decodes each broadcast,
+    and redraws an ANSI table on every state change. View-only: the
+    `record` subcommand handles annotations in a separate terminal,
+    which keeps typing latency-free regardless of how busy the dock is.
+    """
+    latest: dict[str, dict[str, Any]] = {}
+    last_payloads: dict[str, dict[str, Any]] = {}
+    last_change_label = "—"
+    counter = 0
+    # Hide the cursor while the dashboard is running.
+    sys.stdout.write("\033[?25l")
+    sys.stdout.flush()
+    try:
+        for line in _iter_log_stream(args.host, args.ssh_key):
+            m = DUMP_RE.match(line)
+            if not m:
+                continue
+            topic = m.group("topic")
+            log_ts = m.group("ts")
+            payload = _parse_payload(m.group("payload"))
+            counter += 1
+
+            changed = False
+            if isinstance(payload, dict):
+                prev = last_payloads.get(topic)
+                if topic == "status/robot_base_status":
+                    d = _diff_dict(prev, payload, _NOISE_BASE_KEYS)
+                    if d:
+                        last_change_label = f"[{log_ts}] base: " + ", ".join(d[:3])
+                        changed = True
+                elif topic == "status/working_status":
+                    d = _diff_dict(prev, payload, _NOISE_WS_KEYS)
+                    if d:
+                        last_change_label = f"[{log_ts}] ws: " + ", ".join(d[:3])
+                        changed = True
+                if prev != payload:
+                    changed = True
+                last_payloads[topic] = payload
+                latest[topic] = payload
+
+            if not changed:
+                continue
+
+            # Clear screen + move cursor home, then redraw.
+            out = ["\033[2J\033[H"]
+            out.append(f"narwal-dashboard · host={args.host} · broadcasts={counter}\n")
+            out.append("─" * 78 + "\n")
+            consumed_b: set[str] = set()
+            consumed_w: set[str] = set()
+            for label, value, raw in _decode_state(latest, consumed_b, consumed_w):
+                out.append(f"  {label:<16} {value:<48} [{raw}]\n")
+            out.append("\n  Raw / undecoded fields:\n")
+            for src, key, val in _unknown_keys(latest, consumed_b, consumed_w):
+                out.append(f"    {src}.{key:<6} = {val}\n")
+            out.append("\nΔ " + last_change_label + "\n")
+            sys.stdout.write("".join(out))
+            sys.stdout.flush()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        sys.stdout.write("\033[?25h\n")
+        sys.stdout.flush()
+    return 0
+
+
+def cmd_record(args: argparse.Namespace) -> int:
+    """Stream + annotate.
+
+    Records every broadcast to JSONL while the user types annotations
+    at a `> ` prompt. Pair with the `dashboard` subcommand in another
+    terminal to watch the decoded state live without affecting input.
+    """
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    lock = threading.Lock()
+    stop = threading.Event()
+    counter = [0]
+
+    print(
+        f"Recording to {out_path}.\n"
+        f"Type any text + Enter to mark an annotation. "
+        f"Empty line / Ctrl+D / Ctrl+C to stop.\n",
+        file=sys.stderr,
+    )
+
+    with out_path.open("a") as out_fp:
+        # Header line so each capture starts identifiable.
+        out_fp.write(json.dumps({
+            "kind": "session_start",
+            "ts": _now_iso(),
+            "host": args.host,
+        }) + "\n")
+        out_fp.flush()
+
+        worker = threading.Thread(
+            target=_writer_thread,
+            args=(args.host, out_fp, lock, stop, args.verbose, counter, args.ssh_key),
+            daemon=True,
+        )
+        worker.start()
+
+        try:
+            while True:
+                try:
+                    text = input("> ")
+                except (EOFError, KeyboardInterrupt):
+                    break
+                text = text.strip()
+                if not text:
+                    break
+                with lock:
+                    out_fp.write(json.dumps({
+                        "kind": "annotation",
+                        "ts": _now_iso(),
+                        "text": text,
+                    }) + "\n")
+                    out_fp.flush()
+                    print(f"    [annotated; {counter[0]} broadcasts so far]",
+                          file=sys.stderr)
+        finally:
+            stop.set()
+            print(f"\nStopped after {counter[0]} broadcasts.", file=sys.stderr)
+    return 0
+
+
+def _flatten(prefix: str, value: Any, out: dict[str, Any]) -> None:
+    """Flatten a nested dict to dotted-key form for diffing."""
+    if isinstance(value, dict):
+        if not value:
+            out[prefix] = "{}"
+            return
+        for k, v in value.items():
+            _flatten(f"{prefix}.{k}" if prefix else str(k), v, out)
+    elif isinstance(value, list):
+        for i, v in enumerate(value):
+            _flatten(f"{prefix}[{i}]", v, out)
+    else:
+        out[prefix] = value
+
+
+def _last_broadcasts(path: Path) -> dict[str, dict[str, Any]]:
+    """Return {topic: latest payload dict} from a JSONL capture."""
+    latest: dict[str, dict[str, Any]] = {}
+    with path.open() as fp:
+        for line in fp:
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if rec.get("kind") != "broadcast":
+                continue
+            topic = rec.get("topic")
+            payload = rec.get("payload")
+            if isinstance(payload, dict):
+                latest[topic] = payload
+    return latest
+
+
+def cmd_diff(args: argparse.Namespace) -> int:
+    """Show flat-key diffs between the latest broadcast per topic."""
+    a = _last_broadcasts(Path(args.left))
+    b = _last_broadcasts(Path(args.right))
+    topics = sorted(set(a) | set(b))
+    any_diff = False
+    for topic in topics:
+        if topic not in a:
+            print(f"+ {topic}: only in {args.right}")
+            any_diff = True
+            continue
+        if topic not in b:
+            print(f"- {topic}: only in {args.left}")
+            any_diff = True
+            continue
+        flat_a: dict[str, Any] = {}
+        flat_b: dict[str, Any] = {}
+        _flatten("", a[topic], flat_a)
+        _flatten("", b[topic], flat_b)
+        keys = sorted(set(flat_a) | set(flat_b))
+        topic_diffs = [
+            (k, flat_a.get(k, "<missing>"), flat_b.get(k, "<missing>"))
+            for k in keys
+            if flat_a.get(k) != flat_b.get(k)
+        ]
+        if topic_diffs:
+            any_diff = True
+            print(f"\n=== {topic} ===")
+            for k, l, r in topic_diffs:
+                print(f"  {k}: {l!r}  →  {r!r}")
+    if not any_diff:
+        print("No differences.")
+    return 0
+
+
+def cmd_replay(args: argparse.Namespace) -> int:
+    """Print the timeline grouped by annotation, one block per annotation."""
+    path = Path(args.file)
+    with path.open() as fp:
+        for line in fp:
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            kind = rec.get("kind")
+            if kind == "session_start":
+                print(f"[session @ {rec['ts']} on {rec.get('host', '?')}]")
+            elif kind == "annotation":
+                print(f"\n>>> {rec['ts']} :: {rec['text']}")
+            elif kind == "change":
+                ts = rec.get("log_ts", rec.get("ts", "?"))
+                short_topic = rec["topic"].rsplit("/", 1)[-1]
+                hint = ", ".join(rec.get("diff", [])[:6])
+                print(f"  [*] [{ts}] {short_topic}: {hint}")
+            elif kind == "broadcast" and args.full:
+                ts = rec.get("log_ts", rec.get("ts", "?"))
+                print(f"  [{ts}] {rec['topic']}: {rec['payload']!r}")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    rec = sub.add_parser("record", help="record annotated broadcasts")
+    rec.add_argument("--host", required=True, help="ssh target, e.g. root@192.168.178.3")
+    rec.add_argument("--ssh-key", help="optional private key for SSH")
+    rec.add_argument("--out", required=True, help="JSONL output path")
+    rec.add_argument(
+        "--verbose", "-v", action="store_true",
+        help="echo each broadcast on stderr (clutters the input prompt)",
+    )
+    rec.set_defaults(func=cmd_record)
+
+    dash = sub.add_parser(
+        "dashboard",
+        help="live decoded-state view (run in a separate terminal alongside `record`)",
+    )
+    dash.add_argument("--host", required=True, help="ssh target, e.g. root@192.168.178.3")
+    dash.add_argument("--ssh-key", help="optional private key for SSH")
+    dash.set_defaults(func=cmd_dashboard)
+
+    diff = sub.add_parser("diff", help="diff latest broadcast per topic between two captures")
+    diff.add_argument("left")
+    diff.add_argument("right")
+    diff.set_defaults(func=cmd_diff)
+
+    replay = sub.add_parser("replay", help="pretty-print a capture timeline")
+    replay.add_argument("file")
+    replay.add_argument(
+        "--full", action="store_true",
+        help="include every raw broadcast line (default: annotations + change hints only)",
+    )
+    replay.set_defaults(func=cmd_replay)
+
+    args = p.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

This PR expands Flow 2 support and improves the integration’s local discovery, diagnostics, and state decoding.

### Highlights
- Add new diagnostic entities for:
  - active errors
  - station tank errors
  - clean water tank errors
  - remote control mode
  - user-action-required state
- Add a mop humidity select entity
- Improve config flow discovery via mDNS and DHCP
- Expand model decoding and map rendering for richer live state
- Add capture/probing tools for reverse-engineering and validation
- Improve fan speed handling and add coverage for one-indexed fan levels
- Confirm room-by-room cleaning now works reliably end-to-end

### Notes
- Several changes are based on live testing against Flow 2 behavior and Narwal broadcasts.
- This PR is intended to consolidate the fork’s Flow 2 work into upstream.