### PR TITLE
fix(rooms): use the app's own RoomType→name strings; drop per-model overrides (#22)

### DIFF
--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -1292,10 +1292,7 @@ class NarwalClient:
     async def get_map(self) -> MapData:
         """Download the full map data."""
         resp = await self.send_command(TOPIC_CMD_GET_MAP, timeout=15.0)
-        product_key = ""
-        if self.state.device_info and self.state.device_info.product_key:
-            product_key = self.state.device_info.product_key
-        map_data = MapData.from_response(resp.data, product_key=product_key)
+        map_data = MapData.from_response(resp.data)
         self.state.map_data = map_data
         return map_data
 

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -40,28 +40,24 @@ class RoomInfo:
     instance_index: int = 0  # numbering for duplicates (field 8)
 
     # RoomType enum (MapBaseType.RoomType, 0-15) → the app's own en-US.json room-name strings. One shared switch (map_engine_i18n_configer.roomTypei18nKey) takes no model parameter, so every model resolves these same names. See #22.
-    ROOM_TYPE_NAMES: dict[int, str] = field(default=None, repr=False)
-
-    def __post_init__(self):
-        if self.ROOM_TYPE_NAMES is None:
-            object.__setattr__(self, "ROOM_TYPE_NAMES", {
-                0: "Room",
-                1: "Master bedroom",
-                2: "Secondary bedroom",
-                3: "Living room",
-                4: "Kitchen",
-                5: "Bathroom",
-                6: "Toilet",
-                7: "Balcony",
-                8: "Dining room",
-                9: "Closet",
-                10: "Corridor",
-                11: "Study",
-                12: "Kids' room",
-                13: "Entertainment room",
-                14: "Storage room",
-                15: "Others",
-            })
+    ROOM_TYPE_NAMES: ClassVar[dict[int, str]] = {
+        0: "Room",
+        1: "Master bedroom",
+        2: "Secondary bedroom",
+        3: "Living room",
+        4: "Kitchen",
+        5: "Bathroom",
+        6: "Toilet",
+        7: "Balcony",
+        8: "Dining room",
+        9: "Closet",
+        10: "Corridor",
+        11: "Study",
+        12: "Kids' room",
+        13: "Entertainment room",
+        14: "Storage room",
+        15: "Others",
+    }
 
     @property
     def display_name(self) -> str:

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -27,11 +27,7 @@ class RoomInfo:
 
     Fields from get_map / get_editable_map field 2.12:
       field 1: room_id (matches pixel value >> 8 in map grid)
-      field 2: room_sub_type — ROOM_TYPE enum from APK (0=unspecified,
-               1=main bedroom, 2=secondary room, 3=living room, 4=kitchen,
-               5=study, 6=bathroom, 7=dining room, 8=corridor, 9=balcony,
-               10=utility room, 11=cloak room, 12=nursery, 13=recreation,
-               14=shower room, 15=other)
+      field 2: room_sub_type — RoomType enum (MapBaseType.RoomType); see ROOM_TYPE_NAMES
       field 3: user-assigned name (UTF-8, empty if not named by user)
       field 4: category (1=room, 2=utility/small space)
       field 8: instance_index (1-based, for numbering duplicates: Bathroom 1, 2, 3...)
@@ -42,56 +38,37 @@ class RoomInfo:
     room_sub_type: int = 0  # ROOM_TYPE enum from field 2
     category: int = 0  # 1=room, 2=utility (field 4)
     instance_index: int = 0  # numbering for duplicates (field 8)
-    model_key: str = ""  # product_key — selects per-model name overrides
 
-    # ROOM_TYPE enum → default display name (from APK libapp.so string analysis)
+    # RoomType enum (MapBaseType.RoomType, 0-15) → the app's own en-US.json room-name strings. One shared switch (map_engine_i18n_configer.roomTypei18nKey) takes no model parameter, so every model resolves these same names. See #22.
     ROOM_TYPE_NAMES: dict[int, str] = field(default=None, repr=False)
