### PR TITLE
feat(sensor): add "last clean result" sensor

### DIFF
--- a/custom_components/narwal/const.py
+++ b/custom_components/narwal/const.py
@@ -40,6 +40,29 @@ FAN_SPEED_MAP: dict[str, FanLevel] = {
 
 FAN_SPEED_LIST: list[str] = list(FAN_SPEED_MAP.keys())
 
+# base_status field 15 (terminateReason) value → HA option key. From the decoded
+# TaskResult enum (re/ENUMS.md). Live-confirmed: 1 = NORMAL_END.
+TASK_RESULT_OPTIONS: dict[int, str] = {
+    1: "normal_end",
+    2: "user_force_end",
+    3: "shutdown_force_end",
+    4: "low_battery_force_end",
+    5: "overflow_force_end",
+    6: "pause_too_long_force_end",
+    7: "system_error_force_end",
+    8: "user_force_end_on_station",
+    9: "user_force_end_on_app",
+    10: "recall_end",
+    11: "normal_end_replenish_map_fail",
+    12: "map_unmatched_force_end",
+    13: "relocation_fail_with_station_force_end",
+    14: "relocation_fail_without_station_force_end",
+    15: "pretask_error_force_end",
+    16: "schedule_task_force_end",
+    17: "unexecuted",
+    18: "not_find_pet",
+}
+
 # Best-effort help-center deep link for a robot error code. The app's goHelpCenterByCode
 # builds <localized help base>?code=<n>&deviceId=…&lang=…; the exact base is a runtime
 # i18n value we can't read, so this is inferred from the Flow's help-center family and

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -488,6 +488,7 @@ class NarwalState:
     error_codes: list[int] = field(default_factory=list)  # field 1 ErrorCode.identityCode(s)
     error_level: int = 0  # ErrorCode.level (field 1 sub-2)
     error_detail: str = ""  # ErrorCode.debugDetail (field 1 sub-3)
+    terminate_reason: int = 0  # field 15 — TaskResult of the last task (why it ended)
 
     # Station tank/bag enum states (base_status; None = not reported by this model).
     # 0=unspecified, 1=ok/installed, ≥2=attention (empty/abnormal/replace) — see BaseStatusField.
@@ -738,6 +739,11 @@ class NarwalState:
                 self.binded_uuid = str(raw)
                 if self.binded_uuid.startswith("b'"):
                     self.binded_uuid = self.binded_uuid[2:-1]
+        if "15" in decoded:
+            try:
+                self.terminate_reason = int(decoded["15"])
+            except (ValueError, TypeError):
+                pass
 
     def _update_consumables(self, decoded: dict[str, Any]) -> None:
         """Parse base_status consumable/station/fault fields — hardware-sampled, so trustworthy even in deep-sleep battery-only updates."""

--- a/custom_components/narwal/sensor.py
+++ b/custom_components/narwal/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .narwal_client import NarwalState
 
 from . import NarwalConfigEntry
+from .const import TASK_RESULT_OPTIONS
 from .coordinator import NarwalCoordinator
 from .entity import NarwalEntity
 
@@ -87,6 +88,15 @@ SENSOR_DESCRIPTIONS: tuple[NarwalSensorEntityDescription, ...] = (
         translation_key="firmware_version",
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda state: state.firmware_version or None,
+    ),
+    NarwalSensorEntityDescription(
+        key="last_clean_result",
+        translation_key="last_clean_result",
+        device_class=SensorDeviceClass.ENUM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        options=list(TASK_RESULT_OPTIONS.values()),
+        # base_status field 15 terminateReason (TaskResult) — why the last task ended.
+        value_fn=lambda state: TASK_RESULT_OPTIONS.get(state.terminate_reason),
     ),
 )
 

--- a/custom_components/narwal/strings.json
+++ b/custom_components/narwal/strings.json
@@ -41,6 +41,29 @@
       "detergent_remaining": {
         "name": "Detergent remaining"
       },
