### PR TITLE
fix(i18n): sync config-flow translations with code, drop orphaned string

### DIFF
--- a/custom_components/narwal/strings.json
+++ b/custom_components/narwal/strings.json
@@ -51,9 +51,6 @@
           "on": "Docked",
           "off": "Undocked"
         }
-      },
-      "charging": {
-        "name": "Charging"
       }
     }
   }

--- a/custom_components/narwal/translations/en.json
+++ b/custom_components/narwal/translations/en.json
@@ -3,10 +3,11 @@
     "step": {
       "user": {
         "title": "Connect to Narwal Vacuum",
-        "description": "Enter the IP address of your Narwal robot vacuum.",
+        "description": "Enter the IP address of your Narwal robot vacuum and select your model.",
         "data": {
           "host": "IP Address",
-          "port": "Port"
+          "port": "Port",
+          "model": "Model"
         }
       }
     },

--- a/custom_components/narwal/translations/fr.json
+++ b/custom_components/narwal/translations/fr.json
@@ -3,10 +3,11 @@
     "step": {
       "user": {
         "title": "Connexion à l’aspirateur Narwal",
-        "description": "Entrez l’adresse IP de votre robot aspirateur Narwal.",
+        "description": "Entrez l’adresse IP de votre robot aspirateur Narwal et sélectionnez votre modèle.",
         "data": {
           "host": "Adresse IP",
-          "port": "Port"
+          "port": "Port",
+          "model": "Modèle"
         }
       }
     },


### PR DESCRIPTION
## Summary

The config flow's model selector wasn't translated, and `strings.json` carried a
leftover translation key for an entity that doesn't exist. This aligns the
translation files with the code.

### Changes

- **`translations/en.json`, `translations/fr.json`**: add the missing `model`
  field label (Model / Modèle) for the config-flow step, and update the step
  description to match `strings.json` (it now mentions selecting the model).
- **`strings.json`**: remove the orphaned `entity.binary_sensor.charging` key.
  The only binary sensor is `docked`; charging is exposed as a regular sensor
  (`sensor.charging_state`, translation key `charging_state`), so this key
  matched no entity.

### Result

`strings.json`, `translations/en.json`, and `translations/fr.json` now share an
identical key set, and `strings.json`/`en.json` are content-identical for English
— so the model selector is labelled in both English and French, and Hassfest sees
consistent translations.

### Testing

- `pytest tests/` — 168 passed.
- JSON validated; key parity confirmed across strings/en/fr.
