### PR TITLE
feat(sensor): poll consumable maintenance/replacement alerts

### DIFF
--- a/custom_components/narwal/binary_sensor.py
+++ b/custom_components/narwal/binary_sensor.py
@@ -18,7 +18,11 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .narwal_client import NarwalState
 
 from . import NarwalConfigEntry
-from .const import ERROR_HELP_URL_TEMPLATE
+from .const import (
+    CONSUMABLE_MAINTAIN_ITEMS,
+    CONSUMABLE_REPLACE_ITEMS,
+    ERROR_HELP_URL_TEMPLATE,
+)
 from .coordinator import NarwalCoordinator
 from .entity import NarwalEntity
 
@@ -63,6 +67,28 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[NarwalBinarySensorEntityDescription, ...] = (
                 {"help_url": ERROR_HELP_URL_TEMPLATE.format(code=s.error_codes[0])}
                 if s.error_codes else {}
             ),
+        } if s.raw_base_status else None,
+    ),
+    NarwalBinarySensorEntityDescription(
+        key="maintenance_required",
+        translation_key="maintenance_required",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        # consumable/get_consumable_info maintainItems (clean/check these parts).
+        value_fn=lambda s: bool(s.maintain_items) if s.raw_base_status else None,
+        attrs_fn=lambda s: {
+            "items": [CONSUMABLE_MAINTAIN_ITEMS.get(i, str(i)) for i in s.maintain_items]
+        } if s.raw_base_status else None,
+    ),
+    NarwalBinarySensorEntityDescription(
+        key="replacement_required",
+        translation_key="replacement_required",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        # consumable/get_consumable_info replaceItems (replace these parts).
+        value_fn=lambda s: bool(s.replace_items) if s.raw_base_status else None,
+        attrs_fn=lambda s: {
+            "items": [CONSUMABLE_REPLACE_ITEMS.get(i, str(i)) for i in s.replace_items]
         } if s.raw_base_status else None,
     ),
     NarwalBinarySensorEntityDescription(

--- a/custom_components/narwal/const.py
+++ b/custom_components/narwal/const.py
@@ -40,6 +40,19 @@ FAN_SPEED_MAP: dict[str, FanLevel] = {
 
 FAN_SPEED_LIST: list[str] = list(FAN_SPEED_MAP.keys())
 
+# Consumable alert enum value → name (ConsumableMaintainItem / ConsumableReplaceItem).
+CONSUMABLE_MAINTAIN_ITEMS: dict[int, str] = {
+    1: "dust box", 2: "dust filter", 4: "wash ribs", 6: "universal wheel",
+    7: "cliff sensor", 8: "side distance sensor", 9: "water tank sponge",
+    10: "anti-winding brush", 11: "smart module sponge", 20: "dust container",
+}
+CONSUMABLE_REPLACE_ITEMS: dict[int, str] = {
+    1: "dust filter", 2: "mop", 3: "side brush", 4: "clear water filter",
+    5: "roller brush", 6: "detergent", 7: "smart module filter", 8: "dust bag",
+    20: "station bag", 21: "silver ions", 22: "curing agent", 23: "heavy detergent",
+    24: "inner dust box",
+}
+
 # Best-effort help-center deep link for a robot error code. The app's goHelpCenterByCode
 # builds <localized help base>?code=<n>&deviceId=…&lang=…; the exact base is a runtime
 # i18n value we can't read, so this is inferred from the Flow's help-center family and

--- a/custom_components/narwal/coordinator.py
+++ b/custom_components/narwal/coordinator.py
@@ -24,6 +24,9 @@ POLL_INTERVAL = timedelta(seconds=60)
 FAST_POLL_INTERVAL = timedelta(seconds=10)
 FAST_POLL_MAX = 6  # up to 60s of fast polling before falling back to normal
 
+# Consumable alerts change over weeks — poll every ~30 min (30 * POLL_INTERVAL).
+CONSUMABLE_POLL_EVERY = 30
+
 
 class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
     """Push-mode coordinator for Narwal vacuum.
@@ -61,6 +64,7 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         self._last_display_map_resub: float = 0.0
         self._consecutive_failures = 0
         self._max_failures = 5  # 5 * 60s = 5 minutes before entities go unavailable
+        self._consumable_poll_countdown = 0  # 0 = fetch on next poll, then every CONSUMABLE_POLL_EVERY
 
     async def async_setup(self) -> None:
         """Connect to the vacuum and start the WebSocket listener.
@@ -87,6 +91,11 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
             await self.client.get_map()
         except Exception:
             _LOGGER.debug("Could not fetch initial map")
+
+        try:
+            await self.client.get_consumable_info()
+        except Exception:
+            _LOGGER.debug("Could not fetch initial consumable info")
 
         # Subscribe to broadcast topics (display_map, working_status, etc.)
         # Must be sent before listener starts so display_map flows during cleaning.
@@ -250,6 +259,16 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
                 await self.client.get_map()
             except Exception:
                 pass
+
+        # Refresh consumable alerts periodically (slow-changing; not broadcast)
+        if self._consumable_poll_countdown <= 0:
+            self._consumable_poll_countdown = CONSUMABLE_POLL_EVERY
+            try:
+                await self.client.get_consumable_info()
+            except Exception:
+                _LOGGER.debug("Consumable info poll failed")
+        else:
+            self._consumable_poll_countdown -= 1
 
         # Manage fast poll countdown
         if self._fast_poll_remaining > 0:

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -31,6 +31,7 @@ from .const import (
     TOPIC_CMD_FORCE_END,
     TOPIC_CMD_GET_ALL_MAPS,
     TOPIC_CMD_GET_BASE_STATUS,
+    TOPIC_CMD_GET_CONSUMABLE_INFO,
     TOPIC_CMD_GET_CURRENT_TASK,
     TOPIC_CMD_GET_DEVICE_INFO,
     TOPIC_CMD_GET_FEATURE_LIST,
@@ -1289,6 +1290,12 @@ class NarwalClient:
     async def get_current_task(self) -> CommandResponse:
         """Query the current clean task."""
         return await self.send_command(TOPIC_CMD_GET_CURRENT_TASK)
+
+    async def get_consumable_info(self) -> CommandResponse:
+        """Query consumable maintain/replace alert lists (not broadcast)."""
+        resp = await self.send_command(TOPIC_CMD_GET_CONSUMABLE_INFO, timeout=15.0)
+        self.state.update_from_consumable_info(resp.data)
+        return resp
 
     async def get_map(self) -> MapData:
         """Download the full map data."""

--- a/custom_components/narwal/narwal_client/const.py
+++ b/custom_components/narwal/narwal_client/const.py
@@ -68,6 +68,7 @@ TOPIC_CMD_SHUTDOWN = "common/shutdown"
 TOPIC_CMD_GET_DEVICE_INFO = "common/get_device_info"
 TOPIC_CMD_GET_FEATURE_LIST = "common/get_feature_list"
 TOPIC_CMD_GET_BASE_STATUS = "status/get_device_base_status"
+TOPIC_CMD_GET_CONSUMABLE_INFO = "consumable/get_consumable_info"
 
 # Task control
 TOPIC_CMD_PAUSE = "task/pause"

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -174,6 +174,20 @@ def _to_float32(val: Any) -> float | None:
     return None
 
 
+def _enum_int_list(val: Any) -> list[int]:
+    """Coerce a bbp repeated field (int, list, or absent) to a list of non-zero ints."""
+    items = val if isinstance(val, list) else [val] if val is not None else []
+    out: list[int] = []
+    for item in items:
+        try:
+            n = int(item)
+        except (ValueError, TypeError):
+            continue
+        if n:
+            out.append(n)
+    return out
+
+
 def _parse_obstacles(field32: dict) -> list[ObstacleInfo]:
     """Parse obstacle/furniture annotations from bbp-decoded field 2.32.
 
@@ -496,6 +510,10 @@ class NarwalState:
     dust_box_state: int | None = None  # field 20 (DustBoxState)
     dust_bag_state: int | None = None  # field 21 (DustBagState)
     station_bag_state: int | None = None  # field 39 (StationBagStatus)
+
+    # Consumable alerts from consumable/get_consumable_info (queried, not broadcast)
+    maintain_items: list[int] = field(default_factory=list)  # ConsumableMaintainItem values
+    replace_items: list[int] = field(default_factory=list)  # ConsumableReplaceItem values
 
     # Map
     map_data: MapData | None = None
@@ -839,3 +857,15 @@ class NarwalState:
         """
         if "3" in decoded:
             self.download_status = int(decoded["3"])
+
+    def update_from_consumable_info(self, decoded: dict[str, Any]) -> None:
+        """Parse a consumable/get_consumable_info response into maintain/replace alert lists.
+
+        {1: ConsumableInfoPayload{1: maintainItems[], 2: replaceItems[]}}; an empty
+        payload means nothing needs attention. Per-consumable life % is cloud-only.
+        """
+        payload = decoded.get("1")
+        if not isinstance(payload, dict):
+            payload = {}
+        self.maintain_items = _enum_int_list(payload.get("1"))
+        self.replace_items = _enum_int_list(payload.get("2"))

--- a/custom_components/narwal/strings.json
+++ b/custom_components/narwal/strings.json
@@ -79,6 +79,12 @@
       },
       "station_bag": {
         "name": "Station dust bag"
+      },
+      "maintenance_required": {
+        "name": "Maintenance required"
+      },
+      "replacement_required": {
+        "name": "Replacement required"
       }
     }
   }

