### PR TITLE
feat(sensor): audit base_status fields, add station/consumable diagnostics

### DIFF
--- a/custom_components/narwal/binary_sensor.py
+++ b/custom_components/narwal/binary_sensor.py
@@ -2,16 +2,105 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
+    BinarySensorEntityDescription,
 )
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .narwal_client import NarwalState
+
 from . import NarwalConfigEntry
+from .const import ERROR_HELP_URL_TEMPLATE
 from .coordinator import NarwalCoordinator
 from .entity import NarwalEntity
+
+
+@dataclass(frozen=True, kw_only=True)
+class NarwalBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Describes a Narwal binary sensor; value_fn returns None when unavailable."""
+
+    value_fn: Callable[[NarwalState], bool | None]
+    attrs_fn: Callable[[NarwalState], dict[str, Any] | None] | None = None
+
+
+def _tank_problem(attr: str, bad: frozenset[int]) -> Callable[[NarwalState], bool | None]:
+    """A station tank/bag state is a problem when its enum value is one of `bad`.
+
+    The state attr is None when this model doesn't report that field, which
+    keeps the entity unavailable rather than asserting "OK".
+    """
+    def fn(state: NarwalState) -> bool | None:
+        value = getattr(state, attr)
+        return None if value is None else value in bad
+    return fn
+
+
+# Station tank/bag problem sensors. Bad-value sets come from the decoded enums
+# (RobotBaseStatus.pbenum): every named value ≥ 2 is an attention state
+# (empty / abnormal / not-installed / suggest-replace); 0=unspecified, 1=ok.
+BINARY_SENSOR_DESCRIPTIONS: tuple[NarwalBinarySensorEntityDescription, ...] = (
+    NarwalBinarySensorEntityDescription(
+        key="error",
+        translation_key="error",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        # base_status field 1 errorCode: empty when healthy, populated on a fault.
+        value_fn=lambda s: s.has_error if s.raw_base_status else None,
+        # Expose the fault detail (numeric code(s), severity, debug string, help link) when present.
+        attrs_fn=lambda s: {
+            "codes": s.error_codes,
+            "level": s.error_level,
+            "detail": s.error_detail,
+            **(
+                {"help_url": ERROR_HELP_URL_TEMPLATE.format(code=s.error_codes[0])}
+                if s.error_codes else {}
+            ),
+        } if s.raw_base_status else None,
+    ),
+    NarwalBinarySensorEntityDescription(
+        key="clean_water_tank",
+        translation_key="clean_water_tank",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_tank_problem("clean_water_tank_state", frozenset({2, 3, 4})),
+    ),
+    NarwalBinarySensorEntityDescription(
+        key="sewage_tank",
+        translation_key="sewage_tank",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_tank_problem("sewage_tank_state", frozenset({2, 3})),
+    ),
+    NarwalBinarySensorEntityDescription(
+        key="dust_box",
+        translation_key="dust_box",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_tank_problem("dust_box_state", frozenset({2, 3, 4})),
+    ),
+    NarwalBinarySensorEntityDescription(
+        key="dust_bag",
+        translation_key="dust_bag",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_tank_problem("dust_bag_state", frozenset({2, 3, 4})),
+    ),
+    NarwalBinarySensorEntityDescription(
+        key="station_bag",
+        translation_key="station_bag",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_tank_problem("station_bag_state", frozenset({2, 3, 4})),
+    ),
+)
 
 
 async def async_setup_entry(
@@ -21,9 +110,12 @@ async def async_setup_entry(
 ) -> None:
     """Set up Narwal binary sensor entities."""
     coordinator = entry.runtime_data
-    async_add_entities([
-        NarwalDockedSensor(coordinator),
-    ])
+    entities: list[BinarySensorEntity] = [NarwalDockedSensor(coordinator)]
+    entities += [
+        NarwalBinarySensor(coordinator, description)
+        for description in BINARY_SENSOR_DESCRIPTIONS
+    ]
+    async_add_entities(entities)
 
 
 class NarwalDockedSensor(NarwalEntity, BinarySensorEntity):
@@ -46,3 +138,34 @@ class NarwalDockedSensor(NarwalEntity, BinarySensorEntity):
         return state.is_docked
 
 
+class NarwalBinarySensor(NarwalEntity, BinarySensorEntity):
+    """A description-driven Narwal binary sensor (fault / station consumables)."""
+
+    entity_description: NarwalBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: NarwalCoordinator,
+        description: NarwalBinarySensorEntityDescription,
+    ) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        device_id = coordinator.config_entry.data["device_id"]
+        self._attr_unique_id = f"{device_id}_{description.key}"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the sensor value (None = unavailable)."""
+        state = self.coordinator.data
+        if state is None:
+            return None
+        return self.entity_description.value_fn(state)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Optional per-sensor attributes (e.g. fault code detail)."""
+        state = self.coordinator.data
+        if state is None or self.entity_description.attrs_fn is None:
+            return None
+        return self.entity_description.attrs_fn(state)

--- a/custom_components/narwal/const.py
+++ b/custom_components/narwal/const.py
@@ -39,3 +39,11 @@ FAN_SPEED_MAP: dict[str, FanLevel] = {
 }
 
 FAN_SPEED_LIST: list[str] = list(FAN_SPEED_MAP.keys())
+
+# Best-effort help-center deep link for a robot error code. The app's goHelpCenterByCode
+# builds <localized help base>?code=<n>&deviceId=…&lang=…; the exact base is a runtime
+# i18n value we can't read, so this is inferred from the Flow's help-center family and
+# should be corrected if a real error opens a different path. The raw code is the fallback.
+ERROR_HELP_URL_TEMPLATE = (
+    "https://help.narwal.com/helpcenter/vall/#/p2/question/all?eType=1&code={code}&lang=en-US"
+)

--- a/custom_components/narwal/narwal_client/const.py
+++ b/custom_components/narwal/narwal_client/const.py
@@ -146,6 +146,11 @@ class CommandResult(IntEnum):
 class WorkingStatus(IntEnum):
     """Robot working state from robot_base_status field 3 → sub-field 1.
 