-
-    # Per-model overrides where Narwal renamed sub-types between models.
-    # Confirmed on Narwal Flow 2 (QxMSPG6VSO, firmware v01.07.16.01) — see #22.
-    MODEL_ROOM_TYPE_OVERRIDES: ClassVar[dict[str, dict[int, str]]] = {
-        "QxMSPG6VSO": {  # Flow 2
-            1: "Master Bedroom",
-            5: "Bathroom",
-            10: "Corridor",
-        },
-    }
 
     def __post_init__(self):
         if self.ROOM_TYPE_NAMES is None:
             object.__setattr__(self, "ROOM_TYPE_NAMES", {
                 0: "Room",
-                1: "Primary Bedroom",
-                2: "Secondary Bedroom",
-                3: "Living Room",
+                1: "Master bedroom",
+                2: "Secondary bedroom",
+                3: "Living room",
                 4: "Kitchen",
-                5: "Study",
-                6: "Bathroom",
-                7: "Dining Room",
-                8: "Corridor",
-                9: "Balcony",
-                10: "Utility Room",
-                11: "Cloak Room",
-                12: "Nursery",
-                13: "Recreation Room",
-                14: "Shower Room",
-                15: "Other",
+                5: "Bathroom",
+                6: "Toilet",
+                7: "Balcony",
+                8: "Dining room",
+                9: "Closet",
+                10: "Corridor",
+                11: "Study",
+                12: "Kids' room",
+                13: "Entertainment room",
+                14: "Storage room",
+                15: "Others",
             })
 
     @property
     def display_name(self) -> str:
-        """Return user name if set, otherwise generate default from ROOM_TYPE enum.
-
-        Matches Narwal app behavior: unnamed rooms show their type name
-        with an instance number suffix for duplicates (e.g. "Bathroom 2").
-        Per-model overrides apply where Narwal renamed sub-types (e.g. Flow 2
-        renames sub_type 1 → "Master Bedroom" vs Flow 1's "Primary Bedroom").
-        """
+        """User name if set, else the RoomType default name, with an instance-number suffix for duplicates ("Bathroom 2")."""
         if self.name:
             return self.name
-        overrides = self.MODEL_ROOM_TYPE_OVERRIDES.get(self.model_key, {})
-        base = overrides.get(self.room_sub_type) or \
-            self.ROOM_TYPE_NAMES.get(self.room_sub_type, "Room")
+        base = self.ROOM_TYPE_NAMES.get(self.room_sub_type, "Room")
         if self.instance_index > 1:
             return f"{base} {self.instance_index}"
         return base
@@ -256,16 +233,8 @@ class MapData:
     raw: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def from_response(
-        cls, decoded: dict[str, Any], product_key: str = ""
-    ) -> MapData:
-        """Parse map data from a get_map field5 response.
-
-        Args:
-            decoded: blackboxprotobuf-decoded get_map response.
-            product_key: Device product key — propagated to RoomInfo so model-
-                specific room-type name overrides apply (see #22 for Flow 2).
-        """
+    def from_response(cls, decoded: dict[str, Any]) -> MapData:
+        """Parse map data from a get_map field5 response."""
         payload = decoded.get("2", {})
         if not payload:
             return cls()
@@ -292,7 +261,6 @@ class MapData:
                     room_sub_type=int(room.get("2", 0)),
                     category=int(room.get("4", 0)),
                     instance_index=int(room.get("8", 0)),
-                    model_key=product_key,
                 ))
 
         compressed = payload.get("17", b"")

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -1292,10 +1292,7 @@ class NarwalClient:
     async def get_map(self) -> MapData:
         """Download the full map data."""
         resp = await self.send_command(TOPIC_CMD_GET_MAP, timeout=15.0)
-        product_key = ""
-        if self.state.device_info and self.state.device_info.product_key:
-            product_key = self.state.device_info.product_key
-        map_data = MapData.from_response(resp.data, product_key=product_key)
+        map_data = MapData.from_response(resp.data)
         self.state.map_data = map_data
         return map_data
 

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -40,28 +40,24 @@ class RoomInfo:
     instance_index: int = 0  # numbering for duplicates (field 8)
 
     # RoomType enum (MapBaseType.RoomType, 0-15) → the app's own en-US.json room-name strings. One shared switch (map_engine_i18n_configer.roomTypei18nKey) takes no model parameter, so every model resolves these same names. See #22.
