### PR TITLE
narwal: Fix room clean command

### DIFF
--- a/custom_components/narwal/const.py
+++ b/custom_components/narwal/const.py
@@ -31,11 +31,21 @@ PLATFORMS: list[Platform] = [
     Platform.CAMERA,
 ]
 
-FAN_SPEED_MAP: dict[str, FanLevel] = {
-    "quiet": FanLevel.QUIET,
-    "normal": FanLevel.NORMAL,
-    "strong": FanLevel.STRONG,
-    "max": FanLevel.MAX,
+# HA fan_speed labels for the live clean/set_fan_level command. Its
+# SweepFanLevel enum stops at DEEP; SUPER remains available to clean settings.
+_FAN_SPEED_CANONICAL: dict[str, FanLevel] = {
+    "Quiet": FanLevel.MUTE,
+    "Standard": FanLevel.NORMAL,
+    "Strong": FanLevel.STRONG,
+    "Super powerful": FanLevel.DEEP,
 }
 
-FAN_SPEED_LIST: list[str] = list(FAN_SPEED_MAP.keys())
+FAN_SPEED_LIST: list[str] = list(_FAN_SPEED_CANONICAL)
+
+# FAN_SPEED_MAP also accepts the original lowercase fan_speed values (quiet/normal/strong/max) so existing automations keep working; these aliases are not offered in FAN_SPEED_LIST.
+FAN_SPEED_MAP: dict[str, FanLevel] = _FAN_SPEED_CANONICAL | {
+    "quiet": FanLevel.MUTE,
+    "normal": FanLevel.NORMAL,
+    "strong": FanLevel.STRONG,
+    "max": FanLevel.DEEP,
+}

--- a/custom_components/narwal/narwal_client/__init__.py
+++ b/custom_components/narwal/narwal_client/__init__.py
@@ -1,7 +1,7 @@
 """Narwal robot vacuum client library — local WebSocket API."""
 
 from .client import NarwalClient, NarwalCommandError, NarwalConnectionError
-from .const import CommandResult, FanLevel, MopHumidity, WorkingStatus
+from .const import CommandResult, FanLevel, MopHumidity, MopStrengthLevel, WorkMode, WorkingStatus
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState, RoomInfo
 from .protocol import build_frame, parse_frame
 
@@ -17,7 +17,9 @@ __all__ = [
     "MapData",
     "MapDisplayData",
     "MopHumidity",
+    "MopStrengthLevel",
     "RoomInfo",
+    "WorkMode",
     "WorkingStatus",
     "build_frame",
     "parse_frame",

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -19,6 +19,7 @@ from .const import (
     HEARTBEAT_INTERVAL,
     KEEPALIVE_INTERVAL,
     KNOWN_PRODUCT_KEYS,
+    LEGACY_ROOM_CLEAN_PRODUCT_KEYS,
     RECONNECT_BACKOFF_FACTOR,
     RECONNECT_INITIAL_DELAY,
     RECONNECT_MAX_DELAY,
@@ -42,7 +43,8 @@ from .const import (
     TOPIC_CMD_RESUME,
     TOPIC_CMD_SET_FAN_LEVEL,
     TOPIC_CMD_SET_MOP_HUMIDITY,
-    TOPIC_CMD_START_CLEAN,
+    TOPIC_CMD_PLAN_START,
+    TOPIC_CMD_CLEAN_TASK,
     TOPIC_CMD_TAKE_PICTURE,
     TOPIC_CMD_SET_LED,
     TOPIC_CMD_WASH_MOP,
@@ -52,6 +54,9 @@ from .const import (
     CommandResult,
     FanLevel,
     MopHumidity,
+    MopStrengthLevel,
+    WorkMode,
+    WorkingStatus,
 )
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState
 from .protocol import (
@@ -915,7 +920,7 @@ class NarwalClient:
         so we know which rooms to include.
         """
         resp = await self.send_command(
-            TOPIC_CMD_START_CLEAN,
+            TOPIC_CMD_PLAN_START,
             payload=self._DEFAULT_CLEAN_PAYLOAD,
             timeout=10.0,
         )
@@ -944,7 +949,7 @@ class NarwalClient:
         )
         payload = self._build_clean_payload_v2(room_ids)
         return await self.send_command(
-            TOPIC_CMD_START_CLEAN, payload=payload, timeout=10.0,
+            TOPIC_CMD_PLAN_START, payload=payload, timeout=10.0,
         )
 
     def _build_clean_payload_v2(
@@ -958,9 +963,7 @@ class NarwalClient:
         """Build clean task payload using the v2 schema (firmware v01.07.22+).
 
         Observed in issue #36 from a Flow on firmware v01.07.22.00.
-        Each room entry uses a nested room_id (different from the flat
-        schema in _build_room_clean_payload used for room-targeted cleans
-        on older firmware):
+        Each room entry uses a nested room_id:
 
             {
               1: {1: 1, 2: <room_id>},                # nested room ref
@@ -1046,41 +1049,100 @@ class NarwalClient:
         }
         return blackboxprotobuf.encode_message(msg, typedef)
 
-    def _build_room_clean_payload(self, room_ids: list[int]) -> bytes:
-        """Build CleanTask protobuf with per-room clean params in field 1.2.
+    # WorkMode -> (CleanParam.mode tag 1, pass-count tags to set from `passes`). The robot's
+    # execution mode is CleanTask.taskType (= the WorkMode value); CleanParam.mode and the
+    # pass tag are derived here so the two can't drift. Live-validated on a Flow 2; see
+    # project_history.md "CleanParam — fully decoded".
+    _WORK_MODE_PARAM: dict[WorkMode, tuple[int, tuple[str, ...]]] = {
+        WorkMode.VACUUM: (2, ("5",)),               # sweepTime
+        WorkMode.MOP: (3, ("6",)),                 # mopTime
+        WorkMode.VACUUM_THEN_MOP: (5, ("5", "6")),  # sweep + mop pass counts
+        WorkMode.VACUUM_AND_MOP: (4, ("7",)),      # sweepMopSyncTime
+    }
 
-        Each room entry in field 1.2 requires full MapCleanParamInfo fields
-        (from APK proto analysis):
-          field 1: roomId (uint32)
-          field 2: cleanMode (int32) — 0=sweep, 1=mop, 2=sweep+mop
-          field 3: cleanTimes (int32) — number of passes
-          field 6: sweepMode (int32) — suction level (3=max)
-          field 7: mopMode (int32) — mop humidity (2=wet)
+    def _build_start_clean_payload(
+        self,
+        room_ids: list[int],
+        map_id: int,
+        *,
+        work_mode: WorkMode = WorkMode.VACUUM_AND_MOP,
+        fan: FanLevel = FanLevel.NORMAL,
+        water: MopHumidity = MopHumidity.NORMAL,
+        mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL,
+        passes: int = 1,
+    ) -> bytes:
+        """Build a clean/start_clean request for the given rooms.
 
-        A bare roomId without clean params is silently ignored by the robot.
+        StartClean_Request{1: CleanTask{1: map_id, 2: [CleanItem...], 3: {} (TaskOption),
+        5: taskType}}; CleanItem{1: ZoneOption{1: 1 (room zone), 2: room_id}, 2: CleanParam,
+        3: order}. taskType (the execution-mode carrier) and CleanParam.mode/pass-tag are
+        derived from work_mode. overlapLevel is omitted — live-validated as ignored here.
 
         Args:
-            room_ids: List of room IDs from RoomInfo.room_id.
-
-        Returns:
-            Encoded protobuf bytes for clean/plan/start.
+            room_ids: Robot room IDs (RoomInfo.room_id).
+            map_id: Active map id (MapData.map_id, get_map field 2.1).
+            work_mode: Vacuum / mop / vacuum-then-mop / vacuum-and-mop.
+            fan: Suction level (CleanParam tag 2).
+            water: Mop water volume (tag 4).
+            mop_strength: Mop scrub intensity (tag 3).
+            passes: Clean count, routed to the pass tag(s) for the mode.
         """
+        import blackboxprotobuf
+
+        param_mode, pass_tags = self._WORK_MODE_PARAM[work_mode]
+        param: dict[str, int] = {
+            "1": int(param_mode),
+            "2": int(fan),
+            "3": int(mop_strength),
+            "4": int(water),
+        }
+        for tag in pass_tags:
+            param[tag] = int(passes)
+
+        items = [
+            {"1": {"1": 1, "2": rid}, "2": dict(param), "3": idx + 1}
+            for idx, rid in enumerate(room_ids)
+        ]
+        task = {
+            "1": map_id,
+            "2": items if len(items) > 1 else items[0],
+            "3": {},
+            "5": int(work_mode),  # CleanTask.taskType
+        }
+        item_typedef = {
+            "type": "message",
+            "seen_repeated": True,
+            "message_typedef": {
+                "1": {"type": "message", "message_typedef": {
+                    "1": {"type": "int"}, "2": {"type": "int"},
+                }},
+                # Derive the CleanParam typedef from the emitted dict — bbpb silently
+                # drops any tag absent from the typedef.
+                "2": {"type": "message", "message_typedef": {
+                    k: {"type": "int"} for k in param
+                }},
+                "3": {"type": "int"},
+            },
+        }
+        typedef = {"1": {"type": "message", "message_typedef": {
+            "1": {"type": "int"},
+            "2": item_typedef,
+            "3": {"type": "message", "message_typedef": {}},
+            "5": {"type": "int"},
+        }}}
+        return blackboxprotobuf.encode_message({"1": task}, typedef)
+
+    def _build_room_clean_payload(self, room_ids: list[int]) -> bytes:
+        """Build the legacy flat room-clean payload for older firmware."""
         if not room_ids:
             return self._DEFAULT_CLEAN_PAYLOAD
 
         import blackboxprotobuf
 
-        # Build per-room entries with default clean settings
-        room_entries = []
-        for rid in room_ids:
-            room_entries.append({
-                "1": rid,       # roomId
-                "2": 2,         # cleanMode = sweep+mop
-                "3": 1,         # cleanTimes = 1 pass
-                "6": 3,         # sweepMode = max suction
-                "7": 2,         # mopMode = wet
-            })
-
+        room_entries = [
+            {"1": room_id, "2": 2, "3": 1, "6": 3, "7": 2}
+            for room_id in room_ids
+        ]
         room_typedef = {
             "type": "message",
             "seen_repeated": True,
@@ -1090,19 +1152,13 @@ class NarwalClient:
                 "3": {"type": "int"},
                 "6": {"type": "int"},
                 "7": {"type": "int"},
-            }
+            },
         }
-
-        # Single room: field 1.2 is a message; multiple: repeated message
         field_2_value = room_entries[0] if len(room_entries) == 1 else room_entries
-
-        msg = {
+        message = {
             "1": {
                 "2": field_2_value,
-                "5": {
-                    "1": {"1": 3, "2": 2, "3": 1},
-                    "5": {}
-                }
+                "5": {"1": {"1": 3, "2": 2, "3": 1}, "5": {}},
             }
         }
         typedef = {
@@ -1118,53 +1174,143 @@ class NarwalClient:
                                 "message_typedef": {
                                     "1": {"type": "int"},
                                     "2": {"type": "int"},
-                                    "3": {"type": "int"}
-                                }
+                                    "3": {"type": "int"},
+                                },
                             },
-                            "5": {"type": "message", "message_typedef": {}}
-                        }
-                    }
-                }
+                            "5": {"type": "message", "message_typedef": {}},
+                        },
+                    },
+                },
             }
         }
-        return blackboxprotobuf.encode_message(msg, typedef)
+        return blackboxprotobuf.encode_message(message, typedef)
 
     async def start_rooms(
-        self, room_ids: list[int],
+        self,
+        room_ids: list[int],
+        *,
+        work_mode: WorkMode = WorkMode.VACUUM_AND_MOP,
+        fan: FanLevel = FanLevel.DEEP,
+        water: MopHumidity = MopHumidity.WET,
+        mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL,
+        passes: int = 1,
     ) -> CommandResponse:
-        """Start room-specific cleaning.
+        """Start cleaning the given rooms via clean/start_clean.
 
-        Sends clean/plan/start with the user-selected rooms. Tries the v2
-        nested-room schema first (required by firmware v01.07.22+, and fixes
-        the ack-but-ignore behavior in #37 where legacy schema returns
-        SUCCESS but the robot runs the app shortcut instead of HA-selected
-        rooms). Falls back to legacy flat-room schema on NOT_APPLICABLE
-        for older firmware.
+        Room cleaning must use clean/start_clean (StartClean → CleanTask), not
+        clean/plan/start: on Flow firmware the latter is StartWithPlan{planId,
+        mapId} and ignores any room payload — the root cause of #25/#37, where
+        the robot undocks and wanders instead of cleaning the selected rooms.
+        The CleanTask carries the active map id (get_map field 2.1).
+
+        clean/start_clean only works while docked; from STANDBY the robot
+        returns NOT_READY (4). Callers should start from the dock; this retries
+        briefly to cover the dock settling transition.
 
         Args:
-            room_ids: List of room IDs from RoomInfo.room_id.
-
-        Returns:
-            CommandResponse with result code from whichever schema landed.
+            room_ids: Robot room IDs (RoomInfo.room_id), mapped from HA areas.
+            work_mode, fan, water, mop_strength, passes: CleanParam settings —
+                see _build_start_clean_payload.
         """
         if not room_ids:
             return await self.start()
 
-        payload_v2 = self._build_clean_payload_v2(room_ids)
+        product_key = (
+            self.state.device_info.product_key
+            if self.state.device_info is not None
+            and self.state.device_info.product_key
+            else self.topic_prefix.removeprefix("/")
+        )
+        supports_legacy_room_clean = product_key in LEGACY_ROOM_CLEAN_PRODUCT_KEYS
+        map_data = self.state.map_data
+        if not map_data or not map_data.map_id:
+            try:
+                map_data = await self.get_map()
+            except NarwalCommandError:
+                if not supports_legacy_room_clean:
+                    raise
+                _LOGGER.debug(
+                    "start_rooms: map fetch failed; trying legacy room-clean commands"
+                )
+                map_data = None
+        map_id = map_data.map_id if map_data else 0
+        if not map_id and not supports_legacy_room_clean:
+            return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        resp = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        if map_id:
+            payload = self._build_start_clean_payload(
+                room_ids,
+                map_id,
+                work_mode=work_mode,
+                fan=fan,
+                water=water,
+                mop_strength=mop_strength,
+                passes=passes,
+            )
+            resp = await self.send_command(
+                TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
+            )
+            for _ in range(3):
+                if resp.result_code != CommandResult.NOT_READY:
+                    break
+                if not self.state.is_docked:
+                    _LOGGER.warning(
+                        "start_rooms: robot not docked (status=%s); "
+                        "clean/start_clean requires the robot on the dock",
+                        self.state.working_status.name,
+                    )
+                    break
+                _LOGGER.info(
+                    "start_rooms: robot docking/settling, retrying "
+                    "clean/start_clean"
+                )
+                await asyncio.sleep(3.0)
+                resp = await self.send_command(
+                    TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
+                )
+        else:
+            _LOGGER.warning(
+                "start_rooms: no active map id available; trying legacy room clean"
+            )
+        if resp.result_code != CommandResult.NOT_APPLICABLE:
+            return resp
+        if not supports_legacy_room_clean:
+            return resp
+
+        _LOGGER.info(
+            "start_rooms: clean/start_clean rejected, trying clean/plan/start "
+            "compatibility payloads"
+        )
+        legacy_suction = {
+            FanLevel.UNSPECIFIED: 3,
+            FanLevel.MUTE: 0,
+            FanLevel.NORMAL: 1,
+            FanLevel.STRONG: 2,
+            FanLevel.DEEP: 3,
+            FanLevel.SUPER: 3,
+        }[FanLevel(fan)]
+        legacy_water = {
+            MopHumidity.UNSPECIFIED: 2,
+            MopHumidity.DRY: 0,
+            MopHumidity.NORMAL: 1,
+            MopHumidity.WET: 2,
+        }[MopHumidity(water)]
+        legacy_v2 = self._build_clean_payload_v2(
+            room_ids,
+            suction=legacy_suction,
+            mop_humidity=legacy_water,
+            passes=passes,
+        )
         resp = await self.send_command(
-            TOPIC_CMD_START_CLEAN, payload=payload_v2, timeout=10.0,
+            TOPIC_CMD_PLAN_START, payload=legacy_v2, timeout=10.0,
         )
         if resp.result_code != CommandResult.NOT_APPLICABLE:
             return resp
 
-        # v2 rejected — try legacy flat-room schema (older firmware)
-        _LOGGER.info(
-            "start_rooms(): v2 payload rejected, retrying with legacy schema (%d rooms)",
-            len(room_ids),
-        )
-        payload_legacy = self._build_room_clean_payload(room_ids)
         return await self.send_command(
-            TOPIC_CMD_START_CLEAN, payload=payload_legacy, timeout=10.0,
+            TOPIC_CMD_PLAN_START,
+            payload=self._build_room_clean_payload(room_ids),
+            timeout=10.0,
         )
 
     async def start_easy_clean(self) -> CommandResponse:
@@ -1196,21 +1342,48 @@ class NarwalClient:
         return await self.send_command(TOPIC_CMD_RECALL, timeout=timeout)
 
     async def set_fan_speed(self, level: FanLevel | int) -> CommandResponse:
-        """Set suction fan speed.
+        """Set suction fan speed live (clean/set_fan_level, field 1 = SweepFanLevel).
 
-        Args:
-            level: FanLevel enum or int (0=quiet, 1=normal, 2=strong, 3=max).
+        The live command's enum is SweepFanLevel, which has no SUPER. Use its
+        highest available level, DEEP, when callers request SUPER. Bare integer
+        values retain the original 0=quiet through 3=max API mapping.
         """
-        payload = b"\x08" + bytes([int(level) & 0x7F])
+        if isinstance(level, FanLevel):
+            live = min(int(level), int(FanLevel.DEEP))
+        else:
+            legacy_levels = {
+                0: FanLevel.MUTE,
+                1: FanLevel.NORMAL,
+                2: FanLevel.STRONG,
+                3: FanLevel.DEEP,
+            }
+            try:
+                live = int(legacy_levels[level])
+            except KeyError as err:
+                raise ValueError(f"Invalid legacy fan level: {level}") from err
+        payload = b"\x08" + bytes([live & 0x7F])
         return await self.send_command(TOPIC_CMD_SET_FAN_LEVEL, payload)
 
     async def set_mop_humidity(self, level: MopHumidity | int) -> CommandResponse:
-        """Set mop wetness level.
+        """Set mop water volume live (clean/set_mop_humidity, field 1 = MopHumidity).
 
         Args:
-            level: MopHumidity enum or int (0=dry, 1=normal, 2=wet).
+            level: MopHumidity enum, or the legacy int mapping
+                (0=dry, 1=normal, 2=wet).
         """
-        payload = b"\x08" + bytes([int(level) & 0x7F])
+        if isinstance(level, MopHumidity):
+            live = int(level)
+        else:
+            legacy_levels = {
+                0: MopHumidity.DRY,
+                1: MopHumidity.NORMAL,
+                2: MopHumidity.WET,
+            }
+            try:
+                live = int(legacy_levels[level])
+            except KeyError as err:
+                raise ValueError(f"Invalid legacy mop humidity: {level}") from err
+        payload = b"\x08" + bytes([live & 0x7F])
         return await self.send_command(TOPIC_CMD_SET_MOP_HUMIDITY, payload)
 
     async def wash_mop(self) -> CommandResponse:

--- a/custom_components/narwal/narwal_client/const.py
+++ b/custom_components/narwal/narwal_client/const.py
@@ -51,6 +51,8 @@ KNOWN_PRODUCT_KEYS = [
     "cUlfJN5JYP",   # Unknown model (APK, contributed by @northwestsupra)
 ]
 
+LEGACY_ROOM_CLEAN_PRODUCT_KEYS = {"QoEsI5qYXO"}
+
 # --- Status topics (robot → client, field 4 / 0x22 frames) ---
 TOPIC_WORKING_STATUS = "status/working_status"
 TOPIC_ROBOT_BASE_STATUS = "status/robot_base_status"
@@ -82,8 +84,8 @@ TOPIC_CMD_DRY_MOP = "supply/dry_mop"
 TOPIC_CMD_DUST_GATHERING = "supply/dust_gathering"
 
 # Cleaning (Pita protocol — correct for AX12)
-TOPIC_CMD_START_CLEAN = "clean/plan/start"  # whole-house clean (empty payload)
-TOPIC_CMD_START_CLEAN_LEGACY = "clean/start_clean"  # does NOT work from STANDBY
+TOPIC_CMD_PLAN_START = "clean/plan/start"  # whole-house clean (empty payload)
+TOPIC_CMD_CLEAN_TASK = "clean/start_clean"  # room/zone CleanTask; only works docked
 TOPIC_CMD_EASY_CLEAN = "clean/easy_clean/start"
 TOPIC_CMD_SET_FAN_LEVEL = "clean/set_fan_level"
 TOPIC_CMD_SET_MOP_HUMIDITY = "clean/set_mop_humidity"
@@ -141,6 +143,7 @@ class CommandResult(IntEnum):
     SUCCESS = 1
     NOT_APPLICABLE = 2  # e.g., set_fan_level when not cleaning
     CONFLICT = 3  # e.g., recall when already recalling
+    NOT_READY = 4  # clean/start_clean while not docked (robot in STANDBY)
 
 
 class WorkingStatus(IntEnum):
@@ -179,20 +182,42 @@ class WorkingStatus(IntEnum):
 
 
 class FanLevel(IntEnum):
-    """Suction fan speed levels (SweepMode from APK)."""
+    """CleanParam suction level (CleanTask.pbenum FanLevel)."""
 
-    QUIET = 0
-    NORMAL = 1
-    STRONG = 2
-    MAX = 3
+    UNSPECIFIED = 0
+    MUTE = 1
+    QUIET = MUTE
+    NORMAL = 2
+    STRONG = 3
+    DEEP = 4
+    MAX = DEEP
+    SUPER = 5
 
 
 class MopHumidity(IntEnum):
-    """Mop wetness levels."""
+    """Water volume. CleanParam tag 4 and the live clean/set_mop_humidity command share these ints."""
 
-    DRY = 0
+    UNSPECIFIED = 0
+    DRY = 1
+    NORMAL = 2
+    WET = 3
+
+
+class MopStrengthLevel(IntEnum):
+    """Mop scrub intensity (CleanParam tag 3)."""
+
+    UNSPECIFIED = 0
     NORMAL = 1
-    WET = 2
+    HIGH = 2
+
+
+class WorkMode(IntEnum):
+    """Clean work mode — the app's robot_work_mode_* selector (Vacuum / Mop / Vacuum then mop / Vacuum and mop). Its value IS the CleanTask.taskType the robot executes; the per-item CleanParam.mode (the proto's own CleanMode enum) is derived separately in client._WORK_MODE_PARAM."""
+
+    VACUUM = 1
+    MOP = 2
+    VACUUM_THEN_MOP = 3
+    VACUUM_AND_MOP = 4
 
 
 # robot_base_status field numbers

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -254,6 +254,7 @@ class MapData:
     origin_y: int = 0  # y pixel offset from field 2.6.1
     obstacles: list[ObstacleInfo] = field(default_factory=list)
     raw: dict[str, Any] = field(default_factory=dict)
+    map_id: int = 0  # active map id (field 2.1) — required by clean/start_clean
 
     @classmethod
     def from_response(
@@ -344,6 +345,7 @@ class MapData:
             obstacles = _parse_obstacles(field32)
 
         return cls(
+            map_id=int(payload.get("1", 0)),
             width=int(payload.get("4", 0)),
             height=int(payload.get("5", 0)),
             resolution=resolution,

--- a/custom_components/narwal/vacuum.py
+++ b/custom_components/narwal/vacuum.py
@@ -189,7 +189,14 @@ class NarwalVacuum(NarwalEntity, StateVacuumEntity):
         level = FAN_SPEED_MAP.get(fan_speed)
         if level is not None:
             await self.coordinator.client.set_fan_speed(level)
-            self._last_fan_speed = fan_speed
+            self._last_fan_speed = next(
+                (
+                    label
+                    for label in FAN_SPEED_LIST
+                    if FAN_SPEED_MAP[label] == level
+                ),
+                fan_speed,
+            )
             self.async_write_ha_state()
 
     # --- Segment API (HA 2026.3 room-specific cleaning) ---

--- a/narwal_client/__init__.py
+++ b/narwal_client/__init__.py
@@ -1,7 +1,7 @@
 """Narwal robot vacuum client library — local WebSocket API."""
 
 from .client import NarwalClient, NarwalCommandError, NarwalConnectionError
-from .const import CommandResult, FanLevel, MopHumidity, WorkingStatus
+from .const import CommandResult, FanLevel, MopHumidity, MopStrengthLevel, WorkMode, WorkingStatus
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState, RoomInfo
 from .protocol import build_frame, parse_frame
 
@@ -17,7 +17,9 @@ __all__ = [
     "MapData",
     "MapDisplayData",
     "MopHumidity",
+    "MopStrengthLevel",
     "RoomInfo",
+    "WorkMode",
     "WorkingStatus",
     "build_frame",
     "parse_frame",

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -19,6 +19,7 @@ from .const import (
     HEARTBEAT_INTERVAL,
     KEEPALIVE_INTERVAL,
     KNOWN_PRODUCT_KEYS,
+    LEGACY_ROOM_CLEAN_PRODUCT_KEYS,
     RECONNECT_BACKOFF_FACTOR,
     RECONNECT_INITIAL_DELAY,
     RECONNECT_MAX_DELAY,
@@ -42,7 +43,8 @@ from .const import (
     TOPIC_CMD_RESUME,
     TOPIC_CMD_SET_FAN_LEVEL,
     TOPIC_CMD_SET_MOP_HUMIDITY,
-    TOPIC_CMD_START_CLEAN,
+    TOPIC_CMD_PLAN_START,
+    TOPIC_CMD_CLEAN_TASK,
     TOPIC_CMD_TAKE_PICTURE,
     TOPIC_CMD_SET_LED,
     TOPIC_CMD_WASH_MOP,
@@ -52,6 +54,9 @@ from .const import (
     CommandResult,
     FanLevel,
     MopHumidity,
+    MopStrengthLevel,
+    WorkMode,
+    WorkingStatus,
 )
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState
 from .protocol import (
@@ -915,7 +920,7 @@ class NarwalClient:
         so we know which rooms to include.
         """
         resp = await self.send_command(
-            TOPIC_CMD_START_CLEAN,
+            TOPIC_CMD_PLAN_START,
             payload=self._DEFAULT_CLEAN_PAYLOAD,
             timeout=10.0,
         )
@@ -944,7 +949,7 @@ class NarwalClient:
         )
         payload = self._build_clean_payload_v2(room_ids)
         return await self.send_command(
-            TOPIC_CMD_START_CLEAN, payload=payload, timeout=10.0,
+            TOPIC_CMD_PLAN_START, payload=payload, timeout=10.0,
         )
 
     def _build_clean_payload_v2(
@@ -958,9 +963,7 @@ class NarwalClient:
         """Build clean task payload using the v2 schema (firmware v01.07.22+).
 
         Observed in issue #36 from a Flow on firmware v01.07.22.00.
-        Each room entry uses a nested room_id (different from the flat
-        schema in _build_room_clean_payload used for room-targeted cleans
-        on older firmware):
+        Each room entry uses a nested room_id:
 
             {
               1: {1: 1, 2: <room_id>},                # nested room ref
@@ -1046,41 +1049,100 @@ class NarwalClient:
         }
         return blackboxprotobuf.encode_message(msg, typedef)
 
-    def _build_room_clean_payload(self, room_ids: list[int]) -> bytes:
-        """Build CleanTask protobuf with per-room clean params in field 1.2.
+    # WorkMode -> (CleanParam.mode tag 1, pass-count tags to set from `passes`). The robot's
+    # execution mode is CleanTask.taskType (= the WorkMode value); CleanParam.mode and the
+    # pass tag are derived here so the two can't drift. Live-validated on a Flow 2; see
+    # project_history.md "CleanParam — fully decoded".
+    _WORK_MODE_PARAM: dict[WorkMode, tuple[int, tuple[str, ...]]] = {
+        WorkMode.VACUUM: (2, ("5",)),               # sweepTime
+        WorkMode.MOP: (3, ("6",)),                 # mopTime
+        WorkMode.VACUUM_THEN_MOP: (5, ("5", "6")),  # sweep + mop pass counts
+        WorkMode.VACUUM_AND_MOP: (4, ("7",)),      # sweepMopSyncTime
+    }
 
-        Each room entry in field 1.2 requires full MapCleanParamInfo fields
-        (from APK proto analysis):
-          field 1: roomId (uint32)
-          field 2: cleanMode (int32) — 0=sweep, 1=mop, 2=sweep+mop
-          field 3: cleanTimes (int32) — number of passes
-          field 6: sweepMode (int32) — suction level (3=max)
-          field 7: mopMode (int32) — mop humidity (2=wet)
+    def _build_start_clean_payload(
+        self,
+        room_ids: list[int],
+        map_id: int,
+        *,
+        work_mode: WorkMode = WorkMode.VACUUM_AND_MOP,
+        fan: FanLevel = FanLevel.NORMAL,
+        water: MopHumidity = MopHumidity.NORMAL,
+        mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL,
+        passes: int = 1,
+    ) -> bytes:
+        """Build a clean/start_clean request for the given rooms.
 
-        A bare roomId without clean params is silently ignored by the robot.
+        StartClean_Request{1: CleanTask{1: map_id, 2: [CleanItem...], 3: {} (TaskOption),
+        5: taskType}}; CleanItem{1: ZoneOption{1: 1 (room zone), 2: room_id}, 2: CleanParam,
+        3: order}. taskType (the execution-mode carrier) and CleanParam.mode/pass-tag are
+        derived from work_mode. overlapLevel is omitted — live-validated as ignored here.
 
         Args:
-            room_ids: List of room IDs from RoomInfo.room_id.
-
-        Returns:
-            Encoded protobuf bytes for clean/plan/start.
+            room_ids: Robot room IDs (RoomInfo.room_id).
+            map_id: Active map id (MapData.map_id, get_map field 2.1).
+            work_mode: Vacuum / mop / vacuum-then-mop / vacuum-and-mop.
+            fan: Suction level (CleanParam tag 2).
+            water: Mop water volume (tag 4).
+            mop_strength: Mop scrub intensity (tag 3).
+            passes: Clean count, routed to the pass tag(s) for the mode.
         """
+        import blackboxprotobuf
+
+        param_mode, pass_tags = self._WORK_MODE_PARAM[work_mode]
+        param: dict[str, int] = {
+            "1": int(param_mode),
+            "2": int(fan),
+            "3": int(mop_strength),
+            "4": int(water),
+        }
+        for tag in pass_tags:
+            param[tag] = int(passes)
+
+        items = [
+            {"1": {"1": 1, "2": rid}, "2": dict(param), "3": idx + 1}
+            for idx, rid in enumerate(room_ids)
+        ]
+        task = {
+            "1": map_id,
+            "2": items if len(items) > 1 else items[0],
+            "3": {},
+            "5": int(work_mode),  # CleanTask.taskType
+        }
+        item_typedef = {
+            "type": "message",
+            "seen_repeated": True,
+            "message_typedef": {
+                "1": {"type": "message", "message_typedef": {
+                    "1": {"type": "int"}, "2": {"type": "int"},
+                }},
+                # Derive the CleanParam typedef from the emitted dict — bbpb silently
+                # drops any tag absent from the typedef.
+                "2": {"type": "message", "message_typedef": {
+                    k: {"type": "int"} for k in param
+                }},
+                "3": {"type": "int"},
+            },
+        }
+        typedef = {"1": {"type": "message", "message_typedef": {
+            "1": {"type": "int"},
+            "2": item_typedef,
+            "3": {"type": "message", "message_typedef": {}},
+            "5": {"type": "int"},
+        }}}
+        return blackboxprotobuf.encode_message({"1": task}, typedef)
+
+    def _build_room_clean_payload(self, room_ids: list[int]) -> bytes:
+        """Build the legacy flat room-clean payload for older firmware."""
         if not room_ids:
             return self._DEFAULT_CLEAN_PAYLOAD
 
         import blackboxprotobuf
 
-        # Build per-room entries with default clean settings
-        room_entries = []
-        for rid in room_ids:
-            room_entries.append({
-                "1": rid,       # roomId
-                "2": 2,         # cleanMode = sweep+mop
-                "3": 1,         # cleanTimes = 1 pass
-                "6": 3,         # sweepMode = max suction
-                "7": 2,         # mopMode = wet
-            })
-
+        room_entries = [
+            {"1": room_id, "2": 2, "3": 1, "6": 3, "7": 2}
+            for room_id in room_ids
+        ]
         room_typedef = {
             "type": "message",
             "seen_repeated": True,
@@ -1090,19 +1152,13 @@ class NarwalClient:
                 "3": {"type": "int"},
                 "6": {"type": "int"},
                 "7": {"type": "int"},
-            }
+            },
         }
-
-        # Single room: field 1.2 is a message; multiple: repeated message
         field_2_value = room_entries[0] if len(room_entries) == 1 else room_entries
-
-        msg = {
+        message = {
             "1": {
                 "2": field_2_value,
-                "5": {
-                    "1": {"1": 3, "2": 2, "3": 1},
-                    "5": {}
-                }
+                "5": {"1": {"1": 3, "2": 2, "3": 1}, "5": {}},
             }
         }
         typedef = {
@@ -1118,53 +1174,143 @@ class NarwalClient:
                                 "message_typedef": {
                                     "1": {"type": "int"},
                                     "2": {"type": "int"},
-                                    "3": {"type": "int"}
-                                }
+                                    "3": {"type": "int"},
+                                },
                             },
-                            "5": {"type": "message", "message_typedef": {}}
-                        }
-                    }
-                }
+                            "5": {"type": "message", "message_typedef": {}},
+                        },
+                    },
+                },
             }
         }
-        return blackboxprotobuf.encode_message(msg, typedef)
+        return blackboxprotobuf.encode_message(message, typedef)
 
     async def start_rooms(
-        self, room_ids: list[int],
+        self,
+        room_ids: list[int],
+        *,
+        work_mode: WorkMode = WorkMode.VACUUM_AND_MOP,
+        fan: FanLevel = FanLevel.DEEP,
+        water: MopHumidity = MopHumidity.WET,
+        mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL,
+        passes: int = 1,
     ) -> CommandResponse:
-        """Start room-specific cleaning.
+        """Start cleaning the given rooms via clean/start_clean.
 
-        Sends clean/plan/start with the user-selected rooms. Tries the v2
-        nested-room schema first (required by firmware v01.07.22+, and fixes
-        the ack-but-ignore behavior in #37 where legacy schema returns
-        SUCCESS but the robot runs the app shortcut instead of HA-selected
-        rooms). Falls back to legacy flat-room schema on NOT_APPLICABLE
-        for older firmware.
+        Room cleaning must use clean/start_clean (StartClean → CleanTask), not
+        clean/plan/start: on Flow firmware the latter is StartWithPlan{planId,
+        mapId} and ignores any room payload — the root cause of #25/#37, where
+        the robot undocks and wanders instead of cleaning the selected rooms.
+        The CleanTask carries the active map id (get_map field 2.1).
+
+        clean/start_clean only works while docked; from STANDBY the robot
+        returns NOT_READY (4). Callers should start from the dock; this retries
+        briefly to cover the dock settling transition.
 
         Args:
-            room_ids: List of room IDs from RoomInfo.room_id.
-
-        Returns:
-            CommandResponse with result code from whichever schema landed.
+            room_ids: Robot room IDs (RoomInfo.room_id), mapped from HA areas.
+            work_mode, fan, water, mop_strength, passes: CleanParam settings —
+                see _build_start_clean_payload.
         """
         if not room_ids:
             return await self.start()
 
-        payload_v2 = self._build_clean_payload_v2(room_ids)
+        product_key = (
+            self.state.device_info.product_key
+            if self.state.device_info is not None
+            and self.state.device_info.product_key
+            else self.topic_prefix.removeprefix("/")
+        )
+        supports_legacy_room_clean = product_key in LEGACY_ROOM_CLEAN_PRODUCT_KEYS
+        map_data = self.state.map_data
+        if not map_data or not map_data.map_id:
+            try:
+                map_data = await self.get_map()
+            except NarwalCommandError:
+                if not supports_legacy_room_clean:
+                    raise
+                _LOGGER.debug(
+                    "start_rooms: map fetch failed; trying legacy room-clean commands"
+                )
+                map_data = None
+        map_id = map_data.map_id if map_data else 0
+        if not map_id and not supports_legacy_room_clean:
+            return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        resp = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        if map_id:
+            payload = self._build_start_clean_payload(
+                room_ids,
+                map_id,
+                work_mode=work_mode,
+                fan=fan,
+                water=water,
+                mop_strength=mop_strength,
+                passes=passes,
+            )
+            resp = await self.send_command(
+                TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
+            )
+            for _ in range(3):
+                if resp.result_code != CommandResult.NOT_READY:
+                    break
+                if not self.state.is_docked:
+                    _LOGGER.warning(
+                        "start_rooms: robot not docked (status=%s); "
+                        "clean/start_clean requires the robot on the dock",
+                        self.state.working_status.name,
+                    )
+                    break
+                _LOGGER.info(
+                    "start_rooms: robot docking/settling, retrying "
+                    "clean/start_clean"
+                )
+                await asyncio.sleep(3.0)
+                resp = await self.send_command(
+                    TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
+                )
+        else:
+            _LOGGER.warning(
+                "start_rooms: no active map id available; trying legacy room clean"
+            )
+        if resp.result_code != CommandResult.NOT_APPLICABLE:
+            return resp
+        if not supports_legacy_room_clean:
+            return resp
+
+        _LOGGER.info(
+            "start_rooms: clean/start_clean rejected, trying clean/plan/start "
+            "compatibility payloads"
+        )
+        legacy_suction = {
+            FanLevel.UNSPECIFIED: 3,
+            FanLevel.MUTE: 0,
+            FanLevel.NORMAL: 1,
+            FanLevel.STRONG: 2,
+            FanLevel.DEEP: 3,
+            FanLevel.SUPER: 3,
+        }[FanLevel(fan)]
+        legacy_water = {
+            MopHumidity.UNSPECIFIED: 2,
+            MopHumidity.DRY: 0,
+            MopHumidity.NORMAL: 1,
+            MopHumidity.WET: 2,
+        }[MopHumidity(water)]
+        legacy_v2 = self._build_clean_payload_v2(
+            room_ids,
+            suction=legacy_suction,
+            mop_humidity=legacy_water,
+            passes=passes,
+        )
         resp = await self.send_command(
-            TOPIC_CMD_START_CLEAN, payload=payload_v2, timeout=10.0,
+            TOPIC_CMD_PLAN_START, payload=legacy_v2, timeout=10.0,
         )
         if resp.result_code != CommandResult.NOT_APPLICABLE:
             return resp
 
-        # v2 rejected — try legacy flat-room schema (older firmware)
-        _LOGGER.info(
-            "start_rooms(): v2 payload rejected, retrying with legacy schema (%d rooms)",
-            len(room_ids),
-        )
-        payload_legacy = self._build_room_clean_payload(room_ids)
         return await self.send_command(
-            TOPIC_CMD_START_CLEAN, payload=payload_legacy, timeout=10.0,
+            TOPIC_CMD_PLAN_START,
+            payload=self._build_room_clean_payload(room_ids),
+            timeout=10.0,
         )
 
     async def start_easy_clean(self) -> CommandResponse:
@@ -1196,21 +1342,48 @@ class NarwalClient:
         return await self.send_command(TOPIC_CMD_RECALL, timeout=timeout)
 
     async def set_fan_speed(self, level: FanLevel | int) -> CommandResponse:
-        """Set suction fan speed.
+        """Set suction fan speed live (clean/set_fan_level, field 1 = SweepFanLevel).
 
-        Args:
-            level: FanLevel enum or int (0=quiet, 1=normal, 2=strong, 3=max).
+        The live command's enum is SweepFanLevel, which has no SUPER. Use its
+        highest available level, DEEP, when callers request SUPER. Bare integer
+        values retain the original 0=quiet through 3=max API mapping.
         """
-        payload = b"\x08" + bytes([int(level) & 0x7F])
+        if isinstance(level, FanLevel):
+            live = min(int(level), int(FanLevel.DEEP))
+        else:
+            legacy_levels = {
+                0: FanLevel.MUTE,
+                1: FanLevel.NORMAL,
+                2: FanLevel.STRONG,
+                3: FanLevel.DEEP,
+            }
+            try:
+                live = int(legacy_levels[level])
+            except KeyError as err:
+                raise ValueError(f"Invalid legacy fan level: {level}") from err
+        payload = b"\x08" + bytes([live & 0x7F])
         return await self.send_command(TOPIC_CMD_SET_FAN_LEVEL, payload)
 
     async def set_mop_humidity(self, level: MopHumidity | int) -> CommandResponse:
-        """Set mop wetness level.
+        """Set mop water volume live (clean/set_mop_humidity, field 1 = MopHumidity).
 
         Args:
-            level: MopHumidity enum or int (0=dry, 1=normal, 2=wet).
+            level: MopHumidity enum, or the legacy int mapping
+                (0=dry, 1=normal, 2=wet).
         """
-        payload = b"\x08" + bytes([int(level) & 0x7F])
+        if isinstance(level, MopHumidity):
+            live = int(level)
+        else:
+            legacy_levels = {
+                0: MopHumidity.DRY,
+                1: MopHumidity.NORMAL,
+                2: MopHumidity.WET,
+            }
+            try:
+                live = int(legacy_levels[level])
+            except KeyError as err:
+                raise ValueError(f"Invalid legacy mop humidity: {level}") from err
+        payload = b"\x08" + bytes([live & 0x7F])
         return await self.send_command(TOPIC_CMD_SET_MOP_HUMIDITY, payload)
 
     async def wash_mop(self) -> CommandResponse:

--- a/narwal_client/const.py
+++ b/narwal_client/const.py
@@ -51,6 +51,8 @@ KNOWN_PRODUCT_KEYS = [
     "cUlfJN5JYP",   # Unknown model (APK, contributed by @northwestsupra)
 ]
 
+LEGACY_ROOM_CLEAN_PRODUCT_KEYS = {"QoEsI5qYXO"}
+
 # --- Status topics (robot → client, field 4 / 0x22 frames) ---
 TOPIC_WORKING_STATUS = "status/working_status"
 TOPIC_ROBOT_BASE_STATUS = "status/robot_base_status"
@@ -82,8 +84,8 @@ TOPIC_CMD_DRY_MOP = "supply/dry_mop"
 TOPIC_CMD_DUST_GATHERING = "supply/dust_gathering"
 
 # Cleaning (Pita protocol — correct for AX12)
-TOPIC_CMD_START_CLEAN = "clean/plan/start"  # whole-house clean (empty payload)
-TOPIC_CMD_START_CLEAN_LEGACY = "clean/start_clean"  # does NOT work from STANDBY
+TOPIC_CMD_PLAN_START = "clean/plan/start"  # whole-house clean (empty payload)
+TOPIC_CMD_CLEAN_TASK = "clean/start_clean"  # room/zone CleanTask; only works docked
 TOPIC_CMD_EASY_CLEAN = "clean/easy_clean/start"
 TOPIC_CMD_SET_FAN_LEVEL = "clean/set_fan_level"
 TOPIC_CMD_SET_MOP_HUMIDITY = "clean/set_mop_humidity"
@@ -141,6 +143,7 @@ class CommandResult(IntEnum):
     SUCCESS = 1
     NOT_APPLICABLE = 2  # e.g., set_fan_level when not cleaning
     CONFLICT = 3  # e.g., recall when already recalling
+    NOT_READY = 4  # clean/start_clean while not docked (robot in STANDBY)
 
 
 class WorkingStatus(IntEnum):
@@ -179,20 +182,42 @@ class WorkingStatus(IntEnum):
 
 
 class FanLevel(IntEnum):
-    """Suction fan speed levels (SweepMode from APK)."""
+    """CleanParam suction level (CleanTask.pbenum FanLevel)."""
 
-    QUIET = 0
-    NORMAL = 1
-    STRONG = 2
-    MAX = 3
+    UNSPECIFIED = 0
+    MUTE = 1
+    QUIET = MUTE
+    NORMAL = 2
+    STRONG = 3
+    DEEP = 4
+    MAX = DEEP
+    SUPER = 5
 
 
 class MopHumidity(IntEnum):
-    """Mop wetness levels."""
+    """Water volume. CleanParam tag 4 and the live clean/set_mop_humidity command share these ints."""
 
-    DRY = 0
+    UNSPECIFIED = 0
+    DRY = 1
+    NORMAL = 2
+    WET = 3
+
+
+class MopStrengthLevel(IntEnum):
+    """Mop scrub intensity (CleanParam tag 3)."""
+
+    UNSPECIFIED = 0
     NORMAL = 1
-    WET = 2
+    HIGH = 2
+
+
+class WorkMode(IntEnum):
+    """Clean work mode — the app's robot_work_mode_* selector (Vacuum / Mop / Vacuum then mop / Vacuum and mop). Its value IS the CleanTask.taskType the robot executes; the per-item CleanParam.mode (the proto's own CleanMode enum) is derived separately in client._WORK_MODE_PARAM."""
+
+    VACUUM = 1
+    MOP = 2
+    VACUUM_THEN_MOP = 3
+    VACUUM_AND_MOP = 4
 
 
 # robot_base_status field numbers

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -254,6 +254,7 @@ class MapData:
     origin_y: int = 0  # y pixel offset from field 2.6.1
     obstacles: list[ObstacleInfo] = field(default_factory=list)
     raw: dict[str, Any] = field(default_factory=dict)
+    map_id: int = 0  # active map id (field 2.1) — required by clean/start_clean
 
     @classmethod
     def from_response(
@@ -344,6 +345,7 @@ class MapData:
             obstacles = _parse_obstacles(field32)
 
         return cls(
+            map_id=int(payload.get("1", 0)),
             width=int(payload.get("4", 0)),
             height=int(payload.get("5", 0)),
             resolution=resolution,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -34,12 +34,12 @@ class TestNarwalClientInit:
     def test_commands_require_connection(self) -> None:
         client = NarwalClient("10.0.0.1")
         with pytest.raises(NarwalConnectionError):
-            asyncio.get_event_loop().run_until_complete(client.start())
+            asyncio.run(client.start())
 
     def test_send_raw_without_connection_raises(self) -> None:
         client = NarwalClient("10.0.0.1")
         with pytest.raises(NarwalConnectionError):
-            asyncio.get_event_loop().run_until_complete(
+            asyncio.run(
                 client.send_raw("test/topic", b"\x08\x01")
             )
 
@@ -132,7 +132,7 @@ class TestStartLegacyAndV2Fallback:
             client, "send_command", new_callable=AsyncMock
         ) as mock_send:
             mock_send.return_value = success
-            result = asyncio.get_event_loop().run_until_complete(client.start())
+            result = asyncio.run(client.start())
 
         assert result is success
         mock_send.assert_awaited_once()  # no fallback fired
@@ -152,7 +152,7 @@ class TestStartLegacyAndV2Fallback:
             client, "send_command", new_callable=AsyncMock
         ) as mock_send:
             mock_send.side_effect = [not_applicable, success]
-            result = asyncio.get_event_loop().run_until_complete(client.start())
+            result = asyncio.run(client.start())
 
         assert mock_send.await_count == 2
         # Second call's payload must be v2 (different bytes from legacy)
@@ -173,7 +173,7 @@ class TestStartLegacyAndV2Fallback:
             client, "send_command", new_callable=AsyncMock
         ) as mock_send:
             mock_send.return_value = not_applicable
-            result = asyncio.get_event_loop().run_until_complete(client.start())
+            result = asyncio.run(client.start())
 
         mock_send.assert_awaited_once()  # no v2 retry without rooms
         assert result.result_code == CommandResult.NOT_APPLICABLE
@@ -189,7 +189,7 @@ class TestStartLegacyAndV2Fallback:
             client, "send_command", new_callable=AsyncMock
         ) as mock_send:
             mock_send.return_value = not_applicable
-            result = asyncio.get_event_loop().run_until_complete(client.start())
+            result = asyncio.run(client.start())
 
         mock_send.assert_awaited_once()
         assert result.result_code == CommandResult.NOT_APPLICABLE

--- a/tests/test_client_rooms.py
+++ b/tests/test_client_rooms.py
@@ -1,195 +1,350 @@
-"""Tests for narwal_client room-specific clean payload and start_rooms."""
+"""Tests for the room-clean payload (_build_start_clean_payload) and start_rooms."""
 
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import blackboxprotobuf
 import pytest
 
-from narwal_client.client import NarwalClient
-from narwal_client.const import CommandResult
+from narwal_client.client import NarwalClient, NarwalCommandError
+from narwal_client.const import (
+    CommandResult,
+    FanLevel,
+    MopHumidity,
+    MopStrengthLevel,
+    WorkMode,
+)
 from narwal_client.models import CommandResponse
 
 
-class TestBuildRoomCleanPayload:
-    """Tests for _build_room_clean_payload protobuf encoding."""
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
-    def test_single_room_encodes_room_id_and_params(self) -> None:
-        """Single room has roomId + clean params in field 1.2."""
-        import blackboxprotobuf
 
+def _task(payload: bytes) -> dict:
+    """Decode a StartClean payload to its CleanTask (field 1)."""
+    decoded, _ = blackboxprotobuf.decode_message(payload)
+    return decoded["1"]
+
+
+def _items(task: dict) -> list[dict]:
+    items = task["2"]
+    return items if isinstance(items, list) else [items]
+
+
+# WorkMode -> (expected taskType, expected CleanParam.mode, expected pass tags)
+_MODE_EXPECT = {
+    WorkMode.VACUUM: (1, 2, {"5"}),
+    WorkMode.MOP: (2, 3, {"6"}),
+    WorkMode.VACUUM_THEN_MOP: (3, 5, {"5", "6"}),
+    WorkMode.VACUUM_AND_MOP: (4, 4, {"7"}),
+}
+
+
+class TestBuildStartCleanPayload:
+    """The CleanTask/CleanParam encoding."""
+
+    def test_legacy_fan_level_names_remain_available(self) -> None:
+        """External client users keep the original QUIET and MAX names."""
+        assert FanLevel.QUIET is FanLevel.MUTE
+        assert FanLevel.MAX is FanLevel.DEEP
+
+    def test_task_type_and_param_mode_per_mode(self) -> None:
+        """taskType (the carrier) and CleanParam.mode/pass-tags follow work_mode."""
         client = NarwalClient("127.0.0.1")
-        payload = client._build_room_clean_payload([11])
-        decoded, _ = blackboxprotobuf.decode_message(payload)
+        for mode, (task_type, param_mode, pass_tags) in _MODE_EXPECT.items():
+            payload = client._build_start_clean_payload([2], 1, work_mode=mode, passes=2)
+            task = _task(payload)
+            assert task["5"] == task_type, f"taskType for {mode.name}"
+            param = _items(task)[0]["2"]
+            assert param["1"] == param_mode, f"CleanParam.mode for {mode.name}"
+            for tag in pass_tags:
+                assert param[tag] == 2, f"pass tag {tag} for {mode.name}"
+            for tag in {"5", "6", "7"} - pass_tags:
+                assert tag not in param, f"unexpected pass tag {tag} for {mode.name}"
 
-        field1_2 = decoded["1"]["2"]
-        # Single room: field 1.2.1 = roomId
-        assert field1_2["1"] == 11
-        # Per-room clean params must be present (robot ignores bare roomId)
-        assert field1_2["2"] == 2, "cleanMode should be 2 (sweep+mop)"
-        assert field1_2["3"] == 1, "cleanTimes should be 1"
-        assert field1_2["6"] == 3, "sweepMode should be 3 (max suction)"
-        assert field1_2["7"] == 2, "mopMode should be 2 (wet)"
-
-    def test_multiple_rooms_encodes_all(self) -> None:
-        """Multiple rooms encode as repeated messages in field 1.2."""
-        import blackboxprotobuf
-
+    def test_fan_water_strength_encoded(self) -> None:
+        """fan/water/mop_strength land in their CleanParam tags."""
         client = NarwalClient("127.0.0.1")
-        payload = client._build_room_clean_payload([11, 9])
-        decoded, _ = blackboxprotobuf.decode_message(payload)
+        payload = client._build_start_clean_payload(
+            [2], 1, work_mode=WorkMode.MOP,
+            fan=FanLevel.DEEP, water=MopHumidity.WET, mop_strength=MopStrengthLevel.HIGH,
+        )
+        param = _items(_task(payload))[0]["2"]
+        assert param["2"] == FanLevel.DEEP
+        assert param["4"] == MopHumidity.WET
+        assert param["3"] == MopStrengthLevel.HIGH
 
-        field1_2 = decoded["1"]["2"]
-        assert isinstance(field1_2, list), "Multiple rooms should be a list"
-        room_ids = [entry["1"] for entry in field1_2]
-        assert 11 in room_ids
-        assert 9 in room_ids
-        # Each entry has clean params
-        for entry in field1_2:
-            assert entry["2"] == 2, "cleanMode"
-            assert entry["6"] == 3, "sweepMode"
-
-    def test_preserves_global_clean_settings(self) -> None:
-        """Payload preserves suction=3, mop=2, passes=1 in field 1.5."""
-        import blackboxprotobuf
-
+    def test_overlap_not_sent(self) -> None:
+        """overlapLevel (tag 8) is omitted — live-validated as ignored."""
         client = NarwalClient("127.0.0.1")
-        payload = client._build_room_clean_payload([11])
-        decoded, _ = blackboxprotobuf.decode_message(payload)
+        param = _items(_task(client._build_start_clean_payload([2], 1)))[0]["2"]
+        assert "8" not in param
 
-        settings = decoded["1"]["5"]["1"]
-        assert settings["1"] == 3, "Suction should be 3 (max)"
-        assert settings["2"] == 2, "Mop humidity should be 2 (wet)"
-        assert settings["3"] == 1, "Passes should be 1 (single)"
-
-    def test_empty_room_ids_returns_default(self) -> None:
-        """Empty room list returns the default whole-house payload."""
+    def test_map_zone_and_order(self) -> None:
+        """map_id, room zone refs, and 1-based order encode correctly."""
         client = NarwalClient("127.0.0.1")
-        payload = client._build_room_clean_payload([])
-        assert payload == client._DEFAULT_CLEAN_PAYLOAD
-
-    def test_room_payload_differs_from_default(self) -> None:
-        """Room-specific payload is different from whole-house default."""
-        client = NarwalClient("127.0.0.1")
-        room_payload = client._build_room_clean_payload([11])
-        assert room_payload != client._DEFAULT_CLEAN_PAYLOAD
-        assert len(room_payload) > 0
+        task = _task(client._build_start_clean_payload([2, 12], 7))
+        assert task["1"] == 7
+        items = _items(task)
+        assert [it["1"]["2"] for it in items] == [2, 12]
+        assert all(it["1"]["1"] == 1 for it in items)  # zoneType = ROOM
+        assert [it["3"] for it in items] == [1, 2]
 
 
 class TestStartRooms:
-    """Tests for start_rooms async method."""
+    """start_rooms dispatch and settings threading."""
+
+    def _client(self) -> NarwalClient:
+        client = NarwalClient("127.0.0.1")
+        client._ws = AsyncMock()
+        client.state.device_info = MagicMock(product_key="QoEsI5qYXO")
+        client.state.map_data = MagicMock(map_id=1)
+        return client
 
     def test_empty_rooms_calls_start(self) -> None:
         """start_rooms([]) falls back to whole-house start()."""
-        client = NarwalClient("127.0.0.1")
-        client._ws = AsyncMock()  # fake connected state
-        client._connected = True
-
+        client = self._client()
         with patch.object(client, "start", new_callable=AsyncMock) as mock_start:
-            mock_start.return_value = AsyncMock()
-            asyncio.get_event_loop().run_until_complete(client.start_rooms([]))
+            _run(client.start_rooms([]))
             mock_start.assert_awaited_once()
 
-    def test_room_ids_sends_room_payload(self) -> None:
-        """start_rooms with IDs sends room-specific payload via send_command."""
-        client = NarwalClient("127.0.0.1")
-        client._ws = AsyncMock()
-        client._connected = True
+    def test_forwards_settings_to_payload(self) -> None:
+        """Settings passed to start_rooms reach the encoded CleanTask."""
+        client = self._client()
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = success
+            _run(client.start_rooms(
+                [5], work_mode=WorkMode.MOP, fan=FanLevel.STRONG,
+                water=MopHumidity.DRY, mop_strength=MopStrengthLevel.HIGH, passes=3,
+            ))
+        mock_send.assert_awaited_once()
+        param = _items(_task(mock_send.await_args.kwargs["payload"]))[0]["2"]
+        assert param["1"] == 3  # CleanParam.mode MOP
+        assert param["2"] == FanLevel.STRONG
+        assert param["3"] == MopStrengthLevel.HIGH
+        assert param["4"] == MopHumidity.DRY
+        assert param["6"] == 3  # mopTime pass count
 
+    def test_defaults_match_documented_clean(self) -> None:
+        """Default room cleaning uses max suction and wet mopping."""
+        client = self._client()
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = success
+            _run(client.start_rooms([5]))
+
+        param = _items(_task(mock_send.await_args.kwargs["payload"]))[0]["2"]
+        assert param["2"] == FanLevel.DEEP
+        assert param["4"] == MopHumidity.WET
+
+    def test_no_map_id_uses_legacy_fallback(self) -> None:
+        """No active map id skips start_clean but retains the legacy path."""
+        client = self._client()
+        client.state.device_info = MagicMock(product_key="QoEsI5qYXO")
+        client.state.map_data = MagicMock(map_id=0)
+        with patch.object(client, "get_map", new_callable=AsyncMock) as mock_get_map, \
+             patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_get_map.return_value = MagicMock(map_id=0)
+            mock_send.return_value = CommandResponse(result_code=CommandResult.SUCCESS)
+            result = _run(client.start_rooms([5]))
+        mock_send.assert_awaited_once()
+        assert mock_send.await_args.args[0] == "clean/plan/start"
+        assert result.result_code == CommandResult.SUCCESS
+
+    def test_map_fetch_failure_uses_legacy_fallback(self) -> None:
+        """A sleeping robot can still receive the legacy cached-room command."""
+        client = self._client()
+        client.state.device_info = MagicMock(product_key="QoEsI5qYXO")
+        client.state.map_data = None
         success = CommandResponse(result_code=CommandResult.SUCCESS)
         with patch.object(
-            client, "send_command", new_callable=AsyncMock
+            client,
+            "get_map",
+            new_callable=AsyncMock,
+            side_effect=NarwalCommandError("timeout"),
+        ), patch.object(
+            client, "send_command", new_callable=AsyncMock, return_value=success
         ) as mock_send:
-            mock_send.return_value = success
-            asyncio.get_event_loop().run_until_complete(client.start_rooms([11, 9]))
-            mock_send.assert_awaited_once()
-            payload_arg = mock_send.await_args.kwargs.get("payload")
-            assert payload_arg is not None
-            assert payload_arg != client._DEFAULT_CLEAN_PAYLOAD
-
-
-class TestStartRoomsV2First:
-    """Tests for the v2-first schema order in start_rooms (#37 fix).
-
-    start_rooms() now tries v2 nested-room schema first (fixes ack-and-ignore
-    on newer firmware), falling back to legacy flat-room on NOT_APPLICABLE.
-    """
-
-    def _connected_client(self) -> NarwalClient:
-        client = NarwalClient("127.0.0.1")
-        client._ws = AsyncMock()
-        client._connected = True
-        return client
-
-    def test_success_on_v2_does_not_retry(self) -> None:
-        """If the v2 room payload is accepted, no legacy retry happens."""
-        client = self._connected_client()
-        success = CommandResponse(result_code=CommandResult.SUCCESS)
-
-        with patch.object(
-            client, "send_command", new_callable=AsyncMock
-        ) as mock_send:
-            mock_send.return_value = success
-            result = asyncio.get_event_loop().run_until_complete(
-                client.start_rooms([5])
-            )
+            result = _run(client.start_rooms([5]))
 
         assert result is success
         mock_send.assert_awaited_once()
+        assert mock_send.await_args.args[0] == "clean/plan/start"
 
-    def test_v2_sends_correct_room_ids(self) -> None:
-        """v2 payload encodes exactly the requested rooms."""
-        client = self._connected_client()
-        success = CommandResponse(result_code=CommandResult.SUCCESS)
-
+    def test_flow2_map_fetch_failure_does_not_start_legacy_clean(self) -> None:
+        """A missing Flow 2 map cannot fall back to an unsafe whole-home clean."""
+        client = self._client()
+        client.state.device_info = MagicMock(product_key="QxMSPG6VSO")
+        client.state.map_data = None
         with patch.object(
-            client, "send_command", new_callable=AsyncMock
-        ) as mock_send:
-            mock_send.return_value = success
-            asyncio.get_event_loop().run_until_complete(
-                client.start_rooms([5, 7])
-            )
+            client,
+            "get_map",
+            new_callable=AsyncMock,
+            side_effect=NarwalCommandError("timeout"),
+        ), patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            try:
+                _run(client.start_rooms([5]))
+            except NarwalCommandError:
+                pass
+            else:
+                raise AssertionError("Flow 2 map failure should surface to the caller")
 
-        import blackboxprotobuf
-        payload = mock_send.await_args.kwargs.get("payload")
-        decoded, _ = blackboxprotobuf.decode_message(payload)
-        entries = decoded["1"]["2"]
-        ids = [e["1"]["2"] for e in entries]
-        assert ids == [5, 7]
+        mock_send.assert_not_awaited()
 
-    def test_not_applicable_triggers_legacy_retry(self) -> None:
-        """NOT_APPLICABLE on v2 triggers a legacy flat-room retry."""
-        client = self._connected_client()
-        not_applicable = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+    def test_super_live_fan_uses_highest_supported_level(self) -> None:
+        """The live command never reports an unavailable SUPER level."""
+        client = self._client()
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            _run(client.set_fan_speed(FanLevel.SUPER))
+
+        assert mock_send.await_args.args[0] == "clean/set_fan_level"
+        assert mock_send.await_args.args[1] == b"\x08\x04"
+
+    @pytest.mark.parametrize(
+        ("legacy_level", "wire_level"),
+        ((0, 1), (1, 2), (2, 3), (3, 4)),
+    )
+    def test_live_fan_preserves_legacy_integer_levels(
+        self, legacy_level: int, wire_level: int
+    ) -> None:
+        client = self._client()
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            _run(client.set_fan_speed(legacy_level))
+
+        assert mock_send.await_args.args[1] == bytes((0x08, wire_level))
+
+    @pytest.mark.parametrize(
+        ("legacy_level", "wire_level"),
+        ((0, 1), (1, 2), (2, 3)),
+    )
+    def test_live_mop_preserves_legacy_integer_levels(
+        self, legacy_level: int, wire_level: int
+    ) -> None:
+        client = self._client()
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            _run(client.set_mop_humidity(legacy_level))
+
+        assert mock_send.await_args.args[1] == bytes((0x08, wire_level))
+
+    def test_not_ready_retries_while_docked(self) -> None:
+        """NOT_READY on the dock retries clean/start_clean (dock settling)."""
+        client = self._client()
+        client.state.update_from_base_status({"3": {"1": 10, "10": 1}})  # docked
+        assert client.state.is_docked
+        not_ready = CommandResponse(result_code=CommandResult.NOT_READY)
         success = CommandResponse(result_code=CommandResult.SUCCESS)
-
-        with patch.object(
-            client, "send_command", new_callable=AsyncMock
-        ) as mock_send:
-            mock_send.side_effect = [not_applicable, success]
-            result = asyncio.get_event_loop().run_until_complete(
-                client.start_rooms([5, 7])
-            )
-
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send, \
+             patch("narwal_client.client.asyncio.sleep", new_callable=AsyncMock):
+            mock_send.side_effect = [not_ready, success]
+            result = _run(client.start_rooms([5]))
         assert mock_send.await_count == 2
-        v2_payload = mock_send.await_args_list[0].kwargs.get("payload")
-        legacy_payload = mock_send.await_args_list[1].kwargs.get("payload")
-        assert v2_payload != legacy_payload
         assert result is success
 
-    def test_conflict_does_not_trigger_retry(self) -> None:
-        """A CONFLICT response (robot busy) surfaces as-is — no retry."""
-        client = self._connected_client()
+    def test_not_ready_off_dock_does_not_retry(self) -> None:
+        """NOT_READY off the dock surfaces as-is — start_clean needs the dock."""
+        client = self._client()
+        assert not client.state.is_docked
+        not_ready = CommandResponse(result_code=CommandResult.NOT_READY)
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = not_ready
+            result = _run(client.start_rooms([5]))
+        mock_send.assert_awaited_once()
+        assert result.result_code == CommandResult.NOT_READY
+
+    def test_conflict_surfaces_without_retry(self) -> None:
+        """A CONFLICT response (robot busy) is returned as-is."""
+        client = self._client()
         conflict = CommandResponse(result_code=CommandResult.CONFLICT)
-
-        with patch.object(
-            client, "send_command", new_callable=AsyncMock
-        ) as mock_send:
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
             mock_send.return_value = conflict
-            result = asyncio.get_event_loop().run_until_complete(
-                client.start_rooms([5])
-            )
-
+            result = _run(client.start_rooms([5]))
         mock_send.assert_awaited_once()
         assert result.result_code == CommandResult.CONFLICT
+
+    def test_not_applicable_falls_back_to_plan_start(self) -> None:
+        """Older firmware retains the clean/plan/start compatibility path."""
+        client = self._client()
+        not_applicable = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.side_effect = [not_applicable, success]
+            result = _run(client.start_rooms([5]))
+
+        assert result is success
+        assert mock_send.await_count == 2
+        assert mock_send.await_args_list[0].args[0] == "clean/start_clean"
+        assert mock_send.await_args_list[1].args[0] == "clean/plan/start"
+
+    def test_flow2_rejection_does_not_start_legacy_clean(self) -> None:
+        """Flow 2 never falls back to plan/start whole-home behaviour."""
+        client = self._client()
+        client.state.device_info = MagicMock(product_key="QxMSPG6VSO")
+        not_applicable = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = not_applicable
+            result = _run(client.start_rooms([5]))
+
+        assert result is not_applicable
+        mock_send.assert_awaited_once()
+
+    def test_legacy_fallback_translates_water_level(self) -> None:
+        """CleanParam wet maps to the legacy plan/start wet value."""
+        client = self._client()
+        not_applicable = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.side_effect = [not_applicable, success]
+            _run(client.start_rooms([5], water=MopHumidity.WET))
+
+        legacy_payload = mock_send.await_args_list[1].kwargs["payload"]
+        decoded, _ = blackboxprotobuf.decode_message(legacy_payload)
+        assert decoded["1"]["2"]["2"]["7"] == 2
+
+    def test_legacy_fallback_translates_fan_level(self) -> None:
+        """Flow 2 suction levels stay within the legacy plan/start range."""
+        client = self._client()
+        not_applicable = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.side_effect = [not_applicable, success]
+            _run(client.start_rooms([5], fan=FanLevel.SUPER))
+
+        legacy_payload = mock_send.await_args_list[1].kwargs["payload"]
+        decoded, _ = blackboxprotobuf.decode_message(legacy_payload)
+        assert decoded["1"]["2"]["2"]["1"] == 3
+
+    def test_legacy_fallback_translates_strong_fan_level(self) -> None:
+        """CleanParam strong maps to the legacy strong value."""
+        client = self._client()
+        not_applicable = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.side_effect = [not_applicable, success]
+            _run(client.start_rooms([5], fan=FanLevel.STRONG))
+
+        legacy_payload = mock_send.await_args_list[1].kwargs["payload"]
+        decoded, _ = blackboxprotobuf.decode_message(legacy_payload)
+        assert decoded["1"]["2"]["2"]["1"] == 2
+
+    def test_both_new_payloads_rejected_use_legacy_payload(self) -> None:
+        """Older firmware receives the legacy flat-room payload last."""
+        client = self._client()
+        not_applicable = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.side_effect = [not_applicable, not_applicable, success]
+            result = _run(client.start_rooms([5]))
+
+        assert result is success
+        assert mock_send.await_count == 3
+        legacy_payload = mock_send.await_args_list[2].kwargs["payload"]
+        decoded, _ = blackboxprotobuf.decode_message(legacy_payload)
+        assert decoded["1"]["2"]["1"] == 5

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,6 +14,33 @@ from narwal_client.models import (
 )
 
 
+def test_map_data_preserves_existing_positional_arguments() -> None:
+    room = RoomInfo(room_id=7)
+    obstacle = ObstacleInfo(id=1)
+
+    map_data = MapData(
+        10,
+        20,
+        5,
+        [room],
+        b"map",
+        200,
+        1234,
+        1.5,
+        2.5,
+        3,
+        4,
+        [obstacle],
+        {"source": "test"},
+    )
+
+    assert map_data.width == 10
+    assert map_data.height == 20
+    assert map_data.rooms == [room]
+    assert map_data.raw == {"source": "test"}
+    assert map_data.map_id == 0
+
+
 class TestNarwalState:
     """Tests for NarwalState data model."""
 

--- a/tests/test_vacuum_segments.py
+++ b/tests/test_vacuum_segments.py
@@ -51,6 +51,20 @@ def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
     return vac
 
 
+class TestFanSpeed:
+    """Live suction controls expose only levels accepted by the robot."""
+
+    async def test_max_alias_reports_highest_live_level(self) -> None:
+        """The legacy max alias reports the level actually sent."""
+        vac = _make_vacuum()
+        vac.coordinator.client.set_fan_speed = AsyncMock()
+
+        await vac.async_set_fan_speed("max")
+
+        vac.coordinator.client.set_fan_speed.assert_awaited_once()
+        assert vac._last_fan_speed == "Super powerful"
+
+
 class TestAsyncGetSegments:
     """Tests for async_get_segments."""
 


### PR DESCRIPTION
## What

Fix selected-room cleaning by sending Narwal’s local `clean/start_clean` command with a complete `CleanParam`.

## Why

This keeps the Flow 2 behaviour local, explicit, and reviewable without mixing unrelated changes.

## Stack

Part 1 of 8.

This is the first patch and should be reviewed first.

## Validation

- Full stack: `300 passed`
- Home Assistant configuration check
- Live validation against two Narwal Flow 2 vacuums