+    These values are EMPIRICAL and intentionally do NOT match the app's compiled
+    RobotTaskStatus.TaskType enum (sub-field 1's declared type): on this firmware
+    the robot reports e.g. 14=charged where TaskType 14=WASH_AND_DRY_MOP. Trust
+    the live-observed mapping below, not re/ENUMS.md, for this field (and f47).
+
     Values confirmed via live WebSocket monitoring:
       1  = STANDBY (idle, transition state between cleaning and docked)
       2  = DOCKED_V2 (on dock; confirmed v01.07.23.00 while charging at 10-36%)
@@ -197,28 +202,42 @@ class MopHumidity(IntEnum):
 
 # robot_base_status field numbers
 class BaseStatusField(IntEnum):
-    """Field numbers in the robot_base_status protobuf message.
+    """Field numbers in the robot_base_status (RobotBaseStatus) message.
 
-    Battery notes (confirmed via 35-min monitor capture, 2026-02-27):
-      Field 2  = real-time battery level as IEEE 754 float32
-                 (e.g. 1118175232 → 83.0%, matching app display ~84%)
-      Field 38 = static battery health (always 100; design capacity, not SOC)
+    Names from the decompiled BuilderInfo, several live-validated on dock.
+    Field 2 is float32 (PbFieldType 0x100), e.g. 1120403456 → 100.0.
+    Most state fields (5,11,12,14,15,20-24,26,28,29,31,33,39,40,42,47,49,50)
+    are enums whose value→label tables are not yet decoded.
     """
 
-    BATTERY_LEVEL = 2  # real-time SOC as float32 — CONFIRMED
-    MODE_STATE = 3
-    SESSION_ID = 13
-    SENSOR_DATA = 25
-    TIMESTAMP = 36
-    BATTERY_HEALTH = 38  # static, always 100 (design capacity)
-    BATTERY_CAPACITY = 41
+    ERROR_CODE = 1  # repeated ErrorCode; empty when no fault
+    BATTERY_LEVEL = 2  # batteryPercentage, float32
+    ROBOT_TASK_STATUS = 3  # nested task-status message
+    BINDED_UUID = 13  # bound account/device UUID (string)
+    CLEAN_WATER_TANK_STATE = 23  # enum
+    SEWAGE_TANK_STATE = 24  # enum
+    DEVICE_STATUS_CODE_LIST = 25
+    FAN_LEVEL = 26  # active suction (FanLevel enum)
+    MOP_HUMIDITY = 29  # active water level (MopHumidity enum)
+    STATION_BAG_HEALTH_SCORE = 35  # float32, %
+    STATION_BAG_HEALTH_RESET_TIME = 36  # epoch
+    CURING_AGENT_CONSUMPTION_PERCENT = 38
+    HEAVY_DETERGENT_REMAIN_PERCENT = 41
+    CHARGING_STATUS = 47  # canonical charging state (enum)
 
 
-# upgrade_status field numbers
+# upgrade_status field numbers (OTAUpgradeStatus)
 class UpgradeStatusField(IntEnum):
-    """Field numbers in the upgrade_status protobuf message."""
+    """Field numbers in the upgrade_status (OTAUpgradeStatus) message.
 
-    STATUS_CODE = 4
+    Names from the decompiled BuilderInfo: 1 type, 2 status, 3 progress,
+    4 stage, 5 errorCode, 6 detailErrorCode, 7 currentVersion, 8 targetVersion.
+    """
+
+    STATUS = 2
+    PROGRESS = 3
+    STAGE = 4
+    ERROR_CODE = 5
     CURRENT_FIRMWARE = 7
     TARGET_FIRMWARE = 8
 

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -494,16 +494,15 @@ class NarwalState:
     # Core status
     working_status: WorkingStatus = WorkingStatus.UNKNOWN
     battery_level: int = 0  # real-time SOC from field 2 (float32)
-    battery_health: int = 0  # static design capacity from field 38 (always 100)
     firmware_version: str = ""
     firmware_target: str = ""
 
     # Device identity
     device_info: DeviceInfo | None = None
 
-    # Session
-    session_id: str = ""
-    timestamp: int = 0
+    # Identity / station maintenance (base_status)
+    binded_uuid: str = ""  # field 13 — bound account/device UUID
+    station_bag_health_reset_time: int = 0  # field 36 — epoch of last bag-health reset
 
     # Position (from map data)
     position: Position | None = None
@@ -512,14 +511,31 @@ class NarwalState:
     cleaning_area: float = 0.0  # m² (coveredArea)
     cleaning_time: int = 0  # seconds
 
+    # Consumables / station / fault (base_status; present on dock and during cleaning)
+    dust_bag_health: float = 0.0  # field 35 stationBagHealthScore (%)
+    detergent_remaining: int = 0  # field 41 heavyDetergentRemainPercent (%)
+    curing_agent_consumption_percent: int = 0  # field 38
+    has_error: bool = False  # field 1 errorCode has an active code
+    error_codes: list[int] = field(default_factory=list)  # field 1 ErrorCode.identityCode(s)
+    error_level: int = 0  # ErrorCode.level (field 1 sub-2)
+    error_detail: str = ""  # ErrorCode.debugDetail (field 1 sub-3)
+
+    # Station tank/bag enum states (base_status; None = not reported by this model).
+    # 0=unspecified, 1=ok/installed, ≥2=attention (empty/abnormal/replace) — see BaseStatusField.
+    clean_water_tank_state: int | None = None  # field 23 (CleanWaterTankState)
+    sewage_tank_state: int | None = None  # field 24 (SewageTankState)
+    dust_box_state: int | None = None  # field 20 (DustBoxState)
+    dust_bag_state: int | None = None  # field 21 (DustBagState)
+    station_bag_state: int | None = None  # field 39 (StationBagStatus)
+
     # Map
     map_data: MapData | None = None
     map_display_data: MapDisplayData | None = None
 
-    # Vision obstacles (camera-detected transient objects during cleaning)
-    # Download/upgrade status
-    download_status: int = 0
-    upgrade_status_code: int = 0
+    # Download / upgrade status
+    download_status: int = 0  # download_status field 3 (state)
+    upgrade_status: int = 0  # upgrade_status field 2 (status)
+    upgrade_stage: int = 0  # upgrade_status field 4 (stage)
 
     # Pause overlay (field 3 sub-field 2 = 1 means paused)
     is_paused: bool = False
@@ -736,24 +752,75 @@ class NarwalState:
                 type(field3).__name__, field3,
             )
         if "2" in decoded:
-            # Field 2 = real-time battery SOC as float32
+            # Field 2 = real-time battery SOC as float32 (batteryPercentage)
             # (e.g. 1118175232 → 83.0%; bbp may return int or float)
             bat = _to_float32(decoded["2"])
             if bat is not None:
                 self.battery_level = round(bat)
-        if "38" in decoded:
-            # Field 38 = static battery health (always 100, design capacity)
-            self.battery_health = int(decoded["38"])
-        if "36" in decoded:
-            self.timestamp = int(decoded["36"])
+        self._update_consumables(decoded)
         if "13" in decoded:
             raw = decoded["13"]
             if isinstance(raw, bytes):
-                self.session_id = raw.decode("utf-8", errors="replace")
+                self.binded_uuid = raw.decode("utf-8", errors="replace")
             else:
-                self.session_id = str(raw)
-                if self.session_id.startswith("b'"):
-                    self.session_id = self.session_id[2:-1]
+                self.binded_uuid = str(raw)
+                if self.binded_uuid.startswith("b'"):
+                    self.binded_uuid = self.binded_uuid[2:-1]
+
+    def _update_consumables(self, decoded: dict[str, Any]) -> None:
+        """Parse base_status consumable/station/fault fields — hardware-sampled, so trustworthy even in deep-sleep battery-only updates."""
+        if "35" in decoded:
+            score = _to_float32(decoded["35"])
+            if score is not None:
+                self.dust_bag_health = score
+        if "41" in decoded:
+            self.detergent_remaining = int(decoded["41"])
+        if "38" in decoded:
+            self.curing_agent_consumption_percent = int(decoded["38"])
+        if "36" in decoded:
+            self.station_bag_health_reset_time = int(decoded["36"])
+        if "1" in decoded:
+            self._parse_error_codes(decoded["1"])
+        for attr, key in (
+            ("clean_water_tank_state", "23"), ("sewage_tank_state", "24"),
+            ("dust_box_state", "20"), ("dust_bag_state", "21"),
+            ("station_bag_state", "39"),
+        ):
+            if key in decoded:
+                try:
+                    setattr(self, attr, int(decoded[key]))
+                except (ValueError, TypeError):
+                    pass
+
+    def _parse_error_codes(self, raw: Any) -> None:
+        """Decode base_status field 1 (repeated ErrorCode{1:identityCode, 2:level, 3:debugDetail}).
+
+        Empty/zero codes mean no active fault. bbp gives a dict for one entry, a list for many.
+        """
+        entries = raw if isinstance(raw, list) else [raw] if isinstance(raw, dict) else []
+        codes: list[int] = []
+        level = 0
+        detail = ""
+        for entry in entries:
+            if not isinstance(entry, dict) or not entry.get("1"):
+                continue
+            try:
+                codes.append(int(entry["1"]))
+            except (ValueError, TypeError):
+                continue
+            try:
+                level = max(level, int(entry.get("2", 0)))
+            except (ValueError, TypeError):
+                pass
+            raw_detail = entry.get("3")
+            if isinstance(raw_detail, bytes):
+                detail = detail or raw_detail.decode("utf-8", errors="replace")
+            elif isinstance(raw_detail, str):
+                detail = detail or raw_detail
+        self.error_codes = codes
+        self.error_level = level
+        self.error_detail = detail
+        self.has_error = bool(codes)
 
     def update_battery_from_base_status(self, decoded: dict[str, Any]) -> None:
         """Update ONLY hardware-sampled fields from a base_status response.
@@ -768,13 +835,13 @@ class NarwalState:
             bat = _to_float32(decoded["2"])
             if bat is not None:
                 self.battery_level = round(bat)
-        if "38" in decoded:
-            self.battery_health = int(decoded["38"])
-        if "36" in decoded:
-            self.timestamp = int(decoded["36"])
+        self._update_consumables(decoded)
 
     def update_from_upgrade_status(self, decoded: dict[str, Any]) -> None:
-        """Update state from a decoded upgrade_status message."""
+        """Update state from a decoded upgrade_status message.
+
+        Fields: 2 status, 4 stage, 7 currentVersion, 8 targetVersion.
+        """
         if "7" in decoded:
             raw = decoded["7"]
             if isinstance(raw, bytes):
@@ -791,10 +858,15 @@ class NarwalState:
                 self.firmware_target = str(raw)
                 if self.firmware_target.startswith("b'"):
                     self.firmware_target = self.firmware_target[2:-1]
+        if "2" in decoded:
+            self.upgrade_status = int(decoded["2"])
         if "4" in decoded:
-            self.upgrade_status_code = int(decoded["4"])
+            self.upgrade_stage = int(decoded["4"])
 
     def update_from_download_status(self, decoded: dict[str, Any]) -> None:
-        """Update state from a decoded download_status message."""
-        if "1" in decoded:
-            self.download_status = int(decoded["1"])
+        """Update state from a decoded download_status message (voice/timbre pack).
+
+        Field 3 = state; field 1 is `type` (download category), not status.
+        """
+        if "3" in decoded:
+            self.download_status = int(decoded["3"])

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -779,8 +779,8 @@ class NarwalState:
             self.curing_agent_consumption_percent = int(decoded["38"])
         if "36" in decoded:
             self.station_bag_health_reset_time = int(decoded["36"])
-        if "1" in decoded:
-            self._parse_error_codes(decoded["1"])
+        # Always reparse (even when field 1 is absent) — protobuf omits an empty repeated field, so a recovered robot drops it; without this the prior fault would stick forever.
+        self._parse_error_codes(decoded.get("1"))
         for attr, key in (
             ("clean_water_tank_state", "23"), ("sewage_tank_state", "24"),
             ("dust_box_state", "20"), ("dust_bag_state", "21"),
@@ -823,12 +823,9 @@ class NarwalState:
         self.has_error = bool(codes)
 
     def update_battery_from_base_status(self, decoded: dict[str, Any]) -> None:
-        """Update ONLY hardware-sampled fields from a base_status response.
+        """Update only the trustworthy hardware-sampled fields (battery + consumable/station/fault/tank state, via _update_consumables) from a base_status response.
 
-        Used when the robot is not broadcasting (deep sleep on dock).
-        In this mode, get_status() returns current battery (hardware counter)
-        but stale working_status (firmware cache from last active session).
-        We update only the fields we can trust.
+        Used when the robot is not broadcasting (deep sleep on dock): get_status() returns a current battery counter but a stale working_status (firmware cache from the last active session), so working_status is deliberately skipped.
         """
         self.raw_base_status = decoded
         if "2" in decoded:

--- a/custom_components/narwal/sensor.py
+++ b/custom_components/narwal/sensor.py
@@ -61,6 +61,28 @@ SENSOR_DESCRIPTIONS: tuple[NarwalSensorEntityDescription, ...] = (
         else None,
     ),
     NarwalSensorEntityDescription(
+        key="dust_bag_health",
+        translation_key="dust_bag_health",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        # base_status field 35 stationBagHealthScore (float32 %); present only with a station.
+        value_fn=lambda state: round(state.dust_bag_health, 1)
+        if "35" in state.raw_base_status
+        else None,
+    ),
+    NarwalSensorEntityDescription(
+        key="detergent_remaining",
+        translation_key="detergent_remaining",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        # base_status field 41 heavyDetergentRemainPercent.
+        value_fn=lambda state: state.detergent_remaining
+        if "41" in state.raw_base_status
+        else None,
+    ),
+    NarwalSensorEntityDescription(
         key="firmware_version",
         translation_key="firmware_version",
         entity_category=EntityCategory.DIAGNOSTIC,

--- a/custom_components/narwal/strings.json
+++ b/custom_components/narwal/strings.json
@@ -35,6 +35,12 @@
       "firmware_version": {
         "name": "Firmware version"
       },
+      "dust_bag_health": {
+        "name": "Dust bag health"
+      },
+      "detergent_remaining": {
+        "name": "Detergent remaining"
+      },
       "charging_state": {
         "name": "Charging",
         "state": {
@@ -51,6 +57,28 @@
           "on": "Docked",
           "off": "Undocked"
         }
+      },
+      "error": {
+        "name": "Error",
+        "state": {
+          "on": "Problem",
+          "off": "OK"
+        }
+      },
+      "clean_water_tank": {
+        "name": "Clean water tank"
+      },
+      "sewage_tank": {
+        "name": "Sewage tank"
+      },
+      "dust_box": {
+        "name": "Dust box"
+      },
+      "dust_bag": {
+        "name": "Dust bag"
+      },
+      "station_bag": {
+        "name": "Station dust bag"
       }
     }
   }

--- a/custom_components/narwal/translations/en.json
+++ b/custom_components/narwal/translations/en.json
@@ -35,6 +35,12 @@
       "firmware_version": {
         "name": "Firmware version"
       },
+      "dust_bag_health": {
+        "name": "Dust bag health"
+      },
+      "detergent_remaining": {
+        "name": "Detergent remaining"
+      },
       "charging_state": {
         "name": "Charging",
         "state": {
@@ -51,6 +57,28 @@
           "on": "Docked",
           "off": "Undocked"
         }
+      },
+      "error": {
+        "name": "Error",
+        "state": {
+          "on": "Problem",
+          "off": "OK"
+        }
+      },
+      "clean_water_tank": {
+        "name": "Clean water tank"
+      },
+      "sewage_tank": {
+        "name": "Sewage tank"
+      },
+      "dust_box": {
+        "name": "Dust box"
+      },
+      "dust_bag": {
+        "name": "Dust bag"
+      },
+      "station_bag": {
+        "name": "Station dust bag"
       }
     }
   }

--- a/custom_components/narwal/translations/fr.json
+++ b/custom_components/narwal/translations/fr.json
@@ -35,6 +35,12 @@
       "firmware_version": {
         "name": "Version du firmware"
       },
+      "dust_bag_health": {
+        "name": "État du sac à poussière"
+      },
+      "detergent_remaining": {
+        "name": "Détergent restant"
+      },
       "charging_state": {
         "name": "Charge",
         "state": {
@@ -51,6 +57,28 @@
           "on": "Stationné",
           "off": "Non stationné"
         }
+      },
+      "error": {
+        "name": "Erreur",
+        "state": {
+          "on": "Problème",
+          "off": "OK"
+        }
+      },
+      "clean_water_tank": {
+        "name": "Réservoir d'eau propre"
+      },
+      "sewage_tank": {
+        "name": "Réservoir d'eau sale"
+      },
+      "dust_box": {
+        "name": "Bac à poussière"
+      },
+      "dust_bag": {
+        "name": "Sac à poussière"
+      },
+      "station_bag": {
+        "name": "Sac à poussière de la station"
       }
     }
   }

--- a/narwal_client/const.py
+++ b/narwal_client/const.py
@@ -146,6 +146,11 @@ class CommandResult(IntEnum):
 class WorkingStatus(IntEnum):
     """Robot working state from robot_base_status field 3 → sub-field 1.
 
+    These values are EMPIRICAL and intentionally do NOT match the app's compiled
+    RobotTaskStatus.TaskType enum (sub-field 1's declared type): on this firmware
+    the robot reports e.g. 14=charged where TaskType 14=WASH_AND_DRY_MOP. Trust
+    the live-observed mapping below, not re/ENUMS.md, for this field (and f47).
+
     Values confirmed via live WebSocket monitoring:
       1  = STANDBY (idle, transition state between cleaning and docked)
       2  = DOCKED_V2 (on dock; confirmed v01.07.23.00 while charging at 10-36%)
@@ -197,28 +202,42 @@ class MopHumidity(IntEnum):
 
 # robot_base_status field numbers
 class BaseStatusField(IntEnum):
-    """Field numbers in the robot_base_status protobuf message.
+    """Field numbers in the robot_base_status (RobotBaseStatus) message.
 
-    Battery notes (confirmed via 35-min monitor capture, 2026-02-27):
-      Field 2  = real-time battery level as IEEE 754 float32
-                 (e.g. 1118175232 → 83.0%, matching app display ~84%)
-      Field 38 = static battery health (always 100; design capacity, not SOC)
+    Names from the decompiled BuilderInfo, several live-validated on dock.
+    Field 2 is float32 (PbFieldType 0x100), e.g. 1120403456 → 100.0.
+    Most state fields (5,11,12,14,15,20-24,26,28,29,31,33,39,40,42,47,49,50)
+    are enums whose value→label tables are not yet decoded.
     """
 
-    BATTERY_LEVEL = 2  # real-time SOC as float32 — CONFIRMED
-    MODE_STATE = 3
-    SESSION_ID = 13
-    SENSOR_DATA = 25
-    TIMESTAMP = 36
-    BATTERY_HEALTH = 38  # static, always 100 (design capacity)
-    BATTERY_CAPACITY = 41
+    ERROR_CODE = 1  # repeated ErrorCode; empty when no fault
+    BATTERY_LEVEL = 2  # batteryPercentage, float32
+    ROBOT_TASK_STATUS = 3  # nested task-status message
+    BINDED_UUID = 13  # bound account/device UUID (string)
+    CLEAN_WATER_TANK_STATE = 23  # enum
+    SEWAGE_TANK_STATE = 24  # enum
+    DEVICE_STATUS_CODE_LIST = 25
+    FAN_LEVEL = 26  # active suction (FanLevel enum)
+    MOP_HUMIDITY = 29  # active water level (MopHumidity enum)
+    STATION_BAG_HEALTH_SCORE = 35  # float32, %
+    STATION_BAG_HEALTH_RESET_TIME = 36  # epoch
+    CURING_AGENT_CONSUMPTION_PERCENT = 38
+    HEAVY_DETERGENT_REMAIN_PERCENT = 41
+    CHARGING_STATUS = 47  # canonical charging state (enum)
 
 
-# upgrade_status field numbers
+# upgrade_status field numbers (OTAUpgradeStatus)
 class UpgradeStatusField(IntEnum):
-    """Field numbers in the upgrade_status protobuf message."""
+    """Field numbers in the upgrade_status (OTAUpgradeStatus) message.
 
-    STATUS_CODE = 4
+    Names from the decompiled BuilderInfo: 1 type, 2 status, 3 progress,
+    4 stage, 5 errorCode, 6 detailErrorCode, 7 currentVersion, 8 targetVersion.
+    """
+
+    STATUS = 2
+    PROGRESS = 3
+    STAGE = 4
+    ERROR_CODE = 5
     CURRENT_FIRMWARE = 7
     TARGET_FIRMWARE = 8
 

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -494,16 +494,15 @@ class NarwalState:
     # Core status
     working_status: WorkingStatus = WorkingStatus.UNKNOWN
     battery_level: int = 0  # real-time SOC from field 2 (float32)
-    battery_health: int = 0  # static design capacity from field 38 (always 100)
     firmware_version: str = ""
     firmware_target: str = ""
 
     # Device identity
     device_info: DeviceInfo | None = None
 
-    # Session
-    session_id: str = ""
-    timestamp: int = 0
+    # Identity / station maintenance (base_status)
+    binded_uuid: str = ""  # field 13 — bound account/device UUID
+    station_bag_health_reset_time: int = 0  # field 36 — epoch of last bag-health reset
 
     # Position (from map data)
     position: Position | None = None
@@ -512,14 +511,31 @@ class NarwalState:
     cleaning_area: float = 0.0  # m² (coveredArea)
     cleaning_time: int = 0  # seconds
 
+    # Consumables / station / fault (base_status; present on dock and during cleaning)
+    dust_bag_health: float = 0.0  # field 35 stationBagHealthScore (%)
+    detergent_remaining: int = 0  # field 41 heavyDetergentRemainPercent (%)
+    curing_agent_consumption_percent: int = 0  # field 38
+    has_error: bool = False  # field 1 errorCode has an active code
+    error_codes: list[int] = field(default_factory=list)  # field 1 ErrorCode.identityCode(s)
+    error_level: int = 0  # ErrorCode.level (field 1 sub-2)
+    error_detail: str = ""  # ErrorCode.debugDetail (field 1 sub-3)
+
+    # Station tank/bag enum states (base_status; None = not reported by this model).
+    # 0=unspecified, 1=ok/installed, ≥2=attention (empty/abnormal/replace) — see BaseStatusField.
+    clean_water_tank_state: int | None = None  # field 23 (CleanWaterTankState)
+    sewage_tank_state: int | None = None  # field 24 (SewageTankState)
+    dust_box_state: int | None = None  # field 20 (DustBoxState)
+    dust_bag_state: int | None = None  # field 21 (DustBagState)
+    station_bag_state: int | None = None  # field 39 (StationBagStatus)
+
     # Map
     map_data: MapData | None = None
     map_display_data: MapDisplayData | None = None
 
-    # Vision obstacles (camera-detected transient objects during cleaning)
-    # Download/upgrade status
-    download_status: int = 0
-    upgrade_status_code: int = 0
+    # Download / upgrade status
+    download_status: int = 0  # download_status field 3 (state)
+    upgrade_status: int = 0  # upgrade_status field 2 (status)
+    upgrade_stage: int = 0  # upgrade_status field 4 (stage)
 
     # Pause overlay (field 3 sub-field 2 = 1 means paused)
     is_paused: bool = False
@@ -736,24 +752,75 @@ class NarwalState:
                 type(field3).__name__, field3,
             )
         if "2" in decoded:
-            # Field 2 = real-time battery SOC as float32
+            # Field 2 = real-time battery SOC as float32 (batteryPercentage)
             # (e.g. 1118175232 → 83.0%; bbp may return int or float)
             bat = _to_float32(decoded["2"])
             if bat is not None:
                 self.battery_level = round(bat)
-        if "38" in decoded:
-            # Field 38 = static battery health (always 100, design capacity)
-            self.battery_health = int(decoded["38"])
-        if "36" in decoded:
-            self.timestamp = int(decoded["36"])
+        self._update_consumables(decoded)
         if "13" in decoded:
             raw = decoded["13"]
             if isinstance(raw, bytes):
-                self.session_id = raw.decode("utf-8", errors="replace")
+                self.binded_uuid = raw.decode("utf-8", errors="replace")
             else:
-                self.session_id = str(raw)
-                if self.session_id.startswith("b'"):
-                    self.session_id = self.session_id[2:-1]
+                self.binded_uuid = str(raw)
+                if self.binded_uuid.startswith("b'"):
+                    self.binded_uuid = self.binded_uuid[2:-1]
+
+    def _update_consumables(self, decoded: dict[str, Any]) -> None:
+        """Parse base_status consumable/station/fault fields — hardware-sampled, so trustworthy even in deep-sleep battery-only updates."""
+        if "35" in decoded:
+            score = _to_float32(decoded["35"])
+            if score is not None:
+                self.dust_bag_health = score
+        if "41" in decoded:
+            self.detergent_remaining = int(decoded["41"])
+        if "38" in decoded:
+            self.curing_agent_consumption_percent = int(decoded["38"])
+        if "36" in decoded:
+            self.station_bag_health_reset_time = int(decoded["36"])
+        if "1" in decoded:
+            self._parse_error_codes(decoded["1"])
+        for attr, key in (
+            ("clean_water_tank_state", "23"), ("sewage_tank_state", "24"),
+            ("dust_box_state", "20"), ("dust_bag_state", "21"),
+            ("station_bag_state", "39"),
+        ):
+            if key in decoded:
+                try:
+                    setattr(self, attr, int(decoded[key]))
+                except (ValueError, TypeError):
+                    pass
+
+    def _parse_error_codes(self, raw: Any) -> None:
+        """Decode base_status field 1 (repeated ErrorCode{1:identityCode, 2:level, 3:debugDetail}).
+
+        Empty/zero codes mean no active fault. bbp gives a dict for one entry, a list for many.
+        """
+        entries = raw if isinstance(raw, list) else [raw] if isinstance(raw, dict) else []
+        codes: list[int] = []
+        level = 0
+        detail = ""
+        for entry in entries:
+            if not isinstance(entry, dict) or not entry.get("1"):
+                continue
+            try:
+                codes.append(int(entry["1"]))
+            except (ValueError, TypeError):
+                continue
+            try:
+                level = max(level, int(entry.get("2", 0)))
+            except (ValueError, TypeError):
+                pass
+            raw_detail = entry.get("3")
+            if isinstance(raw_detail, bytes):
+                detail = detail or raw_detail.decode("utf-8", errors="replace")
+            elif isinstance(raw_detail, str):
+                detail = detail or raw_detail
+        self.error_codes = codes
+        self.error_level = level
+        self.error_detail = detail
+        self.has_error = bool(codes)
 
     def update_battery_from_base_status(self, decoded: dict[str, Any]) -> None:
         """Update ONLY hardware-sampled fields from a base_status response.
@@ -768,13 +835,13 @@ class NarwalState:
             bat = _to_float32(decoded["2"])
             if bat is not None:
                 self.battery_level = round(bat)
-        if "38" in decoded:
-            self.battery_health = int(decoded["38"])
-        if "36" in decoded:
-            self.timestamp = int(decoded["36"])
+        self._update_consumables(decoded)
 
     def update_from_upgrade_status(self, decoded: dict[str, Any]) -> None:
-        """Update state from a decoded upgrade_status message."""
+        """Update state from a decoded upgrade_status message.
+
+        Fields: 2 status, 4 stage, 7 currentVersion, 8 targetVersion.
+        """
         if "7" in decoded:
             raw = decoded["7"]
             if isinstance(raw, bytes):
@@ -791,10 +858,15 @@ class NarwalState:
                 self.firmware_target = str(raw)
                 if self.firmware_target.startswith("b'"):
                     self.firmware_target = self.firmware_target[2:-1]
+        if "2" in decoded:
+            self.upgrade_status = int(decoded["2"])
         if "4" in decoded:
-            self.upgrade_status_code = int(decoded["4"])
+            self.upgrade_stage = int(decoded["4"])
 
     def update_from_download_status(self, decoded: dict[str, Any]) -> None:
-        """Update state from a decoded download_status message."""
-        if "1" in decoded:
-            self.download_status = int(decoded["1"])
+        """Update state from a decoded download_status message (voice/timbre pack).
+
+        Field 3 = state; field 1 is `type` (download category), not status.
+        """
+        if "3" in decoded:
+            self.download_status = int(decoded["3"])

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -779,8 +779,8 @@ class NarwalState:
             self.curing_agent_consumption_percent = int(decoded["38"])
         if "36" in decoded:
             self.station_bag_health_reset_time = int(decoded["36"])
-        if "1" in decoded:
-            self._parse_error_codes(decoded["1"])
+        # Always reparse (even when field 1 is absent) — protobuf omits an empty repeated field, so a recovered robot drops it; without this the prior fault would stick forever.
+        self._parse_error_codes(decoded.get("1"))
         for attr, key in (
             ("clean_water_tank_state", "23"), ("sewage_tank_state", "24"),
             ("dust_box_state", "20"), ("dust_bag_state", "21"),
@@ -823,12 +823,9 @@ class NarwalState:
         self.has_error = bool(codes)
 
     def update_battery_from_base_status(self, decoded: dict[str, Any]) -> None:
-        """Update ONLY hardware-sampled fields from a base_status response.
+        """Update only the trustworthy hardware-sampled fields (battery + consumable/station/fault/tank state, via _update_consumables) from a base_status response.
 
-        Used when the robot is not broadcasting (deep sleep on dock).
-        In this mode, get_status() returns current battery (hardware counter)
-        but stale working_status (firmware cache from last active session).
-        We update only the fields we can trust.
+        Used when the robot is not broadcasting (deep sleep on dock): get_status() returns a current battery counter but a stale working_status (firmware cache from the last active session), so working_status is deliberately skipped.
         """
         self.raw_base_status = decoded
         if "2" in decoded:

--- a/tests/ha_stubs.py
+++ b/tests/ha_stubs.py
@@ -8,6 +8,7 @@ can be imported and tested in isolation.
 from __future__ import annotations
 
 import sys
+from dataclasses import dataclass
 from types import ModuleType
 from unittest.mock import MagicMock
 
@@ -42,6 +43,12 @@ def install() -> None:
     # homeassistant.const
     ha_const = _mod("homeassistant.const", ha)
     ha_const.Platform = MagicMock()  # type: ignore[attr-defined]
+
+    class _EntityCategory:
+        CONFIG = "config"
+        DIAGNOSTIC = "diagnostic"
+
+    ha_const.EntityCategory = _EntityCategory  # type: ignore[attr-defined]
 
     # homeassistant.core
     ha_core = _mod("homeassistant.core", ha)
@@ -187,8 +194,27 @@ def install() -> None:
     ha_sensor.SensorStateClass = MagicMock  # type: ignore[attr-defined]
 
     ha_bs = _mod("homeassistant.components.binary_sensor", ha_comp)
-    ha_bs.BinarySensorEntity = MagicMock  # type: ignore[attr-defined]
-    ha_bs.BinarySensorDeviceClass = MagicMock  # type: ignore[attr-defined]
+
+    class _BinarySensorEntity:
+        """Stub for BinarySensorEntity base class."""
+
+        def __init_subclass__(cls, **kw: object) -> None:
+            pass
+
+    ha_bs.BinarySensorEntity = _BinarySensorEntity  # type: ignore[attr-defined]
+    ha_bs.BinarySensorDeviceClass = MagicMock()  # type: ignore[attr-defined]
+
+    @dataclass(frozen=True, kw_only=True)
+    class _BinarySensorEntityDescription:
+        """Stub for BinarySensorEntityDescription (fields our code sets)."""
+
+        key: str
+        name: str | None = None
+        translation_key: str | None = None
+        entity_category: object | None = None
+        device_class: object | None = None
+
+    ha_bs.BinarySensorEntityDescription = _BinarySensorEntityDescription  # type: ignore[attr-defined]
 
     ha_cam = _mod("homeassistant.components.camera", ha_comp)
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,67 @@
+"""Tests for the station fault/consumable binary sensors (value_fn logic)."""
+
+from __future__ import annotations
+
+import tests.ha_stubs
+
+tests.ha_stubs.install()
+
+from narwal_client.models import NarwalState  # noqa: E402
+from custom_components.narwal.binary_sensor import (  # noqa: E402
+    BINARY_SENSOR_DESCRIPTIONS,
+)
+
+_DESCS = {d.key: d for d in BINARY_SENSOR_DESCRIPTIONS}
+
+
+def test_error_gated_on_base_status_seen() -> None:
+    """Error is unavailable until a base_status arrives, then reflects has_error."""
+    fn = _DESCS["error"].value_fn
+    assert fn(NarwalState()) is None  # no base_status yet
+    s = NarwalState()
+    s.update_from_base_status({"1": {}})  # healthy
+    assert fn(s) is False
+    s.update_from_base_status({"1": {"1": 7}})  # fault
+    assert fn(s) is True
+
+
+def test_error_attributes_expose_code_detail() -> None:
+    """The error sensor surfaces code/level/detail + a help link when faulted."""
+    desc = _DESCS["error"]
+    s = NarwalState()
+    s.update_from_base_status({"1": {"1": 2105, "2": 3, "3": b"wheel stuck"}})
+    attrs = desc.attrs_fn(s)
+    assert attrs["codes"] == [2105]
+    assert attrs["level"] == 3
+    assert attrs["detail"] == "wheel stuck"
+    assert "code=2105" in attrs["help_url"]
+
+
+def test_no_help_url_when_healthy() -> None:
+    """No help_url attribute when there's no active error code."""
+    desc = _DESCS["error"]
+    s = NarwalState()
+    s.update_from_base_status({"1": {}})
+    assert "help_url" not in desc.attrs_fn(s)
+
+
+def test_tank_problem_states() -> None:
+    """Tank/bag sensors: None until reported, ok at value 1, problem at ≥2."""
+    cw = _DESCS["clean_water_tank"].value_fn
+    sb = _DESCS["station_bag"].value_fn
+    assert cw(NarwalState()) is None  # not reported -> unavailable
+    s = NarwalState()
+    s.update_from_base_status({"23": 1, "39": 1})  # both ok
+    assert cw(s) is False
+    assert sb(s) is False
+    s.update_from_base_status({"23": 2, "39": 3})  # EMPTY / SUGGEST_REPLACE
+    assert cw(s) is True
+    assert sb(s) is True
+
+
+def test_unspecified_is_not_a_problem() -> None:
+    """Value 0 (UNSPECIFIED) must not read as a problem."""
+    fn = _DESCS["sewage_tank"].value_fn
+    s = NarwalState()
+    s.update_from_base_status({"24": 0})
+    assert fn(s) is False

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -25,6 +25,17 @@ def test_error_gated_on_base_status_seen() -> None:
     assert fn(s) is True
 
 
+def test_error_clears_when_field_absent() -> None:
+    """A recovered robot omits field 1 entirely (empty repeated) — the fault must clear, not stick."""
+    fn = _DESCS["error"].value_fn
+    s = NarwalState()
+    s.update_from_base_status({"1": {"1": 7}})  # fault
+    assert fn(s) is True
+    s.update_from_base_status({"2": 0})  # next status drops field 1
+    assert fn(s) is False
+    assert s.error_codes == []
+
+
 def test_error_attributes_expose_code_detail() -> None:
     """The error sensor surfaces code/level/detail + a help link when faulted."""
     desc = _DESCS["error"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -62,7 +62,7 @@ class TestNarwalState:
         assert state.working_status == WorkingStatus.CHARGED
         assert state.is_docked
         assert state.battery_level == 100
-        assert state.battery_health == 100
+        assert state.curing_agent_consumption_percent == 100
 
     def test_update_from_base_status_standby_on_dock(self) -> None:
         """STANDBY(1) with dock sub-state=1 means docked."""
@@ -202,24 +202,74 @@ class TestNarwalState:
             "13": "d4bec8c82c484a3ba0428bb0dd4359e2",
         })
         assert state.battery_level == 85
-        assert state.battery_health == 100
-        assert state.timestamp == 1757252225
-        assert state.session_id == "d4bec8c82c484a3ba0428bb0dd4359e2"
+        assert state.curing_agent_consumption_percent == 100
+        assert state.station_bag_health_reset_time == 1757252225
+        assert state.binded_uuid == "d4bec8c82c484a3ba0428bb0dd4359e2"
+
+    def test_base_status_consumables_and_error(self) -> None:
+        """Field 35 dust-bag health (float32 %), 41 detergent %, 1 errorCode presence."""
+        state = NarwalState()
+        state.update_from_base_status({
+            "1": {},  # empty errorCode = no fault
+            "35": _float_to_uint32(68.5),
+            "41": 100,
+        })
+        assert round(state.dust_bag_health, 1) == 68.5
+        assert state.detergent_remaining == 100
+        assert state.has_error is False
+        assert state.error_codes == []
+        # A populated ErrorCode flips has_error on and exposes code/level/detail.
+        state.update_from_base_status({"1": {"1": 2105, "2": 3, "3": b"wheel stuck"}})
+        assert state.has_error is True
+        assert state.error_codes == [2105]
+        assert state.error_level == 3
+        assert state.error_detail == "wheel stuck"
+        # Clears when the next base_status reports an empty errorCode.
+        state.update_from_base_status({"1": {}})
+        assert state.has_error is False
+        assert state.error_codes == []
+
+    def test_multiple_error_codes(self) -> None:
+        """Repeated ErrorCode (bbp list) collects all identityCodes, max level."""
+        state = NarwalState()
+        state.update_from_base_status({"1": [{"1": 10, "2": 1}, {"1": 20, "2": 4}]})
+        assert state.error_codes == [10, 20]
+        assert state.error_level == 4
+        assert state.has_error is True
+
+    def test_base_status_tank_states(self) -> None:
+        """Tank/bag enum states parse into Optional ints; unreported stays None."""
+        state = NarwalState()
+        # Live healthy snapshot: clean-water/sewage ok (1), dust box ok (1),
+        # station bag installed (1). No dust-bag field on this model.
+        state.update_from_base_status({"23": 1, "24": 1, "20": 1, "39": 1})
+        assert state.clean_water_tank_state == 1
+        assert state.sewage_tank_state == 1
+        assert state.dust_box_state == 1
+        assert state.station_bag_state == 1
+        assert state.dust_bag_state is None  # not reported by this model
+        # Attention states.
+        state.update_from_base_status({"23": 2, "39": 3})
+        assert state.clean_water_tank_state == 2  # EMPTY
+        assert state.station_bag_state == 3  # SUGGEST_REPLACE
 
     def test_update_from_upgrade_status(self) -> None:
         state = NarwalState()
         state.update_from_upgrade_status({
             "7": "v01.02.19.02",
             "8": "v01.02.19.02",
+            "2": 3,
             "4": 10,
         })
         assert state.firmware_version == "v01.02.19.02"
         assert state.firmware_target == "v01.02.19.02"
-        assert state.upgrade_status_code == 10
+        assert state.upgrade_status == 3
+        assert state.upgrade_stage == 10
 
     def test_update_from_download_status(self) -> None:
+        # Field 3 = state (field 1 is download type, ignored).
         state = NarwalState()
-        state.update_from_download_status({"1": 2})
+        state.update_from_download_status({"1": 5, "3": 2})
         assert state.download_status == 2
 
     def test_incremental_updates(self) -> None:
@@ -259,11 +309,11 @@ class TestNarwalState:
         state.update_from_base_status({"2": 83.0})
         assert state.battery_level == 83
 
-    def test_battery_health_field38_static(self) -> None:
-        """Field 38 is static battery health (always 100), not real-time SOC."""
+    def test_field38_curing_agent_not_battery(self) -> None:
+        """Field 38 is curingAgentConsumptionPercent, not battery SOC/health."""
         state = NarwalState()
         state.update_from_base_status({"38": 100})
-        assert state.battery_health == 100
+        assert state.curing_agent_consumption_percent == 100
         # battery_level unchanged (no field 2)
         assert state.battery_level == 0
 
@@ -294,7 +344,7 @@ class TestNarwalState:
 
         # Battery updated, working_status preserved from last authoritative source
         assert state.battery_level == 85
-        assert state.battery_health == 100
+        assert state.curing_agent_consumption_percent == 100
         assert state.working_status == WorkingStatus.DOCKED  # NOT overwritten
         assert state.is_docked  # still correct
 


### PR DESCRIPTION
### Summary
A full decode of the `RobotBaseStatus` proto turned up several **mislabeled
fields** already being parsed into state, plus a number of useful signals the
robot broadcasts that weren't surfaced. This corrects the former and exposes the
latter as diagnostic entities.

### Field corrections (were mapped to the wrong proto field)
- `battery_health` → `curingAgentConsumptionPercent` (f38)
- `session_id` → `bindedUuid` (f13)
- `timestamp` → `stationBagHealthResetTime` (f36)
- upgrade status now reads f2 (not f4 = stage); download state reads f3 (not f1 = type)
- `BaseStatusField` / `UpgradeStatusField` enums corrected to match

### New entities (all from fields already broadcast)
- **Sensors:** dust bag health (f35), detergent remaining (f41)
- **Binary sensors** (`problem` device class, gated on the field being present):
  error/fault (f1 — exposes code/level/detail + a best-effort help-center link),
  clean-water tank, sewage tank, dust box, dust bag, station dust bag

Binary sensors are now description-driven (small refactor) to keep the additions
declarative.

### Caveat
The error help-center URL is a **best-effort deep link** — the app builds it from
a localized base we can't read over LAN, so the template is inferred from the
Flow's help-center family and falls back to showing the raw code. Worth a sanity
check if a real fault opens the wrong page.

### How it was derived
Field/enum identities decoded from the app's compiled protobuf `BuilderInfo` and
constant pool; live-confirmed where possible.

### Testing
New `tests/test_binary_sensor.py`; `test_models.py`/`ha_stubs` updated; suite green.

### Relates to
- #26 (water-tank message — now a clean-water/sewage tank sensor)
- #32 (new sensor request)

---
*Dependent PRs, stacked on this one (review after it merges): #53 (last clean result), #54 (consumable alerts).*