--- a/custom_components/narwal/translations/en.json
+++ b/custom_components/narwal/translations/en.json
@@ -79,6 +79,12 @@
       },
       "station_bag": {
         "name": "Station dust bag"
+      },
+      "maintenance_required": {
+        "name": "Maintenance required"
+      },
+      "replacement_required": {
+        "name": "Replacement required"
       }
     }
   }

--- a/custom_components/narwal/translations/fr.json
+++ b/custom_components/narwal/translations/fr.json
@@ -79,6 +79,12 @@
       },
       "station_bag": {
         "name": "Sac à poussière de la station"
+      },
+      "maintenance_required": {
+        "name": "Entretien requis"
+      },
+      "replacement_required": {
+        "name": "Remplacement requis"
       }
     }
   }

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -31,6 +31,7 @@ from .const import (
     TOPIC_CMD_FORCE_END,
     TOPIC_CMD_GET_ALL_MAPS,
     TOPIC_CMD_GET_BASE_STATUS,
+    TOPIC_CMD_GET_CONSUMABLE_INFO,
     TOPIC_CMD_GET_CURRENT_TASK,
     TOPIC_CMD_GET_DEVICE_INFO,
     TOPIC_CMD_GET_FEATURE_LIST,
@@ -1289,6 +1290,12 @@ class NarwalClient:
     async def get_current_task(self) -> CommandResponse:
         """Query the current clean task."""
         return await self.send_command(TOPIC_CMD_GET_CURRENT_TASK)
+
+    async def get_consumable_info(self) -> CommandResponse:
+        """Query consumable maintain/replace alert lists (not broadcast)."""
+        resp = await self.send_command(TOPIC_CMD_GET_CONSUMABLE_INFO, timeout=15.0)
+        self.state.update_from_consumable_info(resp.data)
+        return resp
 
     async def get_map(self) -> MapData:
         """Download the full map data."""

--- a/narwal_client/const.py
+++ b/narwal_client/const.py
@@ -68,6 +68,7 @@ TOPIC_CMD_SHUTDOWN = "common/shutdown"
 TOPIC_CMD_GET_DEVICE_INFO = "common/get_device_info"
 TOPIC_CMD_GET_FEATURE_LIST = "common/get_feature_list"
 TOPIC_CMD_GET_BASE_STATUS = "status/get_device_base_status"
+TOPIC_CMD_GET_CONSUMABLE_INFO = "consumable/get_consumable_info"
 
 # Task control
 TOPIC_CMD_PAUSE = "task/pause"

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -174,6 +174,20 @@ def _to_float32(val: Any) -> float | None:
     return None
 
 
+def _enum_int_list(val: Any) -> list[int]:
+    """Coerce a bbp repeated field (int, list, or absent) to a list of non-zero ints."""
+    items = val if isinstance(val, list) else [val] if val is not None else []
+    out: list[int] = []
+    for item in items:
+        try:
+            n = int(item)
+        except (ValueError, TypeError):
+            continue
+        if n:
+            out.append(n)
+    return out
+
+
 def _parse_obstacles(field32: dict) -> list[ObstacleInfo]:
     """Parse obstacle/furniture annotations from bbp-decoded field 2.32.
 
@@ -496,6 +510,10 @@ class NarwalState:
     dust_box_state: int | None = None  # field 20 (DustBoxState)
     dust_bag_state: int | None = None  # field 21 (DustBagState)
     station_bag_state: int | None = None  # field 39 (StationBagStatus)
+
+    # Consumable alerts from consumable/get_consumable_info (queried, not broadcast)
+    maintain_items: list[int] = field(default_factory=list)  # ConsumableMaintainItem values
+    replace_items: list[int] = field(default_factory=list)  # ConsumableReplaceItem values
 
     # Map
     map_data: MapData | None = None
@@ -839,3 +857,15 @@ class NarwalState:
         """
         if "3" in decoded:
             self.download_status = int(decoded["3"])
+
+    def update_from_consumable_info(self, decoded: dict[str, Any]) -> None:
+        """Parse a consumable/get_consumable_info response into maintain/replace alert lists.
+
+        {1: ConsumableInfoPayload{1: maintainItems[], 2: replaceItems[]}}; an empty
+        payload means nothing needs attention. Per-consumable life % is cloud-only.
+        """
+        payload = decoded.get("1")
+        if not isinstance(payload, dict):
+            payload = {}
+        self.maintain_items = _enum_int_list(payload.get("1"))
+        self.replace_items = _enum_int_list(payload.get("2"))

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -56,6 +56,22 @@ def test_no_help_url_when_healthy() -> None:
     assert "help_url" not in desc.attrs_fn(s)
 
 
+def test_consumable_alert_sensors() -> None:
+    """Maintenance/replacement sensors reflect the alert lists + name attributes."""
+    maint, repl = _DESCS["maintenance_required"], _DESCS["replacement_required"]
+    s = NarwalState()
+    assert maint.value_fn(s) is None  # no base_status yet
+    s.update_from_base_status({"2": 0})  # robot reachable
+    s.update_from_consumable_info({"1": {"1": [1], "2": [2, 8]}})
+    assert maint.value_fn(s) is True
+    assert maint.attrs_fn(s)["items"] == ["dust box"]
+    assert repl.value_fn(s) is True
+    assert repl.attrs_fn(s)["items"] == ["mop", "dust bag"]
+    s.update_from_consumable_info({"1": {}})
+    assert maint.value_fn(s) is False
+    assert repl.value_fn(s) is False
+
+
 def test_tank_problem_states() -> None:
     """Tank/bag sensors: None until reported, ok at value 1, problem at ≥2."""
     cw = _DESCS["clean_water_tank"].value_fn

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -45,6 +45,7 @@ class TestCoordinatorResilience:
         coordinator.client.state = NarwalState()
         coordinator._consecutive_failures = 0
         coordinator._max_failures = 5
+        coordinator._consumable_poll_countdown = 99  # don't fire consumable poll in unit tests
         coordinator._fast_poll_remaining = 0
         coordinator._listen_task = None
         coordinator._map_fetch_pending = False

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -272,6 +272,16 @@ class TestNarwalState:
         assert state.clean_water_tank_state == 2  # EMPTY
         assert state.station_bag_state == 3  # SUGGEST_REPLACE
 
+    def test_consumable_info_parse(self) -> None:
+        """consumable/get_consumable_info → maintain/replace alert lists; empty clears."""
+        state = NarwalState()
+        state.update_from_consumable_info({"1": {"1": [1, 9], "2": 8}})
+        assert state.maintain_items == [1, 9]  # dust_box, water_tank_sponge
+        assert state.replace_items == [8]  # dust_bag
+        state.update_from_consumable_info({"1": {}})  # healthy
+        assert state.maintain_items == []
+        assert state.replace_items == []
+
     def test_update_from_upgrade_status(self) -> None:
         state = NarwalState()
         state.update_from_upgrade_status({


### PR DESCRIPTION
### Summary
Adds a periodic `consumable/get_consumable_info` query (at startup, then every
~30 min) and exposes the robot's `maintainItems` / `replaceItems` as two
`problem` binary sensors. The specific parts (mop, dust bag, side brush, …) are
listed in an `items` attribute.

Per-part life percentages are cloud-only and not available over the LAN protocol,
so these alert lists are what the robot exposes locally — but they're enough to
drive "time to clean/replace X" notifications.

### Depends on #52
Uses the description-driven binary-sensor framework introduced in #52. Review/merge
that first; this branch is based on it (will rebase onto `master` once it lands).

### Testing
`tests/test_binary_sensor.py`, `test_models.py`, `test_coordinator.py` updated;
suite green.

### Relates to
- #32 (new sensor request)