-    ROOM_TYPE_NAMES: dict[int, str] = field(default=None, repr=False)
-
-    def __post_init__(self):
-        if self.ROOM_TYPE_NAMES is None:
-            object.__setattr__(self, "ROOM_TYPE_NAMES", {
-                0: "Room",
-                1: "Master bedroom",
-                2: "Secondary bedroom",
-                3: "Living room",
-                4: "Kitchen",
-                5: "Bathroom",
-                6: "Toilet",
-                7: "Balcony",
-                8: "Dining room",
-                9: "Closet",
-                10: "Corridor",
-                11: "Study",
-                12: "Kids' room",
-                13: "Entertainment room",
-                14: "Storage room",
-                15: "Others",
-            })
+    ROOM_TYPE_NAMES: ClassVar[dict[int, str]] = {
+        0: "Room",
+        1: "Master bedroom",
+        2: "Secondary bedroom",
+        3: "Living room",
+        4: "Kitchen",
+        5: "Bathroom",
+        6: "Toilet",
+        7: "Balcony",
+        8: "Dining room",
+        9: "Closet",
+        10: "Corridor",
+        11: "Study",
+        12: "Kids' room",
+        13: "Entertainment room",
+        14: "Storage room",
+        15: "Others",
+    }
 
     @property
     def display_name(self) -> str:

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -27,11 +27,7 @@ class RoomInfo:
 
     Fields from get_map / get_editable_map field 2.12:
       field 1: room_id (matches pixel value >> 8 in map grid)
-      field 2: room_sub_type — ROOM_TYPE enum from APK (0=unspecified,
-               1=main bedroom, 2=secondary room, 3=living room, 4=kitchen,
-               5=study, 6=bathroom, 7=dining room, 8=corridor, 9=balcony,
-               10=utility room, 11=cloak room, 12=nursery, 13=recreation,
-               14=shower room, 15=other)
+      field 2: room_sub_type — RoomType enum (MapBaseType.RoomType); see ROOM_TYPE_NAMES
       field 3: user-assigned name (UTF-8, empty if not named by user)
       field 4: category (1=room, 2=utility/small space)
       field 8: instance_index (1-based, for numbering duplicates: Bathroom 1, 2, 3...)
@@ -42,56 +38,37 @@ class RoomInfo:
     room_sub_type: int = 0  # ROOM_TYPE enum from field 2
     category: int = 0  # 1=room, 2=utility (field 4)
     instance_index: int = 0  # numbering for duplicates (field 8)
-    model_key: str = ""  # product_key — selects per-model name overrides
 
-    # ROOM_TYPE enum → default display name (from APK libapp.so string analysis)
+    # RoomType enum (MapBaseType.RoomType, 0-15) → the app's own en-US.json room-name strings. One shared switch (map_engine_i18n_configer.roomTypei18nKey) takes no model parameter, so every model resolves these same names. See #22.
     ROOM_TYPE_NAMES: dict[int, str] = field(default=None, repr=False)
-
-    # Per-model overrides where Narwal renamed sub-types between models.
-    # Confirmed on Narwal Flow 2 (QxMSPG6VSO, firmware v01.07.16.01) — see #22.
-    MODEL_ROOM_TYPE_OVERRIDES: ClassVar[dict[str, dict[int, str]]] = {
-        "QxMSPG6VSO": {  # Flow 2
-            1: "Master Bedroom",
-            5: "Bathroom",
-            10: "Corridor",
-        },
-    }
 
     def __post_init__(self):
         if self.ROOM_TYPE_NAMES is None:
             object.__setattr__(self, "ROOM_TYPE_NAMES", {
                 0: "Room",
-                1: "Primary Bedroom",
-                2: "Secondary Bedroom",
-                3: "Living Room",
+                1: "Master bedroom",
+                2: "Secondary bedroom",
+                3: "Living room",
                 4: "Kitchen",
-                5: "Study",
-                6: "Bathroom",
-                7: "Dining Room",
-                8: "Corridor",
-                9: "Balcony",
-                10: "Utility Room",
-                11: "Cloak Room",
-                12: "Nursery",
-                13: "Recreation Room",
-                14: "Shower Room",
-                15: "Other",
+                5: "Bathroom",
+                6: "Toilet",
+                7: "Balcony",
+                8: "Dining room",
+                9: "Closet",
+                10: "Corridor",
+                11: "Study",
+                12: "Kids' room",
+                13: "Entertainment room",
+                14: "Storage room",
+                15: "Others",
             })
 
     @property
     def display_name(self) -> str:
-        """Return user name if set, otherwise generate default from ROOM_TYPE enum.
-
-        Matches Narwal app behavior: unnamed rooms show their type name
-        with an instance number suffix for duplicates (e.g. "Bathroom 2").
-        Per-model overrides apply where Narwal renamed sub-types (e.g. Flow 2
-        renames sub_type 1 → "Master Bedroom" vs Flow 1's "Primary Bedroom").
-        """
+        """User name if set, else the RoomType default name, with an instance-number suffix for duplicates ("Bathroom 2")."""
         if self.name:
             return self.name
-        overrides = self.MODEL_ROOM_TYPE_OVERRIDES.get(self.model_key, {})
-        base = overrides.get(self.room_sub_type) or \
-            self.ROOM_TYPE_NAMES.get(self.room_sub_type, "Room")
+        base = self.ROOM_TYPE_NAMES.get(self.room_sub_type, "Room")
         if self.instance_index > 1:
             return f"{base} {self.instance_index}"
         return base
@@ -256,16 +233,8 @@ class MapData:
     raw: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def from_response(
-        cls, decoded: dict[str, Any], product_key: str = ""
-    ) -> MapData:
-        """Parse map data from a get_map field5 response.
-
-        Args:
-            decoded: blackboxprotobuf-decoded get_map response.
-            product_key: Device product key — propagated to RoomInfo so model-
-                specific room-type name overrides apply (see #22 for Flow 2).
-        """
+    def from_response(cls, decoded: dict[str, Any]) -> MapData:
+        """Parse map data from a get_map field5 response."""
         payload = decoded.get("2", {})
         if not payload:
             return cls()
@@ -292,7 +261,6 @@ class MapData:
                     room_sub_type=int(room.get("2", 0)),
                     category=int(room.get("4", 0)),
                     instance_index=int(room.get("8", 0)),