+      "last_clean_result": {
+        "name": "Last clean result",
+        "state": {
+          "normal_end": "Completed",
+          "user_force_end": "Stopped by user",
+          "shutdown_force_end": "Ended (shutdown)",
+          "low_battery_force_end": "Ended (low battery)",
+          "overflow_force_end": "Ended (tank overflow)",
+          "pause_too_long_force_end": "Ended (paused too long)",
+          "system_error_force_end": "Ended (system error)",
+          "user_force_end_on_station": "Stopped at station",
+          "user_force_end_on_app": "Stopped from app",
+          "recall_end": "Recalled to dock",
+          "normal_end_replenish_map_fail": "Completed (map update failed)",
+          "map_unmatched_force_end": "Ended (map mismatch)",
+          "relocation_fail_with_station_force_end": "Ended (relocation failed)",
+          "relocation_fail_without_station_force_end": "Ended (relocation failed, no station)",
+          "pretask_error_force_end": "Ended (pre-task error)",
+          "schedule_task_force_end": "Ended (schedule)",
+          "unexecuted": "Not run",
+          "not_find_pet": "Pet not found"
+        }
+      },
       "charging_state": {
         "name": "Charging",
         "state": {

--- a/custom_components/narwal/translations/en.json
+++ b/custom_components/narwal/translations/en.json
@@ -41,6 +41,29 @@
       "detergent_remaining": {
         "name": "Detergent remaining"
       },
+      "last_clean_result": {
+        "name": "Last clean result",
+        "state": {
+          "normal_end": "Completed",
+          "user_force_end": "Stopped by user",
+          "shutdown_force_end": "Ended (shutdown)",
+          "low_battery_force_end": "Ended (low battery)",
+          "overflow_force_end": "Ended (tank overflow)",
+          "pause_too_long_force_end": "Ended (paused too long)",
+          "system_error_force_end": "Ended (system error)",
+          "user_force_end_on_station": "Stopped at station",
+          "user_force_end_on_app": "Stopped from app",
+          "recall_end": "Recalled to dock",
+          "normal_end_replenish_map_fail": "Completed (map update failed)",
+          "map_unmatched_force_end": "Ended (map mismatch)",
+          "relocation_fail_with_station_force_end": "Ended (relocation failed)",
+          "relocation_fail_without_station_force_end": "Ended (relocation failed, no station)",
+          "pretask_error_force_end": "Ended (pre-task error)",
+          "schedule_task_force_end": "Ended (schedule)",
+          "unexecuted": "Not run",
+          "not_find_pet": "Pet not found"
+        }
+      },
       "charging_state": {
         "name": "Charging",
         "state": {

--- a/custom_components/narwal/translations/fr.json
+++ b/custom_components/narwal/translations/fr.json
@@ -41,6 +41,29 @@
       "detergent_remaining": {
         "name": "Détergent restant"
       },
+      "last_clean_result": {
+        "name": "Résultat du dernier nettoyage",
+        "state": {
+          "normal_end": "Terminé",
+          "user_force_end": "Arrêté par l'utilisateur",
+          "shutdown_force_end": "Terminé (extinction)",
+          "low_battery_force_end": "Terminé (batterie faible)",
+          "overflow_force_end": "Terminé (réservoir plein)",
+          "pause_too_long_force_end": "Terminé (pause trop longue)",
+          "system_error_force_end": "Terminé (erreur système)",
+          "user_force_end_on_station": "Arrêté à la station",
+          "user_force_end_on_app": "Arrêté depuis l'app",
+          "recall_end": "Rappelé à la base",
+          "normal_end_replenish_map_fail": "Terminé (échec mise à jour carte)",
+          "map_unmatched_force_end": "Terminé (carte non concordante)",
+          "relocation_fail_with_station_force_end": "Terminé (échec de relocalisation)",
+          "relocation_fail_without_station_force_end": "Terminé (échec de relocalisation, sans station)",
+          "pretask_error_force_end": "Terminé (erreur pré-tâche)",
+          "schedule_task_force_end": "Terminé (planification)",
+          "unexecuted": "Non exécuté",
+          "not_find_pet": "Animal introuvable"
+        }
+      },
       "charging_state": {
         "name": "Charge",
         "state": {

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -488,6 +488,7 @@ class NarwalState:
     error_codes: list[int] = field(default_factory=list)  # field 1 ErrorCode.identityCode(s)
     error_level: int = 0  # ErrorCode.level (field 1 sub-2)
     error_detail: str = ""  # ErrorCode.debugDetail (field 1 sub-3)
+    terminate_reason: int = 0  # field 15 — TaskResult of the last task (why it ended)
 
     # Station tank/bag enum states (base_status; None = not reported by this model).
     # 0=unspecified, 1=ok/installed, ≥2=attention (empty/abnormal/replace) — see BaseStatusField.
@@ -738,6 +739,11 @@ class NarwalState:
                 self.binded_uuid = str(raw)
                 if self.binded_uuid.startswith("b'"):
                     self.binded_uuid = self.binded_uuid[2:-1]
+        if "15" in decoded:
+            try:
+                self.terminate_reason = int(decoded["15"])
+            except (ValueError, TypeError):
+                pass
 
     def _update_consumables(self, decoded: dict[str, Any]) -> None:
         """Parse base_status consumable/station/fault fields — hardware-sampled, so trustworthy even in deep-sleep battery-only updates."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -272,6 +272,12 @@ class TestNarwalState:
         assert state.clean_water_tank_state == 2  # EMPTY
         assert state.station_bag_state == 3  # SUGGEST_REPLACE
 
+    def test_terminate_reason(self) -> None:
+        """Field 15 = terminateReason (TaskResult)."""
+        state = NarwalState()
+        state.update_from_base_status({"15": 4})
+        assert state.terminate_reason == 4  # LOW_BATTERY_FORCE_END
+
     def test_update_from_upgrade_status(self) -> None:
         state = NarwalState()
         state.update_from_upgrade_status({


### PR DESCRIPTION
### Summary
Surfaces `base_status` field 15 (`terminateReason`) as an enum sensor that
explains **why the last task ended** — Completed, Ended (low battery), Stopped by
user, etc. — mapping the decoded `TaskResult` values to readable states.

### Depends on #52
Builds on the corrected `update_from_base_status` from #52. Review/merge that
first; this branch is based on it (will rebase onto `master` once it lands).

### How it was derived
`TaskResult` values from the app's decoded enum; live-confirmed f15=1 → `NORMAL_END`.

### Testing
`tests/test_models.py` updated; suite green.

### Relates to
- #32 (new sensor request)