-                    model_key=product_key,
                 ))
 
         compressed = payload.get("17", b"")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -596,12 +596,16 @@ class TestRoomInfoNames:
     """
 
     def test_shared_table_names(self) -> None:
-        """Sub-types resolve to the app's en-US.json room names."""
-        assert RoomInfo(room_sub_type=1).display_name == "Master bedroom"
-        assert RoomInfo(room_sub_type=3).display_name == "Living room"
-        assert RoomInfo(room_sub_type=6).display_name == "Toilet"
-        assert RoomInfo(room_sub_type=9).display_name == "Closet"
-        assert RoomInfo(room_sub_type=13).display_name == "Entertainment room"
+        """Every RoomType resolves to its verbatim en-US.json name."""
+        expected = {
+            0: "Room", 1: "Master bedroom", 2: "Secondary bedroom",
+            3: "Living room", 4: "Kitchen", 5: "Bathroom", 6: "Toilet",
+            7: "Balcony", 8: "Dining room", 9: "Closet", 10: "Corridor",
+            11: "Study", 12: "Kids' room", 13: "Entertainment room",
+            14: "Storage room", 15: "Others",
+        }
+        for sub_type, name in expected.items():
+            assert RoomInfo(room_sub_type=sub_type).display_name == name
 
     def test_user_assigned_name_wins(self) -> None:
         """A user-assigned name always wins over the table."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -589,48 +589,36 @@ class TestParseObstacles:
 
 
 
-class TestRoomInfoModelOverrides:
-    """Tests for per-model ROOM_TYPE_NAMES overrides (issue #22)."""
+class TestRoomInfoNames:
+    """Tests for the shared RoomType→name table (issue #22).
 
-    def test_flow_1_uses_default_names(self) -> None:
-        """Flow 1 (no/empty model_key) keeps the original sub-type names."""
-        room = RoomInfo(room_id=1, room_sub_type=1)
-        assert room.display_name == "Primary Bedroom"
-        room = RoomInfo(room_id=5, room_sub_type=5)
-        assert room.display_name == "Study"
-        room = RoomInfo(room_id=10, room_sub_type=10)
-        assert room.display_name == "Utility Room"
+    The app names rooms through one switch keyed only on the RoomType enum (no model parameter), so every model resolves the same names — taken verbatim from the app's en-US.json.
+    """
 
-    def test_flow_2_overrides_apply(self) -> None:
-        """Flow 2 product key renames sub-types 1, 5, 10."""
-        flow2 = "QxMSPG6VSO"
-        assert RoomInfo(room_sub_type=1, model_key=flow2).display_name == "Master Bedroom"
-        assert RoomInfo(room_sub_type=5, model_key=flow2).display_name == "Bathroom"
-        assert RoomInfo(room_sub_type=10, model_key=flow2).display_name == "Corridor"
+    def test_shared_table_names(self) -> None:
+        """Sub-types resolve to the app's en-US.json room names."""
+        assert RoomInfo(room_sub_type=1).display_name == "Master bedroom"
+        assert RoomInfo(room_sub_type=3).display_name == "Living room"
+        assert RoomInfo(room_sub_type=6).display_name == "Toilet"
+        assert RoomInfo(room_sub_type=9).display_name == "Closet"
+        assert RoomInfo(room_sub_type=13).display_name == "Entertainment room"
 
-    def test_flow_2_non_overridden_types_use_defaults(self) -> None:
-        """Sub-types not in the Flow 2 override map use the base names."""
-        flow2 = "QxMSPG6VSO"
-        assert RoomInfo(room_sub_type=3, model_key=flow2).display_name == "Living Room"
-        assert RoomInfo(room_sub_type=4, model_key=flow2).display_name == "Kitchen"
-        assert RoomInfo(room_sub_type=6, model_key=flow2).display_name == "Bathroom"
-
-    def test_user_assigned_name_wins_over_override(self) -> None:
-        """A user-assigned name always wins, regardless of model overrides."""
-        room = RoomInfo(
-            room_sub_type=5, model_key="QxMSPG6VSO", name="Powder Room"
-        )
+    def test_user_assigned_name_wins(self) -> None:
+        """A user-assigned name always wins over the table."""
+        room = RoomInfo(room_sub_type=5, name="Powder Room")
         assert room.display_name == "Powder Room"
 
-    def test_instance_index_appends_to_overridden_name(self) -> None:
-        """Duplicate Flow 2 bathrooms number as Bathroom 2, 3..."""
-        room = RoomInfo(
-            room_sub_type=5, model_key="QxMSPG6VSO", instance_index=2
-        )
+    def test_instance_index_appends(self) -> None:
+        """Duplicate rooms get an instance-number suffix (Bathroom 2)."""
+        room = RoomInfo(room_sub_type=5, instance_index=2)
         assert room.display_name == "Bathroom 2"
 
-    def test_map_data_from_response_propagates_product_key(self) -> None:
-        """get_map parse pushes product_key into every RoomInfo."""
+    def test_unknown_sub_type_falls_back_to_room(self) -> None:
+        """An out-of-range sub-type falls back to the default name."""
+        assert RoomInfo(room_sub_type=99).display_name == "Room"
+
+    def test_map_data_from_response_resolves_names(self) -> None:
+        """get_map parse resolves room names via the shared table."""
         decoded = {
             "2": {
                 "12": [
@@ -639,14 +627,6 @@ class TestRoomInfoModelOverrides:
                 ],
             }
         }
-        map_data = MapData.from_response(decoded, product_key="QxMSPG6VSO")
-        names = [r.display_name for r in map_data.rooms]
-        assert names == ["Master Bedroom", "Bathroom 2"]
-
-    def test_map_data_from_response_default_no_key(self) -> None:
-        """Omitting product_key keeps the original behavior unchanged."""
-        decoded = {
-            "2": {"12": [{"1": 1, "2": 1, "3": b"", "4": 1, "8": 1}]},
-        }
         map_data = MapData.from_response(decoded)
-        assert map_data.rooms[0].display_name == "Primary Bedroom"
+        names = [r.display_name for r in map_data.rooms]
+        assert names == ["Master bedroom", "Bathroom 2"]

--- a/tests/test_vacuum_segments.py
+++ b/tests/test_vacuum_segments.py
@@ -129,7 +129,7 @@ class TestAsyncGetSegments:
 
         names = {s.id: s.name for s in result}
         assert names["1"] == "Master Suite"
-        assert names["2"] == "Bathroom 2"
+        assert names["2"] == "Toilet 2"
 
     async def test_segment_groups_by_category(self) -> None:
         """Category 1 -> group='Rooms', category 2 -> group='Utility'."""


### PR DESCRIPTION
## Summary

Unnamed rooms were getting the wrong type label. The base `ROOM_TYPE_NAMES` table
was mis-derived (shifted from index 5 on — `5→Study`, `8→Corridor`, `11→Cloak Room`…),
and a per-`product_key` override map had been bolted on to patch it. This replaces
both with the app's own room-type names, verified by reverse-engineering the Narwal app.

Addresses #22.

## Evidence (from the decompiled app)

Room-type naming in the app is **model-independent** — there is nothing to override:

1. **One shared switch, keyed only on the enum.** `MapEnginei18nConfiger.roomTypei18nKey(int)`
   takes just the `RoomType` int — no `product_key`/`model`/`device`/`sn` argument, and it
   reads no instance state. It maps the enum to `map_room_name_*` i18n keys.
2. **One shared enum.** `MapBaseType.RoomType` has 16 constants; the switch handles them in
   value order 0–15.
3. **One shared localization.** Those keys resolve through a single `en-US.json` in the app's
   shared `app_res_config` package — not per-model.
4. **Live-confirmed.** A production Flow 2 matched the mapping at values 3/4/8/11
   (Living room, Kitchen, Dining room, Study).

The resulting table is taken **verbatim** from the app's `en-US.json`:

> 0 Room · 1 Master bedroom · 2 Secondary bedroom · 3 Living room · 4 Kitchen ·
> 5 Bathroom · 6 Toilet · 7 Balcony · 8 Dining room · 9 Closet · 10 Corridor ·
> 11 Study · 12 Kids' room · 13 Entertainment room · 14 Storage room · 15 Others

## Changes

- **`narwal_client/models.py`** (and the embedded `custom_components/narwal/narwal_client/`
  copy): set `ROOM_TYPE_NAMES` to the verbatim app strings; remove `MODEL_ROOM_TYPE_OVERRIDES`,
  the `RoomInfo.model_key` field, and the override lookup in `display_name`; drop the now-unused
  `product_key` parameter from `MapData.from_response`; fix the stale `RoomInfo` field-2 docstring
  (it still listed the old, wrong enum).
- **`narwal_client/client.py`** (and embedded copy): `get_map()` no longer computes/passes a
  `product_key` to `from_response`.
- **`tests/test_models.py`**: rewrite `TestRoomInfoModelOverrides` → `TestRoomInfoNames` (the
  override premise is gone); assert the verbatim names, including values that were previously
  paraphrased.
- **`tests/test_vacuum_segments.py`**: segment-name assertion updated (`Toilet 2`).

## Testing

- `pytest tests/` — 166 passed.
- Verified live on a Flow 2: HA showed a "rooms changed" remap and unnamed rooms now read the
  correct labels (Study, Dining room, …).

---

<sup><b>Footnote — localization (out of scope for this PR):</b> the app ships these names in 23
locales, so the integration could later localize unnamed-room type labels to the user's Home
Assistant language. Some locales are untranslated stubs (e.g. <code>pt-BR</code> ships the keys
empty), so such a follow-up would need an English fallback. User-assigned room names are
unaffected — they pass through as-is regardless of language.</sup>
