### PR TITLE
narwal: Decode Flow 2 task details

### DIFF
--- a/custom_components/narwal/camera.py
+++ b/custom_components/narwal/camera.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import NarwalConfigEntry
 from .coordinator import NarwalCoordinator
 from .entity import NarwalEntity
-from .narwal_client.const import WorkingStatus
+from .narwal_client.const import ACTIVE_CLEANING_STATUSES, WorkingStatus
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -154,17 +154,17 @@ class NarwalMapCamera(NarwalEntity, Camera):
 
         # Detect cleaning session transitions — clear trail on new session
         current_status = state.working_status
-        was_cleaning = self._last_cleaning_status in (
-            WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT,
-        )
-        is_cleaning = current_status in (
-            WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT,
+        was_cleaning = self._last_cleaning_status in ACTIVE_CLEANING_STATUSES
+        is_cleaning = (
+            current_status in ACTIVE_CLEANING_STATUSES and not state.is_docked
         )
         if is_cleaning and not was_cleaning:
             _LOGGER.info("New cleaning session — clearing trail and vision obstacles")
             self._reset_trail()
         if current_status != WorkingStatus.UNKNOWN:
-            self._last_cleaning_status = current_status
+            self._last_cleaning_status = (
+                current_status if not state.is_docked else WorkingStatus.STANDBY
+            )
 
         if _DEBUG_VIEW:
             if not display or (display.robot_x == 0.0 and display.robot_y == 0.0):

--- a/custom_components/narwal/config_flow.py
+++ b/custom_components/narwal/config_flow.py
@@ -43,47 +43,69 @@ class NarwalConfigFlow(ConfigFlow, domain=DOMAIN):
             model_label = user_input[CONF_MODEL]
             product_key = NARWAL_MODELS[model_label]
 
-            # If user selected a specific model, set topic prefix directly
-            topic_prefix = None if product_key == "auto" else f"/{product_key}"
-
-            client = NarwalClient(
-                host=host, port=port, topic_prefix=topic_prefix,
-            )
-            try:
-                await client.connect()
-                # Discover device_id from broadcast, then query info
-                await client.discover_device_id(timeout=15.0)
-                # Drain any stale field5 responses left in the WebSocket
-                # buffer from discover's wake probes before sending a
-                # real command
-                await client.drain_ws_buffer()
-                device_info = await client.get_device_info()
-            except Exception as ex:
-                _LOGGER.warning(
-                    "Setup failed: %s: %s", type(ex).__name__, ex,
-                )
-                errors["base"] = "cannot_connect"
+            # Try the selected model key first for speed. Some Flow/Flow 2
+            # units only wake on a sibling key before reporting their actual
+            # product key, so fall back to auto-discovery before failing.
+            topic_prefixes: list[str | None]
+            if product_key == "auto":
+                topic_prefixes = [None]
             else:
-                device_id = device_info.device_id
-                await self.async_set_unique_id(device_id)
-                self._abort_if_unique_id_configured()
+                topic_prefixes = [f"/{product_key}", None]
 
-                # Use the product key that actually worked (may have been
-                # auto-detected during discovery even if user picked "auto")
-                resolved_key = client.topic_prefix.lstrip("/")
-
-                return self.async_create_entry(
-                    title=model_label if product_key != "auto" else f"Narwal {resolved_key}",
-                    data={
-                        "host": host,
-                        "port": port,
-                        "device_id": device_id,
-                        CONF_PRODUCT_KEY: resolved_key,
-                        CONF_MODEL: model_label,
-                    },
+            last_error: Exception | None = None
+            for topic_prefix in topic_prefixes:
+                client = NarwalClient(
+                    host=host, port=port, topic_prefix=topic_prefix,
                 )
-            finally:
-                await client.disconnect()
+                try:
+                    await client.connect()
+                    # Discover device_id from broadcast, then query info
+                    await client.discover_device_id(timeout=15.0)
+                    # Drain any stale field5 responses left in the WebSocket
+                    # buffer from discover's wake probes before sending a
+                    # real command
+                    await client.drain_ws_buffer()
+                    device_info = await client.get_device_info()
+                except Exception as ex:
+                    last_error = ex
+                    _LOGGER.debug(
+                        "Setup probe failed with prefix %s: %s: %s",
+                        topic_prefix or "auto",
+                        type(ex).__name__,
+                        ex,
+                    )
+                    await client.disconnect()
+                    continue
+
+                try:
+                    device_id = device_info.device_id
+                    await self.async_set_unique_id(device_id)
+                    self._abort_if_unique_id_configured()
+
+                    # Use the product key that actually worked (may have been
+                    # auto-detected during discovery even if user picked "auto")
+                    resolved_key = client.topic_prefix.lstrip("/")
+
+                    return self.async_create_entry(
+                        title=model_label if product_key != "auto" else f"Narwal {resolved_key}",
+                        data={
+                            "host": host,
+                            "port": port,
+                            "device_id": device_id,
+                            CONF_PRODUCT_KEY: resolved_key,
+                            CONF_MODEL: model_label,
+                        },
+                    )
+                finally:
+                    await client.disconnect()
+
+            if last_error is not None:
+                _LOGGER.warning(
+                    "Setup failed: %s: %s",
+                    type(last_error).__name__,
+                    last_error,
+                )
+            errors["base"] = "cannot_connect"
 
         return self.async_show_form(
             step_id="user",

--- a/custom_components/narwal/const.py
+++ b/custom_components/narwal/const.py
@@ -31,11 +31,21 @@ PLATFORMS: list[Platform] = [
     Platform.CAMERA,
 ]
 
-FAN_SPEED_MAP: dict[str, FanLevel] = {
-    "quiet": FanLevel.QUIET,
-    "normal": FanLevel.NORMAL,
-    "strong": FanLevel.STRONG,
-    "max": FanLevel.MAX,
+# HA fan_speed labels for the live clean/set_fan_level command. Its
+# SweepFanLevel enum stops at DEEP; SUPER remains available to clean settings.
+_FAN_SPEED_CANONICAL: dict[str, FanLevel] = {
+    "Quiet": FanLevel.MUTE,
+    "Standard": FanLevel.NORMAL,
+    "Strong": FanLevel.STRONG,
+    "Super powerful": FanLevel.DEEP,
 }
 
-FAN_SPEED_LIST: list[str] = list(FAN_SPEED_MAP.keys())
+FAN_SPEED_LIST: list[str] = list(_FAN_SPEED_CANONICAL)
+
+# FAN_SPEED_MAP also accepts the original lowercase fan_speed values (quiet/normal/strong/max) so existing automations keep working; these aliases are not offered in FAN_SPEED_LIST.
+FAN_SPEED_MAP: dict[str, FanLevel] = _FAN_SPEED_CANONICAL | {
+    "quiet": FanLevel.MUTE,
+    "normal": FanLevel.NORMAL,
+    "strong": FanLevel.STRONG,
+    "max": FanLevel.DEEP,
+}

--- a/custom_components/narwal/coordinator.py
+++ b/custom_components/narwal/coordinator.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .narwal_client import NarwalClient, NarwalConnectionError, NarwalState
-from .narwal_client.const import WorkingStatus
+from .narwal_client.const import ACTIVE_CLEANING_STATUSES, WorkingStatus
 
 from .const import DOMAIN
 
@@ -144,8 +144,7 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
             state.working_status in (
                 WorkingStatus.STANDBY, WorkingStatus.DOCKED_V2,
             )
-            and self._prev_working_status
-            in (WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT)
+            and self._prev_working_status in ACTIVE_CLEANING_STATUSES
         ):
             _LOGGER.info("Return-to-dock detected, refreshing dock status")
             self.hass.async_create_task(self._refresh_dock_status())
@@ -154,9 +153,7 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         # display_map dropout recovery: if cleaning but no display_map for
         # 30s, re-send topic subscription. Only subscription — no wake burst
         # (wake bursts during cleaning cause pause bouncing).
-        is_cleaning = state.working_status in (
-            WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT,
-        )
+        is_cleaning = state.working_status in ACTIVE_CLEANING_STATUSES
         if is_cleaning:
             display_age = self.client.last_display_map_age
             now = time.monotonic()

--- a/custom_components/narwal/narwal_client/__init__.py
+++ b/custom_components/narwal/narwal_client/__init__.py
@@ -1,7 +1,7 @@
 """Narwal robot vacuum client library — local WebSocket API."""
 
 from .client import NarwalClient, NarwalCommandError, NarwalConnectionError
-from .const import CommandResult, FanLevel, MopHumidity, WorkingStatus
+from .const import CommandResult, FanLevel, MopHumidity, MopStrengthLevel, WorkMode, WorkingStatus
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState, RoomInfo
 from .protocol import build_frame, parse_frame
 
@@ -17,7 +17,9 @@ __all__ = [
     "MapData",
     "MapDisplayData",
     "MopHumidity",
+    "MopStrengthLevel",
     "RoomInfo",
+    "WorkMode",
     "WorkingStatus",
     "build_frame",
     "parse_frame",

--- a/custom_components/narwal/narwal_client/__init__.py
+++ b/custom_components/narwal/narwal_client/__init__.py
@@ -1,7 +1,15 @@
 """Narwal robot vacuum client library — local WebSocket API."""
 
 from .client import NarwalClient, NarwalCommandError, NarwalConnectionError
-from .const import CommandResult, FanLevel, MopHumidity, MopStrengthLevel, WorkMode, WorkingStatus
+from .const import (
+    CleaningRoute,
+    CommandResult,
+    FanLevel,
+    MopHumidity,
+    MopStrengthLevel,
+    WorkMode,
+    WorkingStatus,
+)
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState, RoomInfo
 from .protocol import build_frame, parse_frame
 
@@ -12,6 +20,7 @@ __all__ = [
     "NarwalState",
     "CommandResponse",
     "CommandResult",
+    "CleaningRoute",
     "DeviceInfo",
     "FanLevel",
     "MapData",

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -16,6 +16,7 @@ from .const import (
     BROADCAST_STALE_TIMEOUT,
     COMMAND_RESPONSE_TIMEOUT,
     DEFAULT_PORT,
+    DEFAULT_TOPIC_PREFIX,
     HEARTBEAT_INTERVAL,
     KEEPALIVE_INTERVAL,
     KNOWN_PRODUCT_KEYS,
@@ -26,37 +27,49 @@ from .const import (
     TOPIC_CMD_ACTIVE_ROBOT,
     TOPIC_CMD_APP_HEARTBEAT,
     TOPIC_CMD_CANCEL,
+    TOPIC_CMD_CLEAN_TASK,
+    TOPIC_CMD_DRY_DUST_BAG,
     TOPIC_CMD_DRY_MOP,
+    TOPIC_CMD_DRY_STATION_BAG,
     TOPIC_CMD_DUST_GATHERING,
     TOPIC_CMD_EASY_CLEAN,
     TOPIC_CMD_FORCE_END,
     TOPIC_CMD_GET_ALL_MAPS,
     TOPIC_CMD_GET_BASE_STATUS,
+    TOPIC_CMD_GET_CLEAN_PROGRESS_INFO,
     TOPIC_CMD_GET_CURRENT_TASK,
     TOPIC_CMD_GET_DEVICE_INFO,
+    TOPIC_CMD_GET_DRY_MOP_REMAIN_TIME,
     TOPIC_CMD_GET_FEATURE_LIST,
     TOPIC_CMD_GET_MAP,
+    TOPIC_CMD_GET_ROBOT_TASK_STATUS,
     TOPIC_CMD_NOTIFY_APP_EVENT,
     TOPIC_CMD_PAUSE,
-    TOPIC_CMD_PING,
+    TOPIC_CMD_PLAN_START,
     TOPIC_CMD_RECALL,
     TOPIC_CMD_RESUME,
     TOPIC_CMD_SET_FAN_LEVEL,
-    TOPIC_CMD_SET_MOP_HUMIDITY,
-    TOPIC_CMD_PLAN_START,
-    TOPIC_CMD_CLEAN_TASK,
-    TOPIC_CMD_TAKE_PICTURE,
     TOPIC_CMD_SET_LED,
+    TOPIC_CMD_SET_MOP_HUMIDITY,
+    TOPIC_CMD_TAKE_PICTURE,
+    TOPIC_CMD_WASH_AND_DRY_MOP,
     TOPIC_CMD_WASH_MOP,
+    TOPIC_CMD_WASH_MOP_BY_ROBOT_STATUS,
     TOPIC_CMD_YELL,
-    DEFAULT_TOPIC_PREFIX,
+    TOPIC_PLANNING_DEBUG,
+    TOPIC_POINT_NAVI_PLAN_TRAJ,
+    TOPIC_ROBOT_CURRENT_STATUS,
+    TOPIC_ROBOT_STATUS,
+    TOPIC_ROBOT_TASK_STATUS,
+    TOPIC_TIMELINE_STATUS,
     WAKE_TIMEOUT,
+    CleaningRoute,
     CommandResult,
     FanLevel,
     MopHumidity,
     MopStrengthLevel,
-    WorkMode,
     WorkingStatus,
+    WorkMode,
 )
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState
 from .protocol import (
@@ -68,6 +81,92 @@ from .protocol import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+_ACTIVE_WORKING_STATUS_TTL = 15.0
+_STALE_DOCK_BASE_STATUSES = {
+    WorkingStatus.UNKNOWN,
+    WorkingStatus.STANDBY,
+    WorkingStatus.DOCKED,
+    WorkingStatus.CHARGED,
+    WorkingStatus.DOCKED_V2,
+}
+_AUX_STATUS_TOPICS = {
+    TOPIC_TIMELINE_STATUS,
+    TOPIC_POINT_NAVI_PLAN_TRAJ,
+    TOPIC_PLANNING_DEBUG,
+    TOPIC_ROBOT_STATUS,
+    TOPIC_ROBOT_CURRENT_STATUS,
+    TOPIC_ROBOT_TASK_STATUS,
+}
+
+
+def _short_repr(value: Any, limit: int = 1200) -> str:
+    text = repr(value)
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}…"
+
+
+def _normalise_blackboxprotobuf_typedef(typedef: dict[str, Any]) -> dict[str, Any]:
+    """Add field names expected by some blackboxprotobuf releases."""
+    for info in typedef.values():
+        info.setdefault("name", "")
+        message_typedef = info.get("message_typedef")
+        if isinstance(message_typedef, dict):
+            _normalise_blackboxprotobuf_typedef(message_typedef)
+        alt_typedefs = info.get("alt_typedefs")
+        if isinstance(alt_typedefs, dict):
+            for alt_typedef in alt_typedefs.values():
+                if isinstance(alt_typedef, dict):
+                    _normalise_blackboxprotobuf_typedef(alt_typedef)
+    return typedef
+
+
+def _base_status_working_status(decoded: dict[str, Any] | object) -> WorkingStatus | None:
+    """Extract robot_base_status field 3.1."""
+    if not isinstance(decoded, dict):
+        return None
+    field3 = decoded.get("3")
+    if isinstance(field3, list):
+        field3 = field3[0] if field3 else None
+    if not isinstance(field3, dict) or "1" not in field3:
+        return None
+    try:
+        return WorkingStatus(int(field3["1"]))
+    except (TypeError, ValueError):
+        return None
+
+
+def _base_status_confirms_docked(
+    decoded: dict[str, Any] | object, status: WorkingStatus | None
+) -> bool:
+    """Return true when a terminal status also carries live dock indicators."""
+    if not isinstance(decoded, dict) or status not in {
+        WorkingStatus.STANDBY,
+        WorkingStatus.DOCKED,
+        WorkingStatus.CHARGED,
+        WorkingStatus.DOCKED_V2,
+    }:
+        return False
+    field3 = decoded.get("3")
+    if isinstance(field3, list):
+        field3 = field3[0] if field3 else None
+    field3 = field3 if isinstance(field3, dict) else {}
+
+    def int_field(container: dict[str, Any], field: str) -> int:
+        try:
+            return int(container.get(field, 0))
+        except (TypeError, ValueError):
+            return 0
+
+    return (
+        int_field(decoded, "11") >= 2
+        or int_field(decoded, "47") in (1, 3)
+        or int_field(field3, "3") in (1, 6)
+        or int_field(field3, "10") == 1
+        or int_field(field3, "12") > 0
+        or int_field(field3, "18") > 0
+    )
 
 
 class NarwalConnectionError(Exception):
@@ -115,7 +214,11 @@ class NarwalClient:
         self._listener_active = False  # True when start_listening() is running recv loop
         self._robot_awake = False  # True once we receive a broadcast
         self._last_broadcast_time: float = 0.0  # monotonic time of last broadcast
+        self._last_status_time: float = 0.0  # monotonic time of last status/base broadcast
         self._last_display_map_time: float = 0.0  # monotonic time of last display_map
+        self._last_active_working_status_time: float = 0.0
+        self._last_aux_log_time: dict[str, float] = {}
+        self._last_base_status_log: tuple[Any, Any, Any] | None = None
         # Queue for field5 command responses
         self._response_queue: asyncio.Queue[NarwalMessage] = asyncio.Queue()
         # Lock to prevent concurrent send_command calls from racing on the queue
@@ -148,6 +251,89 @@ class NarwalClient:
         if self._last_display_map_time <= 0:
             return 999.0
         return time.monotonic() - self._last_display_map_time
+
+    @property
+    def last_status_age(self) -> float:
+        """Seconds since last status/base broadcast (999.0 if none received)."""
+        if self._last_status_time <= 0:
+            return 999.0
+        return time.monotonic() - self._last_status_time
+
+    def _active_working_status_is_recent(self, now: float | None = None) -> bool:
+        """Return true while fresh working_status telemetry is contradicting base_status."""
+        if self._last_active_working_status_time <= 0:
+            return False
+        now = time.monotonic() if now is None else now
+        return now - self._last_active_working_status_time <= _ACTIVE_WORKING_STATUS_TTL
+
+    def _state_needs_keepalive(self) -> bool:
+        """Return true when the app-style keepalive should keep the robot awake."""
+        state = self.state
+        if state.working_status == WorkingStatus.UNKNOWN:
+            return True
+        if state.working_status == WorkingStatus.ERROR:
+            return True
+        if state.is_cleaning or state.is_returning:
+            return True
+        if state.is_station_active:
+            return True
+        if (
+            state.is_paused
+            and state._working_status_is_cleaning_like()
+            and not state.is_docked
+        ):
+            return True
+        if state.working_status == WorkingStatus.CLEANING_ALT and state.is_docked:
+            return True
+        return not state.is_docked
+
+    def _update_from_working_status_broadcast(
+        self, decoded: dict[str, Any], now: float | None = None
+    ) -> None:
+        """Update state from a working_status broadcast."""
+        self.state.update_from_working_status(decoded)
+        if self.state.has_recent_active_working_status:
+            self._last_active_working_status_time = (
+                self.state.last_active_working_status_time
+            )
+
+    def _update_from_base_status_broadcast(
+        self, decoded: dict[str, Any], now: float | None = None
+    ) -> None:
+        """Update state from robot_base_status, ignoring stale dock overlays mid-task."""
+        now = time.monotonic() if now is None else now
+        base_status = _base_status_working_status(decoded)
+        signature = (decoded.get("3"), decoded.get("11"), decoded.get("47"))
+        if signature != self._last_base_status_log:
+            self._last_base_status_log = signature
+            _LOGGER.debug(
+                "%s robot_base_status field3=%r field11=%r field47=%r",
+                self.host,
+                decoded.get("3"),
+                decoded.get("11"),
+                decoded.get("47"),
+            )
+        if (
+            base_status in _STALE_DOCK_BASE_STATUSES
+            and self._active_working_status_is_recent(now)
+            and not _base_status_confirms_docked(decoded, base_status)
+        ):
+            _LOGGER.debug(
+                "Ignoring stale %s base_status while active working_status is fresh",
+                base_status.name,
+            )
+            self.state.update_battery_from_base_status(decoded)
+            return
+        self.state.update_from_base_status(decoded)
+
+    def _update_from_aux_status_broadcast(
+        self, short_topic: str, decoded: dict[str, Any]
+    ) -> None:
+        self.state.update_from_aux_status(short_topic, decoded)
+        now = time.monotonic()
+        if now - self._last_aux_log_time.get(short_topic, 0.0) > 30.0:
+            self._last_aux_log_time[short_topic] = now
+            _LOGGER.debug("%s decoded status: %s", short_topic, _short_repr(decoded))
 
     async def connect(self) -> None:
         """Establish WebSocket connection to the vacuum.
@@ -255,6 +441,9 @@ class NarwalClient:
                     else:
                         raw_id = str(raw_id).strip()
                     if raw_id:
+                        parts = msg.topic.split("/") if msg.topic else []
+                        if len(parts) >= 2 and parts[1]:
+                            self.topic_prefix = f"/{parts[1]}"
                         self.device_id = raw_id
                         _LOGGER.info("Discovered device_id from response: %s", self.device_id)
                         return self.device_id
@@ -333,12 +522,11 @@ class NarwalClient:
             try:
                 if not self.connected:
                     await self.connect()
-                    # Immediate wake burst on (re)connect — the fresh TCP
-                    # connection may trigger the robot's deep-sleep wake
-                    # interrupt, but only if we send commands before it
-                    # expires.  Don't wait for the keepalive loop's first
-                    # tick (15s delay would be too late).
-                    await self._send_wake_burst()
+                    if self._state_needs_keepalive():
+                        await self._send_wake_burst()
+                    else:
+                        await self.subscribe_to_topics()
+                        _LOGGER.debug("Robot is docked/idle; not sending reconnect wake")
 
                 retry_delay = RECONNECT_INITIAL_DELAY  # reset on success
                 self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
@@ -413,10 +601,13 @@ class NarwalClient:
             _LOGGER.debug("Failed to decode protobuf for topic %s", short_topic)
             return
 
+        now = time.monotonic()
         if short_topic == "status/working_status":
-            self.state.update_from_working_status(decoded)
+            self._last_status_time = now
+            self._update_from_working_status_broadcast(decoded, now)
         elif short_topic == "status/robot_base_status":
-            self.state.update_from_base_status(decoded)
+            self._last_status_time = now
+            self._update_from_base_status_broadcast(decoded, now)
         elif short_topic == "upgrade/upgrade_status":
             self.state.update_from_upgrade_status(decoded)
         elif short_topic == "status/download_status":
@@ -430,6 +621,8 @@ class NarwalClient:
                 self.state.map_display_data.robot_y,
                 self.state.map_display_data.timestamp,
             )
+        elif short_topic in _AUX_STATUS_TOPICS:
+            self._update_from_aux_status_broadcast(short_topic, decoded)
         if self.on_state_update:
             self.on_state_update(self.state)
 
@@ -489,9 +682,12 @@ class NarwalClient:
         "upgrade/upgrade_status",
         "status/download_status",
         "map/display_map",
-        "status/time_line_status",
-        "status/point_navi_plan_traj",
-        "developer/planning_debug_info",
+        TOPIC_TIMELINE_STATUS,
+        TOPIC_POINT_NAVI_PLAN_TRAJ,
+        TOPIC_PLANNING_DEBUG,
+        TOPIC_ROBOT_STATUS,
+        TOPIC_ROBOT_CURRENT_STATUS,
+        TOPIC_ROBOT_TASK_STATUS,
     ]
 
     def _build_topic_subscription(self, duration: int = 600) -> bytes:
@@ -696,9 +892,12 @@ class NarwalClient:
                         except Exception:
                             _LOGGER.debug("Topic re-subscribe failed")
 
+                    if not self._state_needs_keepalive():
+                        _LOGGER.debug("Robot is docked/idle; skipping app keepalive")
+                        continue
+
                     # Send lightweight heartbeat to keep robot awake.
-                    # The Narwal app sends this continuously regardless of
-                    # robot state — it's safe during cleaning.
+                    # This is only needed while an active task is in progress.
                     try:
                         payload = self._encode_varint_field(1, 1)
                         frame = build_frame(
@@ -710,6 +909,11 @@ class NarwalClient:
                         _LOGGER.debug("Keepalive send failed")
                         break
                 else:
+                    if not self._state_needs_keepalive():
+                        consecutive_wake_failures = 0
+                        _LOGGER.debug("Robot is docked/idle; not waking")
+                        continue
+
                     # Robot appears asleep — send full wake burst
                     # (wake burst includes topic subscription)
                     consecutive_wake_failures += 1
@@ -857,16 +1061,19 @@ class NarwalClient:
             except Exception:
                 continue
 
+            now = time.monotonic()
             if short_topic == "status/working_status":
-                self.state.update_from_working_status(decoded)
+                self._update_from_working_status_broadcast(decoded, now)
             elif short_topic == "status/robot_base_status":
-                self.state.update_from_base_status(decoded)
+                self._update_from_base_status_broadcast(decoded, now)
             elif short_topic == "upgrade/upgrade_status":
                 self.state.update_from_upgrade_status(decoded)
             elif short_topic == "status/download_status":
                 self.state.update_from_download_status(decoded)
             elif short_topic == "map/display_map":
                 self.state.map_display_data = MapDisplayData.from_broadcast(decoded)
+            elif short_topic in _AUX_STATUS_TOPICS:
+                self._update_from_aux_status_broadcast(short_topic, decoded)
 
         raise NarwalCommandError(
             f"No field5 response within {timeout}s"
@@ -948,9 +1155,10 @@ class NarwalClient:
             len(room_ids),
         )
         payload = self._build_clean_payload_v2(room_ids)
-        return await self.send_command(
+        resp = await self.send_command(
             TOPIC_CMD_PLAN_START, payload=payload, timeout=10.0,
         )
+        return resp
 
     def _build_clean_payload_v2(
         self,
@@ -1047,7 +1255,9 @@ class NarwalClient:
                 },
             }
         }
-        return blackboxprotobuf.encode_message(msg, typedef)
+        return blackboxprotobuf.encode_message(
+            msg, _normalise_blackboxprotobuf_typedef(typedef)
+        )
 
     # WorkMode -> (CleanParam.mode tag 1, pass-count tags to set from `passes`). The robot's
     # execution mode is CleanTask.taskType (= the WorkMode value); CleanParam.mode and the
@@ -1070,13 +1280,14 @@ class NarwalClient:
         water: MopHumidity = MopHumidity.NORMAL,
         mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL,
         passes: int = 1,
+        route: CleaningRoute | None = None,
     ) -> bytes:
         """Build a clean/start_clean request for the given rooms.
 
         StartClean_Request{1: CleanTask{1: map_id, 2: [CleanItem...], 3: {} (TaskOption),
         5: taskType}}; CleanItem{1: ZoneOption{1: 1 (room zone), 2: room_id}, 2: CleanParam,
         3: order}. taskType (the execution-mode carrier) and CleanParam.mode/pass-tag are
-        derived from work_mode. overlapLevel is omitted — live-validated as ignored here.
+        derived from work_mode. overlapLevel is CleanParam tag 8 when supplied.
 
         Args:
             room_ids: Robot room IDs (RoomInfo.room_id).
@@ -1086,6 +1297,7 @@ class NarwalClient:
             water: Mop water volume (tag 4).
             mop_strength: Mop scrub intensity (tag 3).
             passes: Clean count, routed to the pass tag(s) for the mode.
+            route: Optional route overlap level (tag 8).
         """
         import blackboxprotobuf
 
@@ -1096,6 +1308,8 @@ class NarwalClient:
             "3": int(mop_strength),
             "4": int(water),
         }
+        if route is not None:
+            param["8"] = int(route)
         for tag in pass_tags:
             param[tag] = int(passes)
 
@@ -1130,7 +1344,9 @@ class NarwalClient:
             "3": {"type": "message", "message_typedef": {}},
             "5": {"type": "int"},
         }}}
-        return blackboxprotobuf.encode_message({"1": task}, typedef)
+        return blackboxprotobuf.encode_message(
+            {"1": task}, _normalise_blackboxprotobuf_typedef(typedef)
+        )
 
     def _build_room_clean_payload(self, room_ids: list[int]) -> bytes:
         """Build the legacy flat room-clean payload for older firmware."""
@@ -1194,6 +1410,7 @@ class NarwalClient:
         water: MopHumidity = MopHumidity.WET,
         mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL,
         passes: int = 1,
+        route: CleaningRoute | None = None,
     ) -> CommandResponse:
         """Start cleaning the given rooms via clean/start_clean.
 
@@ -1209,7 +1426,7 @@ class NarwalClient:
 
         Args:
             room_ids: Robot room IDs (RoomInfo.room_id), mapped from HA areas.
-            work_mode, fan, water, mop_strength, passes: CleanParam settings —
+            work_mode, fan, water, mop_strength, passes, route: CleanParam settings —
                 see _build_start_clean_payload.
         """
         if not room_ids:
@@ -1246,6 +1463,7 @@ class NarwalClient:
                 water=water,
                 mop_strength=mop_strength,
                 passes=passes,
+                route=route,
             )
             resp = await self.send_command(
                 TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
@@ -1390,6 +1608,10 @@ class NarwalClient:
         """Wash the mop pads at the station."""
         return await self.send_command(TOPIC_CMD_WASH_MOP)
 
+    async def wash_mop_by_robot_status(self) -> CommandResponse:
+        """Wash mop pads using the app's status-gated station command."""
+        return await self.send_command(TOPIC_CMD_WASH_MOP_BY_ROBOT_STATUS)
+
     async def dry_mop(self) -> CommandResponse:
         """Dry the mop pads at the station."""
         return await self.send_command(TOPIC_CMD_DRY_MOP)
@@ -1397,6 +1619,18 @@ class NarwalClient:
     async def empty_dustbin(self) -> CommandResponse:
         """Empty the dustbin at the station."""
         return await self.send_command(TOPIC_CMD_DUST_GATHERING)
+
+    async def wash_and_dry_mop(self) -> CommandResponse:
+        """Wash and dry the mop pads at the station."""
+        return await self.send_command(TOPIC_CMD_WASH_AND_DRY_MOP)
+
+    async def dry_dust_bag(self) -> CommandResponse:
+        """Dry/disinfect the robot dust bin/canister."""
+        return await self.send_command(TOPIC_CMD_DRY_DUST_BAG)
+
+    async def dry_station_bag(self) -> CommandResponse:
+        """Dry/disinfect the dock dust bag."""
+        return await self.send_command(TOPIC_CMD_DRY_STATION_BAG)
 
     # --- Query commands ---
 
@@ -1443,12 +1677,27 @@ class NarwalClient:
         """
         resp = await self.send_command(TOPIC_CMD_GET_BASE_STATUS)
         status_data = resp.data.get("2", {})
+        if status_data and not isinstance(status_data, dict):
+            _LOGGER.debug(
+                "%s get_status response field 2 is %s, not a base-status object: %r",
+                self.host,
+                type(status_data).__name__,
+                status_data,
+            )
+            return resp
         if status_data:
             _LOGGER.debug(
-                "get_status response (full=%s): field3=%r, field2=%r",
+                "%s get_status response (full=%s): field3=%r, field2=%r",
+                self.host,
                 full_update,
                 status_data.get("3") if isinstance(status_data, dict) else None,
                 status_data.get("2") if isinstance(status_data, dict) else None,
+            )
+            _LOGGER.debug(
+                "%s get_status decoded base_status (full=%s): %r",
+                self.host,
+                full_update,
+                status_data,
             )
             if full_update:
                 self.state.update_from_base_status(status_data)
@@ -1461,6 +1710,27 @@ class NarwalClient:
     async def get_current_task(self) -> CommandResponse:
         """Query the current clean task."""
         return await self.send_command(TOPIC_CMD_GET_CURRENT_TASK)
+
+    async def get_clean_progress_info(self) -> CommandResponse:
+        """Query active clean progress information."""
+        resp = await self.send_command(TOPIC_CMD_GET_CLEAN_PROGRESS_INFO)
+        self.state.update_from_aux_status(TOPIC_CMD_GET_CLEAN_PROGRESS_INFO, resp.data)
+        _LOGGER.debug("%s clean_progress_info response: %r", self.host, resp.data)
+        return resp
+
+    async def get_dry_mop_remain_time(self) -> CommandResponse:
+        """Query remaining mop drying time."""
+        resp = await self.send_command(TOPIC_CMD_GET_DRY_MOP_REMAIN_TIME)
+        self.state.update_from_aux_status(TOPIC_CMD_GET_DRY_MOP_REMAIN_TIME, resp.data)
+        _LOGGER.debug("%s dry_mop_remain_time response: %r", self.host, resp.data)
+        return resp
+
+    async def get_robot_task_status(self) -> CommandResponse:
+        """Query the robot task status model."""
+        resp = await self.send_command(TOPIC_CMD_GET_ROBOT_TASK_STATUS)
+        self.state.update_from_aux_status(TOPIC_CMD_GET_ROBOT_TASK_STATUS, resp.data)
+        _LOGGER.debug("%s robot_task_status response: %r", self.host, resp.data)
+        return resp
 
     async def get_map(self) -> MapData:
         """Download the full map data."""

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -19,6 +19,7 @@ from .const import (
     HEARTBEAT_INTERVAL,
     KEEPALIVE_INTERVAL,
     KNOWN_PRODUCT_KEYS,
+    LEGACY_ROOM_CLEAN_PRODUCT_KEYS,
     RECONNECT_BACKOFF_FACTOR,
     RECONNECT_INITIAL_DELAY,
     RECONNECT_MAX_DELAY,
@@ -42,7 +43,8 @@ from .const import (
     TOPIC_CMD_RESUME,
     TOPIC_CMD_SET_FAN_LEVEL,
     TOPIC_CMD_SET_MOP_HUMIDITY,
-    TOPIC_CMD_START_CLEAN,
+    TOPIC_CMD_PLAN_START,
+    TOPIC_CMD_CLEAN_TASK,
     TOPIC_CMD_TAKE_PICTURE,
     TOPIC_CMD_SET_LED,
     TOPIC_CMD_WASH_MOP,
@@ -52,6 +54,9 @@ from .const import (
     CommandResult,
     FanLevel,
     MopHumidity,
+    MopStrengthLevel,
+    WorkMode,
+    WorkingStatus,
 )
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState
 from .protocol import (
@@ -915,7 +920,7 @@ class NarwalClient:
         so we know which rooms to include.
         """
         resp = await self.send_command(
-            TOPIC_CMD_START_CLEAN,
+            TOPIC_CMD_PLAN_START,
             payload=self._DEFAULT_CLEAN_PAYLOAD,
             timeout=10.0,
         )
@@ -944,7 +949,7 @@ class NarwalClient:
         )
         payload = self._build_clean_payload_v2(room_ids)
         return await self.send_command(
-            TOPIC_CMD_START_CLEAN, payload=payload, timeout=10.0,
+            TOPIC_CMD_PLAN_START, payload=payload, timeout=10.0,
         )
 
     def _build_clean_payload_v2(
@@ -958,9 +963,7 @@ class NarwalClient:
         """Build clean task payload using the v2 schema (firmware v01.07.22+).
 
         Observed in issue #36 from a Flow on firmware v01.07.22.00.
-        Each room entry uses a nested room_id (different from the flat
-        schema in _build_room_clean_payload used for room-targeted cleans
-        on older firmware):
+        Each room entry uses a nested room_id:
 
             {
               1: {1: 1, 2: <room_id>},                # nested room ref
@@ -1046,41 +1049,100 @@ class NarwalClient:
         }
         return blackboxprotobuf.encode_message(msg, typedef)
 
-    def _build_room_clean_payload(self, room_ids: list[int]) -> bytes:
-        """Build CleanTask protobuf with per-room clean params in field 1.2.
+    # WorkMode -> (CleanParam.mode tag 1, pass-count tags to set from `passes`). The robot's
+    # execution mode is CleanTask.taskType (= the WorkMode value); CleanParam.mode and the
+    # pass tag are derived here so the two can't drift. Live-validated on a Flow 2; see
+    # project_history.md "CleanParam — fully decoded".
+    _WORK_MODE_PARAM: dict[WorkMode, tuple[int, tuple[str, ...]]] = {
+        WorkMode.VACUUM: (2, ("5",)),               # sweepTime
+        WorkMode.MOP: (3, ("6",)),                 # mopTime
+        WorkMode.VACUUM_THEN_MOP: (5, ("5", "6")),  # sweep + mop pass counts
+        WorkMode.VACUUM_AND_MOP: (4, ("7",)),      # sweepMopSyncTime
+    }
 
-        Each room entry in field 1.2 requires full MapCleanParamInfo fields
-        (from APK proto analysis):
-          field 1: roomId (uint32)
-          field 2: cleanMode (int32) — 0=sweep, 1=mop, 2=sweep+mop
-          field 3: cleanTimes (int32) — number of passes
-          field 6: sweepMode (int32) — suction level (3=max)
-          field 7: mopMode (int32) — mop humidity (2=wet)
+    def _build_start_clean_payload(
+        self,
+        room_ids: list[int],
+        map_id: int,
+        *,
+        work_mode: WorkMode = WorkMode.VACUUM_AND_MOP,
+        fan: FanLevel = FanLevel.NORMAL,
+        water: MopHumidity = MopHumidity.NORMAL,
+        mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL,
+        passes: int = 1,
+    ) -> bytes:
+        """Build a clean/start_clean request for the given rooms.
 
-        A bare roomId without clean params is silently ignored by the robot.
+        StartClean_Request{1: CleanTask{1: map_id, 2: [CleanItem...], 3: {} (TaskOption),
+        5: taskType}}; CleanItem{1: ZoneOption{1: 1 (room zone), 2: room_id}, 2: CleanParam,
+        3: order}. taskType (the execution-mode carrier) and CleanParam.mode/pass-tag are
+        derived from work_mode. overlapLevel is omitted — live-validated as ignored here.
 
         Args:
-            room_ids: List of room IDs from RoomInfo.room_id.
-
-        Returns:
-            Encoded protobuf bytes for clean/plan/start.
+            room_ids: Robot room IDs (RoomInfo.room_id).
+            map_id: Active map id (MapData.map_id, get_map field 2.1).
+            work_mode: Vacuum / mop / vacuum-then-mop / vacuum-and-mop.
+            fan: Suction level (CleanParam tag 2).
+            water: Mop water volume (tag 4).
+            mop_strength: Mop scrub intensity (tag 3).
+            passes: Clean count, routed to the pass tag(s) for the mode.
         """
+        import blackboxprotobuf
+
+        param_mode, pass_tags = self._WORK_MODE_PARAM[work_mode]
+        param: dict[str, int] = {
+            "1": int(param_mode),
+            "2": int(fan),
+            "3": int(mop_strength),
+            "4": int(water),
+        }
+        for tag in pass_tags:
+            param[tag] = int(passes)
+
+        items = [
+            {"1": {"1": 1, "2": rid}, "2": dict(param), "3": idx + 1}
+            for idx, rid in enumerate(room_ids)
+        ]
+        task = {
+            "1": map_id,
+            "2": items if len(items) > 1 else items[0],
+            "3": {},
+            "5": int(work_mode),  # CleanTask.taskType
+        }
+        item_typedef = {
+            "type": "message",
+            "seen_repeated": True,
+            "message_typedef": {
+                "1": {"type": "message", "message_typedef": {
+                    "1": {"type": "int"}, "2": {"type": "int"},
+                }},
+                # Derive the CleanParam typedef from the emitted dict — bbpb silently
+                # drops any tag absent from the typedef.
+                "2": {"type": "message", "message_typedef": {
+                    k: {"type": "int"} for k in param
+                }},
+                "3": {"type": "int"},
+            },
+        }
+        typedef = {"1": {"type": "message", "message_typedef": {
+            "1": {"type": "int"},
+            "2": item_typedef,
+            "3": {"type": "message", "message_typedef": {}},
+            "5": {"type": "int"},
+        }}}
+        return blackboxprotobuf.encode_message({"1": task}, typedef)
+
+    def _build_room_clean_payload(self, room_ids: list[int]) -> bytes:
+        """Build the legacy flat room-clean payload for older firmware."""
         if not room_ids:
             return self._DEFAULT_CLEAN_PAYLOAD
 
         import blackboxprotobuf
 
-        # Build per-room entries with default clean settings
-        room_entries = []
-        for rid in room_ids:
-            room_entries.append({
-                "1": rid,       # roomId
-                "2": 2,         # cleanMode = sweep+mop
-                "3": 1,         # cleanTimes = 1 pass
-                "6": 3,         # sweepMode = max suction
-                "7": 2,         # mopMode = wet
-            })
-
+        room_entries = [
+            {"1": room_id, "2": 2, "3": 1, "6": 3, "7": 2}
+            for room_id in room_ids
+        ]
         room_typedef = {
             "type": "message",
             "seen_repeated": True,
@@ -1090,19 +1152,13 @@ class NarwalClient:
                 "3": {"type": "int"},
                 "6": {"type": "int"},
                 "7": {"type": "int"},
-            }
+            },
         }
-
-        # Single room: field 1.2 is a message; multiple: repeated message
         field_2_value = room_entries[0] if len(room_entries) == 1 else room_entries
-
-        msg = {
+        message = {
             "1": {
                 "2": field_2_value,
-                "5": {
-                    "1": {"1": 3, "2": 2, "3": 1},
-                    "5": {}
-                }
+                "5": {"1": {"1": 3, "2": 2, "3": 1}, "5": {}},
             }
         }
         typedef = {
@@ -1118,53 +1174,143 @@ class NarwalClient:
                                 "message_typedef": {
                                     "1": {"type": "int"},
                                     "2": {"type": "int"},
-                                    "3": {"type": "int"}
-                                }
+                                    "3": {"type": "int"},
+                                },
                             },
-                            "5": {"type": "message", "message_typedef": {}}
-                        }
-                    }
-                }
+                            "5": {"type": "message", "message_typedef": {}},
+                        },
+                    },
+                },
             }
         }
-        return blackboxprotobuf.encode_message(msg, typedef)
+        return blackboxprotobuf.encode_message(message, typedef)
 
     async def start_rooms(
-        self, room_ids: list[int],
+        self,
+        room_ids: list[int],
+        *,
+        work_mode: WorkMode = WorkMode.VACUUM_AND_MOP,
+        fan: FanLevel = FanLevel.DEEP,
+        water: MopHumidity = MopHumidity.WET,
+        mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL,
+        passes: int = 1,
     ) -> CommandResponse:
-        """Start room-specific cleaning.
+        """Start cleaning the given rooms via clean/start_clean.
 
-        Sends clean/plan/start with the user-selected rooms. Tries the v2
-        nested-room schema first (required by firmware v01.07.22+, and fixes
-        the ack-but-ignore behavior in #37 where legacy schema returns
-        SUCCESS but the robot runs the app shortcut instead of HA-selected
-        rooms). Falls back to legacy flat-room schema on NOT_APPLICABLE
-        for older firmware.
+        Room cleaning must use clean/start_clean (StartClean → CleanTask), not
+        clean/plan/start: on Flow firmware the latter is StartWithPlan{planId,
+        mapId} and ignores any room payload — the root cause of #25/#37, where
+        the robot undocks and wanders instead of cleaning the selected rooms.
+        The CleanTask carries the active map id (get_map field 2.1).
+
+        clean/start_clean only works while docked; from STANDBY the robot
+        returns NOT_READY (4). Callers should start from the dock; this retries
+        briefly to cover the dock settling transition.
 
         Args:
-            room_ids: List of room IDs from RoomInfo.room_id.
-
-        Returns:
-            CommandResponse with result code from whichever schema landed.
+            room_ids: Robot room IDs (RoomInfo.room_id), mapped from HA areas.
+            work_mode, fan, water, mop_strength, passes: CleanParam settings —
+                see _build_start_clean_payload.
         """
         if not room_ids:
             return await self.start()
 
-        payload_v2 = self._build_clean_payload_v2(room_ids)
+        product_key = (
+            self.state.device_info.product_key
+            if self.state.device_info is not None
+            and self.state.device_info.product_key
+            else self.topic_prefix.removeprefix("/")
+        )
+        supports_legacy_room_clean = product_key in LEGACY_ROOM_CLEAN_PRODUCT_KEYS
+        map_data = self.state.map_data
+        if not map_data or not map_data.map_id:
+            try:
+                map_data = await self.get_map()
+            except NarwalCommandError:
+                if not supports_legacy_room_clean:
+                    raise
+                _LOGGER.debug(
+                    "start_rooms: map fetch failed; trying legacy room-clean commands"
+                )
+                map_data = None
+        map_id = map_data.map_id if map_data else 0
+        if not map_id and not supports_legacy_room_clean:
+            return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        resp = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        if map_id:
+            payload = self._build_start_clean_payload(
+                room_ids,
+                map_id,
+                work_mode=work_mode,
+                fan=fan,
+                water=water,
+                mop_strength=mop_strength,
+                passes=passes,
+            )
+            resp = await self.send_command(
+                TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
+            )
+            for _ in range(3):
+                if resp.result_code != CommandResult.NOT_READY:
+                    break
+                if not self.state.is_docked:
+                    _LOGGER.warning(
+                        "start_rooms: robot not docked (status=%s); "
+                        "clean/start_clean requires the robot on the dock",
+                        self.state.working_status.name,
+                    )
+                    break
+                _LOGGER.info(
+                    "start_rooms: robot docking/settling, retrying "
+                    "clean/start_clean"
+                )
+                await asyncio.sleep(3.0)
+                resp = await self.send_command(
+                    TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
+                )
+        else:
+            _LOGGER.warning(
+                "start_rooms: no active map id available; trying legacy room clean"
+            )
+        if resp.result_code != CommandResult.NOT_APPLICABLE:
+            return resp
+        if not supports_legacy_room_clean:
+            return resp
+
+        _LOGGER.info(
+            "start_rooms: clean/start_clean rejected, trying clean/plan/start "
+            "compatibility payloads"
+        )
+        legacy_suction = {
+            FanLevel.UNSPECIFIED: 3,
+            FanLevel.MUTE: 0,
+            FanLevel.NORMAL: 1,
+            FanLevel.STRONG: 2,
+            FanLevel.DEEP: 3,
+            FanLevel.SUPER: 3,
+        }[FanLevel(fan)]
+        legacy_water = {
+            MopHumidity.UNSPECIFIED: 2,
+            MopHumidity.DRY: 0,
+            MopHumidity.NORMAL: 1,
+            MopHumidity.WET: 2,
+        }[MopHumidity(water)]
+        legacy_v2 = self._build_clean_payload_v2(
+            room_ids,
+            suction=legacy_suction,
+            mop_humidity=legacy_water,
+            passes=passes,
+        )
         resp = await self.send_command(
-            TOPIC_CMD_START_CLEAN, payload=payload_v2, timeout=10.0,
+            TOPIC_CMD_PLAN_START, payload=legacy_v2, timeout=10.0,
         )
         if resp.result_code != CommandResult.NOT_APPLICABLE:
             return resp
 
-        # v2 rejected — try legacy flat-room schema (older firmware)
-        _LOGGER.info(
-            "start_rooms(): v2 payload rejected, retrying with legacy schema (%d rooms)",
-            len(room_ids),
-        )
-        payload_legacy = self._build_room_clean_payload(room_ids)
         return await self.send_command(
-            TOPIC_CMD_START_CLEAN, payload=payload_legacy, timeout=10.0,
+            TOPIC_CMD_PLAN_START,
+            payload=self._build_room_clean_payload(room_ids),
+            timeout=10.0,
         )
 
     async def start_easy_clean(self) -> CommandResponse:
@@ -1196,21 +1342,48 @@ class NarwalClient:
         return await self.send_command(TOPIC_CMD_RECALL, timeout=timeout)
 
     async def set_fan_speed(self, level: FanLevel | int) -> CommandResponse:
-        """Set suction fan speed.
+        """Set suction fan speed live (clean/set_fan_level, field 1 = SweepFanLevel).
 
-        Args:
-            level: FanLevel enum or int (0=quiet, 1=normal, 2=strong, 3=max).
+        The live command's enum is SweepFanLevel, which has no SUPER. Use its
+        highest available level, DEEP, when callers request SUPER. Bare integer
+        values retain the original 0=quiet through 3=max API mapping.
         """
-        payload = b"\x08" + bytes([int(level) & 0x7F])
+        if isinstance(level, FanLevel):
+            live = min(int(level), int(FanLevel.DEEP))
+        else:
+            legacy_levels = {
+                0: FanLevel.MUTE,
+                1: FanLevel.NORMAL,
+                2: FanLevel.STRONG,
+                3: FanLevel.DEEP,
+            }
+            try:
+                live = int(legacy_levels[level])
+            except KeyError as err:
+                raise ValueError(f"Invalid legacy fan level: {level}") from err
+        payload = b"\x08" + bytes([live & 0x7F])
         return await self.send_command(TOPIC_CMD_SET_FAN_LEVEL, payload)
 
     async def set_mop_humidity(self, level: MopHumidity | int) -> CommandResponse:
-        """Set mop wetness level.
+        """Set mop water volume live (clean/set_mop_humidity, field 1 = MopHumidity).
 
         Args:
-            level: MopHumidity enum or int (0=dry, 1=normal, 2=wet).
+            level: MopHumidity enum, or the legacy int mapping
+                (0=dry, 1=normal, 2=wet).
         """
-        payload = b"\x08" + bytes([int(level) & 0x7F])
+        if isinstance(level, MopHumidity):
+            live = int(level)
+        else:
+            legacy_levels = {
+                0: MopHumidity.DRY,
+                1: MopHumidity.NORMAL,
+                2: MopHumidity.WET,
+            }
+            try:
+                live = int(legacy_levels[level])
+            except KeyError as err:
+                raise ValueError(f"Invalid legacy mop humidity: {level}") from err
+        payload = b"\x08" + bytes([live & 0x7F])
         return await self.send_command(TOPIC_CMD_SET_MOP_HUMIDITY, payload)
 
     async def wash_mop(self) -> CommandResponse:

--- a/custom_components/narwal/narwal_client/const.py
+++ b/custom_components/narwal/narwal_client/const.py
@@ -51,6 +51,8 @@ KNOWN_PRODUCT_KEYS = [
     "cUlfJN5JYP",   # Unknown model (APK, contributed by @northwestsupra)
 ]
 
+LEGACY_ROOM_CLEAN_PRODUCT_KEYS = {"QoEsI5qYXO"}
+
 # --- Status topics (robot → client, field 4 / 0x22 frames) ---
 TOPIC_WORKING_STATUS = "status/working_status"
 TOPIC_ROBOT_BASE_STATUS = "status/robot_base_status"
@@ -82,8 +84,8 @@ TOPIC_CMD_DRY_MOP = "supply/dry_mop"
 TOPIC_CMD_DUST_GATHERING = "supply/dust_gathering"
 
 # Cleaning (Pita protocol — correct for AX12)
-TOPIC_CMD_START_CLEAN = "clean/plan/start"  # whole-house clean (empty payload)
-TOPIC_CMD_START_CLEAN_LEGACY = "clean/start_clean"  # does NOT work from STANDBY
+TOPIC_CMD_PLAN_START = "clean/plan/start"  # whole-house clean (empty payload)
+TOPIC_CMD_CLEAN_TASK = "clean/start_clean"  # room/zone CleanTask; only works docked
 TOPIC_CMD_EASY_CLEAN = "clean/easy_clean/start"
 TOPIC_CMD_SET_FAN_LEVEL = "clean/set_fan_level"
 TOPIC_CMD_SET_MOP_HUMIDITY = "clean/set_mop_humidity"
@@ -141,6 +143,7 @@ class CommandResult(IntEnum):
     SUCCESS = 1
     NOT_APPLICABLE = 2  # e.g., set_fan_level when not cleaning
     CONFLICT = 3  # e.g., recall when already recalling
+    NOT_READY = 4  # clean/start_clean while not docked (robot in STANDBY)
 
 
 class WorkingStatus(IntEnum):
@@ -179,20 +182,42 @@ class WorkingStatus(IntEnum):
 
 
 class FanLevel(IntEnum):
-    """Suction fan speed levels (SweepMode from APK)."""
+    """CleanParam suction level (CleanTask.pbenum FanLevel)."""
 
-    QUIET = 0
-    NORMAL = 1
-    STRONG = 2
-    MAX = 3
+    UNSPECIFIED = 0
+    MUTE = 1
+    QUIET = MUTE
+    NORMAL = 2
+    STRONG = 3
+    DEEP = 4
+    MAX = DEEP
+    SUPER = 5
 
 
 class MopHumidity(IntEnum):
-    """Mop wetness levels."""
+    """Water volume. CleanParam tag 4 and the live clean/set_mop_humidity command share these ints."""
 
-    DRY = 0
+    UNSPECIFIED = 0
+    DRY = 1
+    NORMAL = 2
+    WET = 3
+
+
+class MopStrengthLevel(IntEnum):
+    """Mop scrub intensity (CleanParam tag 3)."""
+
+    UNSPECIFIED = 0
     NORMAL = 1
-    WET = 2
+    HIGH = 2
+
+
+class WorkMode(IntEnum):
+    """Clean work mode — the app's robot_work_mode_* selector (Vacuum / Mop / Vacuum then mop / Vacuum and mop). Its value IS the CleanTask.taskType the robot executes; the per-item CleanParam.mode (the proto's own CleanMode enum) is derived separately in client._WORK_MODE_PARAM."""
+
+    VACUUM = 1
+    MOP = 2
+    VACUUM_THEN_MOP = 3
+    VACUUM_AND_MOP = 4
 
 
 # robot_base_status field numbers

--- a/custom_components/narwal/narwal_client/const.py
+++ b/custom_components/narwal/narwal_client/const.py
@@ -24,6 +24,7 @@ KNOWN_PRODUCT_KEYS = [
     # Confirmed working (local WebSocket)
     "QoEsI5qYXO",  # AX12 — Narwal Flow (primary, confirmed)
     "QxMSPG6VSO",  # Narwal Flow 2 (confirmed working via local WebSocket)
+    "iSuVlI1If2",  # Narwal Flow 2 alternate key (confirmed working locally)
     "DrzDKQ0MU8",   # CX4  — Freo Z10 Ultra (confirmed by @irekkl-maker)
     # Confirmed cloud-only (port 9002 open but no local broadcasts)
     "BYWBPqSxeC",   # CX7  — Freo Z Ultra (cloud-only, confirmed by @gabrielozcomidi)
@@ -60,7 +61,11 @@ TOPIC_UPGRADE_STATUS = "upgrade/upgrade_status"
 TOPIC_DOWNLOAD_STATUS = "status/download_status"
 TOPIC_DISPLAY_MAP = "map/display_map"
 TOPIC_TIMELINE_STATUS = "status/time_line_status"
+TOPIC_POINT_NAVI_PLAN_TRAJ = "status/point_navi_plan_traj"
 TOPIC_PLANNING_DEBUG = "developer/planning_debug_info"
+TOPIC_ROBOT_STATUS = "status/robot"
+TOPIC_ROBOT_CURRENT_STATUS = "status/robot/current"
+TOPIC_ROBOT_TASK_STATUS = "robot/task/status"
 
 # --- Command topics (client → robot, confirmed working) ---
 # Common
@@ -80,8 +85,12 @@ TOPIC_CMD_CANCEL = "task/cancel"
 # Supply/dock
 TOPIC_CMD_RECALL = "supply/recall"
 TOPIC_CMD_WASH_MOP = "supply/wash_mop"
+TOPIC_CMD_WASH_MOP_BY_ROBOT_STATUS = "supply/wash_mop_by_robot_status"
 TOPIC_CMD_DRY_MOP = "supply/dry_mop"
 TOPIC_CMD_DUST_GATHERING = "supply/dust_gathering"
+TOPIC_CMD_WASH_AND_DRY_MOP = "supply/wash_and_dry_mop"
+TOPIC_CMD_DRY_DUST_BAG = "supply/dry_dust_bag"
+TOPIC_CMD_DRY_STATION_BAG = "supply/dry_station_bag"
 
 # Cleaning (Pita protocol — correct for AX12)
 TOPIC_CMD_PLAN_START = "clean/plan/start"  # whole-house clean (empty payload)
@@ -90,6 +99,9 @@ TOPIC_CMD_EASY_CLEAN = "clean/easy_clean/start"
 TOPIC_CMD_SET_FAN_LEVEL = "clean/set_fan_level"
 TOPIC_CMD_SET_MOP_HUMIDITY = "clean/set_mop_humidity"
 TOPIC_CMD_GET_CURRENT_TASK = "clean/current_clean_task/get"
+TOPIC_CMD_GET_CLEAN_PROGRESS_INFO = "info/get_clean_progress_info"
+TOPIC_CMD_GET_DRY_MOP_REMAIN_TIME = "supply/get_dry_mop_remain_time"
+TOPIC_CMD_GET_ROBOT_TASK_STATUS = "robot/task/status/get"
 
 # Map
 TOPIC_CMD_GET_MAP = "map/get_map"
@@ -152,8 +164,10 @@ class WorkingStatus(IntEnum):
     Values confirmed via live WebSocket monitoring:
       1  = STANDBY (idle, transition state between cleaning and docked)
       2  = DOCKED_V2 (on dock; confirmed v01.07.23.00 while charging at 10-36%)
+      3  = CLEANING_V2 (active room clean; confirmed on Flow 2 v01.07.23)
       4  = CLEANING (plan-based start; also stays 4 while returning to dock on older FW)
       5  = CLEANING_ALT (observed live: robot was physically stuck when reporting 5)
+      7  = CLEANING_FLOW2 (active cleaning on Flow 2 v01.07.10.33)
       10 = DOCKED (on dock, charging)
       14 = CHARGED (on dock, fully charged)
       19 = TASK_COMPLETED (transitional: scheduled task finished, returning to base)
@@ -171,14 +185,26 @@ class WorkingStatus(IntEnum):
     UNKNOWN = 0
     STANDBY = 1       # idle / transition state
     DOCKED_V2 = 2     # on dock (v01.07.23.00+ — replaces DOCKED=10/CHARGED=14 from older FW)
+    CLEANING_V2 = 3   # active cleaning on Flow 2 firmware v01.07.23+
     CLEANING = 4      # active cleaning (stays 4 even while returning to dock)
     CLEANING_ALT = 5  # cleaning — observed when robot was physically stuck; may indicate error/stuck state
+    CLEANING_FLOW2 = 7  # active cleaning on Flow 2 v01.07.10.33
     DOCKED = 10       # on dock (does NOT reliably indicate charging vs charged)
     CHARGED = 14      # on dock (reported before 100% — use battery_level for charge state)
     TASK_COMPLETED = 19  # transitional: task finished, robot returning to base (#41)
     # PLACEHOLDER: error state value not yet observed live.
     # Trigger a real error (e.g., pick up robot mid-clean) to discover the value.
     ERROR = 99
+
+
+ACTIVE_CLEANING_STATUSES = frozenset(
+    {
+        WorkingStatus.CLEANING_V2,
+        WorkingStatus.CLEANING,
+        WorkingStatus.CLEANING_ALT,
+        WorkingStatus.CLEANING_FLOW2,
+    }
+)
 
 
 class FanLevel(IntEnum):
@@ -209,6 +235,13 @@ class MopStrengthLevel(IntEnum):
     UNSPECIFIED = 0
     NORMAL = 1
     HIGH = 2
+
+
+class CleaningRoute(IntEnum):
+    """Cleaning route overlap level (CleanParam tag 8)."""
+
+    STANDARD = 1
+    METICULOUS = 2
 
 
 class WorkMode(IntEnum):

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -254,6 +254,7 @@ class MapData:
     origin_y: int = 0  # y pixel offset from field 2.6.1
     obstacles: list[ObstacleInfo] = field(default_factory=list)
     raw: dict[str, Any] = field(default_factory=dict)
+    map_id: int = 0  # active map id (field 2.1) — required by clean/start_clean
 
     @classmethod
     def from_response(
@@ -344,6 +345,7 @@ class MapData:
             obstacles = _parse_obstacles(field32)
 
         return cls(
+            map_id=int(payload.get("1", 0)),
             width=int(payload.get("4", 0)),
             height=int(payload.get("5", 0)),
             resolution=resolution,

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -4,12 +4,20 @@ from __future__ import annotations
 
 import logging
 import struct
+import time
 from dataclasses import dataclass, field
 from typing import Any, ClassVar
 
 _LOGGER = logging.getLogger(__name__)
+_ACTIVE_WORKING_STATUS_TTL = 15.0
 
-from .const import CommandResult, FanLevel, MopHumidity, WorkingStatus
+from .const import (
+    ACTIVE_CLEANING_STATUSES,
+    TOPIC_CMD_GET_ROBOT_TASK_STATUS,
+    TOPIC_ROBOT_TASK_STATUS,
+    CommandResult,
+    WorkingStatus,
+)
 
 
 @dataclass
@@ -51,6 +59,11 @@ class RoomInfo:
     # Confirmed on Narwal Flow 2 (QxMSPG6VSO, firmware v01.07.16.01) — see #22.
     MODEL_ROOM_TYPE_OVERRIDES: ClassVar[dict[str, dict[int, str]]] = {
         "QxMSPG6VSO": {  # Flow 2
+            1: "Master Bedroom",
+            5: "Bathroom",
+            10: "Corridor",
+        },
+        "iSuVlI1If2": {  # Flow 2 alternate product key
             1: "Master Bedroom",
             5: "Bathroom",
             10: "Corridor",
@@ -237,6 +250,73 @@ def _parse_obstacles(field32: dict) -> list[ObstacleInfo]:
     return obstacles
 
 
+def _coerce_bytes(value: Any) -> bytes:
+    """Return a protobuf bytes value as bytes."""
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, bytearray):
+        return bytes(value)
+    if isinstance(value, str):
+        return value.encode("latin-1", "ignore")
+    return b""
+
+
+def _count_cleaned_pixels(value: Any, expected_pixels: int) -> int:
+    """Count non-zero cells in a display_map cleaned-area overlay."""
+    data = _coerce_bytes(value)
+    if not data:
+        return 0
+
+    from .map_renderer import _decode_packed_varints, decompress_map
+
+    decompressed = decompress_map(data)
+    pixels = _decode_packed_varints(decompressed)
+    if pixels:
+        if expected_pixels > 0:
+            pixels = pixels[:expected_pixels]
+        return sum(1 for pixel in pixels if pixel)
+
+    raw = decompressed or data
+    if expected_pixels > 0:
+        raw = raw[:expected_pixels]
+    return sum(1 for byte in raw if byte)
+
+
+def _extract_ints(value: Any) -> list[int]:
+    """Extract integer values from a loosely-decoded protobuf field."""
+    if isinstance(value, bool):
+        return []
+    if isinstance(value, int):
+        return [value]
+    if isinstance(value, list):
+        result: list[int] = []
+        for item in value:
+            result.extend(_extract_ints(item))
+        return result
+    if isinstance(value, dict):
+        result: list[int] = []
+        for item in value.values():
+            result.extend(_extract_ints(item))
+        return result
+    return []
+
+
+def _positive_int_field(decoded: dict[str, Any], field: str) -> bool:
+    """Return true when a decoded protobuf field is a positive integer."""
+    try:
+        return int(decoded.get(field, 0) or 0) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _optional_int(value: Any) -> int | None:
+    """Return value coerced to int, or None when it cannot be coerced."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 @dataclass
 class MapData:
     """Map data from get_map response."""
@@ -361,6 +441,43 @@ class MapData:
             raw=payload,
         )
 
+    def cleanable_area_cm2(self, room_ids: list[int] | None = None) -> int:
+        """Estimate cleanable area in cm² from room floor pixels."""
+        if not self.compressed_map or self.width <= 0 or self.height <= 0:
+            return 0
+        if self.resolution <= 0:
+            return 0
+
+        from .map_renderer import _decode_packed_varints, decompress_map
+
+        pixels = _decode_packed_varints(decompress_map(self.compressed_map))
+        expected = self.width * self.height
+        if len(pixels) < expected:
+            pixels.extend([0] * (expected - len(pixels)))
+        elif len(pixels) > expected:
+            pixels = pixels[:expected]
+
+        selected = {int(room_id) for room_id in room_ids or []}
+        floor_pixels = 0
+        for val in pixels:
+            if val in (0, 0x28):
+                continue
+            if val == 0x20:
+                if selected:
+                    continue
+                floor_pixels += 1
+                continue
+            room_id = val >> 8
+            pixel_type = val & 0xFF
+            if pixel_type & 0x10:
+                continue
+            if selected and room_id not in selected:
+                continue
+            floor_pixels += 1
+
+        cm_per_pixel = self.resolution / 10
+        return round(floor_pixels * cm_per_pixel * cm_per_pixel)
+
 
 @dataclass
 class MapDisplayData:
@@ -386,6 +503,10 @@ class MapDisplayData:
     # Dock/reference position from field 5 (same coordinate system as robot)
     dock_ref_x: float = 0.0
     dock_ref_y: float = 0.0
+    cleaned_width: int = 0
+    cleaned_height: int = 0
+    cleaned_pixel_count: int = 0
+    active_room_ids: list[int] = field(default_factory=list)
 
     def to_grid_coords(
         self, resolution: int, origin_x: int, origin_y: int,
@@ -457,7 +578,38 @@ class MapDisplayData:
             except (ValueError, TypeError):
                 pass
 
+        field7 = decoded.get("7")
+        if isinstance(field7, list):
+            field7 = field7[0] if field7 else None
+        if isinstance(field7, dict):
+            try:
+                result.cleaned_width = int(field7.get("1", 0))
+                result.cleaned_height = int(field7.get("2", 0))
+            except (ValueError, TypeError):
+                result.cleaned_width = 0
+                result.cleaned_height = 0
+            result.cleaned_pixel_count = _count_cleaned_pixels(
+                field7.get("3"),
+                result.cleaned_width * result.cleaned_height,
+            )
+
+        if "12" in decoded:
+            seen: set[int] = set()
+            room_ids: list[int] = []
+            for room_id in _extract_ints(decoded["12"]):
+                if room_id > 0 and room_id not in seen:
+                    seen.add(room_id)
+                    room_ids.append(room_id)
+            result.active_room_ids = room_ids
+
         return result
+
+    def cleaned_area_cm2(self, resolution: int) -> int:
+        """Return the cleaned overlay area in cm²."""
+        if self.cleaned_pixel_count <= 0 or resolution <= 0:
+            return 0
+        cm_per_pixel = resolution / 10
+        return round(self.cleaned_pixel_count * cm_per_pixel * cm_per_pixel)
 
 
 @dataclass
@@ -497,6 +649,7 @@ class NarwalState:
     working_status: WorkingStatus = WorkingStatus.UNKNOWN
     battery_level: int = 0  # real-time SOC from field 2 (float32)
     battery_health: int = 0  # static design capacity from field 38 (always 100)
+    inferred_docked_from_battery: bool = False
     firmware_version: str = ""
     firmware_target: str = ""
 
@@ -513,6 +666,12 @@ class NarwalState:
     # Cleaning stats
     cleaning_area: int = 0  # cm²
     cleaning_time: int = 0  # seconds
+    last_active_working_status_time: float = 0.0
+    task_progress_percent: int | None = None
+    task_elapsed_time: int = 0
+    current_room_id: int | None = None
+    current_room_name: str = ""
+    dry_mop_remaining_time: int | None = None
 
     # Map
     map_data: MapData | None = None
@@ -536,9 +695,21 @@ class NarwalState:
     # Dock activity (field 3 sub-field 12: 2/6 observed when docked)
     dock_activity: int = 0
 
+    # Station activity (field 3 sub-field 18)
+    # Observed: 1 during dust gathering, 4 during dock dry/disinfection work.
+    station_activity: int = 0
+
     # Dock presence (field 3 sub-field 3)
     # Values observed: 1=on dock, 2=off dock, 6=on dock (charged idle)
     dock_presence: int = 0
+
+    # Newer Flow firmware sub-state (field 3 sub-field 4).
+    # Observed during active clean startup/navigation: 8 -> 7 -> 3.
+    flow_activity: int = 0
+
+    # Newer Flow firmware task flag (field 3 sub-field 14). Observed as 1
+    # during active cleaning/navigation.
+    flow_task_flag: int = 0
 
     # Dock indicator from field 11 (top-level base_status field)
     # Validated via dock_research.py guided test (5 captures):
@@ -557,12 +728,67 @@ class NarwalState:
     # Raw data for fields we haven't fully decoded yet
     raw_base_status: dict[str, Any] = field(default_factory=dict)
     raw_working_status: dict[str, Any] = field(default_factory=dict)
+    raw_aux_status: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    def _working_status_is_cleaning_like(self) -> bool:
+        """True when the cached working_status looks like a cleaning task."""
+        return self.working_status in (
+            WorkingStatus.CLEANING,
+            WorkingStatus.CLEANING_V2,
+            WorkingStatus.CLEANING_ALT,
+            WorkingStatus.CLEANING_FLOW2,
+        )
+
+    def _dock_fields_indicate_docked(self) -> bool:
+        """True when base-status dock fields indicate the robot is on dock."""
+        if self.dock_sub_state == 1:
+            return True
+        if self.dock_activity > 0:
+            return True
+        if self.station_activity > 0:
+            return True
+        if self.dock_field11 >= 2:
+            return True
+        if self.dock_field47 in (1, 3):
+            return True
+        return False
+
+    @property
+    def is_station_active(self) -> bool:
+        """True when the base station is running a dock-side task."""
+        return self.station_activity > 0 or (
+            self.working_status == WorkingStatus.CLEANING_ALT and self.is_docked
+        )
+
+    def _set_battery_level(self, battery_level: int) -> None:
+        """Update battery level and infer docked state from charging trend."""
+        if (
+            self.battery_level > 0
+            and battery_level > self.battery_level
+            and self._working_status_is_cleaning_like()
+            and not self.has_recent_active_working_status
+        ):
+            self.inferred_docked_from_battery = True
+        self.battery_level = battery_level
+
+    @property
+    def has_recent_active_working_status(self) -> bool:
+        """True while working_status is actively reporting task counters."""
+        if self.working_status not in ACTIVE_CLEANING_STATUSES:
+            return False
+        if self.last_active_working_status_time <= 0:
+            return False
+        return time.monotonic() - self.last_active_working_status_time <= _ACTIVE_WORKING_STATUS_TTL
 
     @property
     def is_cleaning(self) -> bool:
         """True when actively cleaning (not paused, not returning to dock)."""
+        if self.has_recent_active_working_status:
+            return not self.is_paused and not self.is_returning
+        if self._dock_fields_indicate_docked() or self.inferred_docked_from_battery:
+            return False
         return (
-            self.working_status in (WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT)
+            self._working_status_is_cleaning_like()
             and not self.is_paused
             and not self.is_returning_to_dock
         )
@@ -583,25 +809,21 @@ class NarwalState:
         cleaning is not active, since the robot can report unmapped states
         (e.g. self-test) while physically docked.
         """
+        if self.has_recent_active_working_status:
+            return False
         if self.working_status in (
             WorkingStatus.DOCKED, WorkingStatus.CHARGED, WorkingStatus.DOCKED_V2,
         ):
             return True
-        if self.working_status in (WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT):
-            return False
         # For STANDBY, UNKNOWN, or any other status: check dock field signals.
         # Values differ across firmware versions:
         #   Old FW: dock_sub_state=1, dock_field11=2, dock_field47=3
         #   v01.07.23.00: dock_sub_state absent, dock_field11=3, dock_field47=1
-        if self.dock_sub_state == 1:
-            return True
-        if self.dock_activity > 0:
-            return True
-        if self.dock_field11 >= 2:
-            return True
-        if self.dock_field47 in (1, 3):
-            return True
-        return False
+        #
+        # Narwal can keep reporting a stale CLEANING working_status after the
+        # active working_status payload has stopped. Once that live payload is
+        # no longer recent, dock fields are a better source of truth.
+        return self._dock_fields_indicate_docked() or self.inferred_docked_from_battery
 
     @property
     def is_returning(self) -> bool:
@@ -620,8 +842,11 @@ class NarwalState:
         transitions to STANDBY/DOCKED/CHARGED, it has already docked
         even if field 3.7 is momentarily still set.
         """
-        if self.working_status not in (
-            WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT,
+        if not self.has_recent_active_working_status and self.working_status not in (
+            WorkingStatus.CLEANING,
+            WorkingStatus.CLEANING_V2,
+            WorkingStatus.CLEANING_ALT,
+            WorkingStatus.CLEANING_FLOW2,
         ):
             return False
         return self.is_returning_to_dock and self.dock_sub_state == 2
@@ -636,6 +861,8 @@ class NarwalState:
           Field 15 = 600 during cleaning (purpose uncertain)
         """
         self.raw_working_status = decoded
+        previous_cleaning_time = self.cleaning_time
+        previous_cleaning_area = self.cleaning_area
         if "3" in decoded:
             try:
                 self.cleaning_time = int(decoded["3"])
@@ -646,6 +873,34 @@ class NarwalState:
         if "15" in decoded:
             # Field 15 may be cumulative time; prefer field 3 for current session
             pass
+        has_active_payload = any(
+            _positive_int_field(decoded, field) for field in ("3", "13")
+        )
+        active_payload_changed = (
+            self.cleaning_time != previous_cleaning_time
+            or self.cleaning_area != previous_cleaning_area
+        )
+        if has_active_payload and active_payload_changed:
+            self.last_active_working_status_time = time.monotonic()
+            self.inferred_docked_from_battery = False
+        if (
+            has_active_payload
+            and active_payload_changed
+            and self.working_status
+            in (
+                WorkingStatus.UNKNOWN,
+                WorkingStatus.STANDBY,
+                WorkingStatus.DOCKED,
+                WorkingStatus.CHARGED,
+                WorkingStatus.DOCKED_V2,
+            )
+        ):
+            self.working_status = WorkingStatus.CLEANING
+            self.dock_field11 = 1
+            self.dock_field47 = 2
+            self.dock_sub_state = 0
+            self.dock_activity = 0
+            self.station_activity = 0
 
     def update_from_base_status(self, decoded: dict[str, Any]) -> None:
         """Update state from a decoded robot_base_status message.
@@ -661,6 +916,7 @@ class NarwalState:
           3.7  = 1 means RETURNING to dock (live-validated)
           3.10 = dock sub-state (1=docked, 2=docking in progress)
           3.12 = dock activity (values 2, 6 observed)
+          3.18 = station activity (1=dust gathering, 4=dry/disinfection observed)
 
         Dock indicators (validated via dock_research.py, 5 captures):
           Field 11 = 2 when docked, 1 when undocked
@@ -717,13 +973,41 @@ class NarwalState:
                     self.dock_activity = int(field3["12"])
                 except (ValueError, TypeError):
                     pass
+            self.station_activity = 0
+            if "18" in field3:
+                try:
+                    self.station_activity = int(field3["18"])
+                except (ValueError, TypeError):
+                    pass
             if "3" in field3:
                 try:
                     self.dock_presence = int(field3["3"])
                 except (ValueError, TypeError):
                     pass
+            self.flow_activity = 0
+            if "4" in field3:
+                try:
+                    self.flow_activity = int(field3["4"])
+                except (ValueError, TypeError):
+                    pass
+            self.flow_task_flag = 0
+            if "14" in field3:
+                try:
+                    self.flow_task_flag = int(field3["14"])
+                except (ValueError, TypeError):
+                    pass
+            if self.working_status in ACTIVE_CLEANING_STATUSES:
+                if "11" not in decoded:
+                    self.dock_field11 = 1
+                if "47" not in decoded:
+                    self.dock_field47 = 2
+                if "10" not in field3:
+                    self.dock_sub_state = 0
+                if "12" not in field3:
+                    self.dock_activity = 0
+                self.inferred_docked_from_battery = False
             # Log unrecognized sub-fields for future firmware mapping
-            _known_f3 = {"1", "2", "3", "7", "10", "12"}
+            _known_f3 = {"1", "2", "3", "4", "7", "10", "11", "12", "14", "18"}
             _unknown_f3 = set(field3.keys()) - _known_f3
             if _unknown_f3:
                 _LOGGER.debug(
@@ -736,12 +1020,21 @@ class NarwalState:
                 "Please report this at the GitHub repo.",
                 type(field3).__name__, field3,
             )
+        explicitly_off_dock = (
+            ("11" in decoded and self.dock_field11 == 1)
+            or ("47" in decoded and self.dock_field47 == 2)
+        )
+        if not self.is_returning_to_dock and explicitly_off_dock:
+            self.dock_sub_state = 0
+            self.dock_activity = 0
         if "2" in decoded:
             # Field 2 = real-time battery SOC as float32
             # (e.g. 1118175232 → 83.0%; bbp may return int or float)
             bat = _to_float32(decoded["2"])
             if bat is not None:
-                self.battery_level = round(bat)
+                self._set_battery_level(round(bat))
+        if explicitly_off_dock:
+            self.inferred_docked_from_battery = False
         if "38" in decoded:
             # Field 38 = static battery health (always 100, design capacity)
             self.battery_health = int(decoded["38"])
@@ -768,7 +1061,7 @@ class NarwalState:
         if "2" in decoded:
             bat = _to_float32(decoded["2"])
             if bat is not None:
-                self.battery_level = round(bat)
+                self._set_battery_level(round(bat))
         if "38" in decoded:
             self.battery_health = int(decoded["38"])
         if "36" in decoded:
@@ -799,3 +1092,46 @@ class NarwalState:
         """Update state from a decoded download_status message."""
         if "1" in decoded:
             self.download_status = int(decoded["1"])
+
+    def update_from_aux_status(self, topic: str, decoded: dict[str, Any]) -> None:
+        """Store decoded status payloads that are not mapped yet."""
+        self.raw_aux_status[topic] = decoded
+        if topic in {TOPIC_ROBOT_TASK_STATUS, TOPIC_CMD_GET_ROBOT_TASK_STATUS}:
+            payload = decoded.get("2")
+            if not isinstance(payload, dict):
+                return
+            progress = _optional_int(payload.get("1"))
+            if progress is not None:
+                self.task_progress_percent = max(0, min(100, progress))
+            elapsed = _optional_int(payload.get("2"))
+            if elapsed is not None:
+                self.task_elapsed_time = elapsed
+            room = payload.get("6")
+            if not isinstance(room, dict):
+                room = payload.get("8")
+            if isinstance(room, dict):
+                self.current_room_id = _optional_int(room.get("1"))
+                name = room.get("3")
+                if isinstance(name, (bytes, bytearray)):
+                    self.current_room_name = bytes(name).decode(
+                        "utf-8", errors="replace"
+                    )
+                else:
+                    self.current_room_name = str(name) if name else ""
+                    if self.current_room_name.startswith(
+                        "b'"
+                    ) and self.current_room_name.endswith("'"):
+                        self.current_room_name = self.current_room_name[2:-1]
+                if self.current_room_id is not None and self.map_data is not None:
+                    map_room = next(
+                        (
+                            candidate
+                            for candidate in self.map_data.rooms
+                            if candidate.room_id == self.current_room_id
+                        ),
+                        None,
+                    )
+                    if map_room is not None:
+                        self.current_room_name = map_room.display_name
+        elif topic == "supply/get_dry_mop_remain_time":
+            self.dry_mop_remaining_time = _optional_int(decoded.get("2"))

--- a/custom_components/narwal/vacuum.py
+++ b/custom_components/narwal/vacuum.py
@@ -189,7 +189,14 @@ class NarwalVacuum(NarwalEntity, StateVacuumEntity):
         level = FAN_SPEED_MAP.get(fan_speed)
         if level is not None:
             await self.coordinator.client.set_fan_speed(level)
-            self._last_fan_speed = fan_speed
+            self._last_fan_speed = next(
+                (
+                    label
+                    for label in FAN_SPEED_LIST
+                    if FAN_SPEED_MAP[label] == level
+                ),
+                fan_speed,
+            )
             self.async_write_ha_state()
 
     # --- Segment API (HA 2026.3 room-specific cleaning) ---

--- a/custom_components/narwal/vacuum.py
+++ b/custom_components/narwal/vacuum.py
@@ -20,6 +20,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .narwal_client import CommandResult, FanLevel, NarwalCommandError, WorkingStatus
+from .narwal_client.const import ACTIVE_CLEANING_STATUSES
 
 from . import NarwalConfigEntry
 from .const import FAN_SPEED_LIST, FAN_SPEED_MAP
@@ -33,8 +34,10 @@ WORKING_STATUS_TO_ACTIVITY: dict[WorkingStatus, VacuumActivity] = {
     WorkingStatus.CHARGED: VacuumActivity.DOCKED,
     WorkingStatus.DOCKED_V2: VacuumActivity.DOCKED,
     WorkingStatus.STANDBY: VacuumActivity.IDLE,
+    WorkingStatus.CLEANING_V2: VacuumActivity.CLEANING,
     WorkingStatus.CLEANING: VacuumActivity.CLEANING,
     WorkingStatus.CLEANING_ALT: VacuumActivity.CLEANING,
+    WorkingStatus.CLEANING_FLOW2: VacuumActivity.CLEANING,
     WorkingStatus.TASK_COMPLETED: VacuumActivity.RETURNING,
     WorkingStatus.ERROR: VacuumActivity.ERROR,
 }
@@ -77,9 +80,9 @@ class NarwalVacuum(NarwalEntity, StateVacuumEntity):
         state = self.coordinator.data
         if state is None:
             return VacuumActivity.IDLE
-        is_cleaning_state = state.working_status in (
-            WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT,
-        )
+        is_cleaning_state = state.working_status in ACTIVE_CLEANING_STATUSES
+        if state.is_docked:
+            return VacuumActivity.DOCKED
         # is_paused (field 3.2) stays stale after docking — only trust
         # during cleaning states. Paused takes priority over returning
         # since the robot physically stops when paused mid-return.
@@ -91,8 +94,6 @@ class NarwalVacuum(NarwalEntity, StateVacuumEntity):
             return VacuumActivity.RETURNING
         if state.is_cleaning:
             return VacuumActivity.CLEANING
-        if state.is_docked:
-            return VacuumActivity.DOCKED
         activity = WORKING_STATUS_TO_ACTIVITY.get(state.working_status)
         if activity is not None:
             return activity
@@ -138,8 +139,10 @@ class NarwalVacuum(NarwalEntity, StateVacuumEntity):
         await self._ensure_awake()
         state = self.coordinator.data
         # is_paused stays stale after docking — only trust it during cleaning
-        is_cleaning = state and state.working_status in (
-            WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT,
+        is_cleaning = (
+            state
+            and not state.is_docked
+            and state.working_status in ACTIVE_CLEANING_STATUSES
         )
         if is_cleaning and state.is_paused:
             await self.coordinator.client.resume(timeout=self._ACTION_TIMEOUT)

--- a/narwal_client/__init__.py
+++ b/narwal_client/__init__.py
@@ -1,7 +1,7 @@
 """Narwal robot vacuum client library — local WebSocket API."""
 
 from .client import NarwalClient, NarwalCommandError, NarwalConnectionError
-from .const import CommandResult, FanLevel, MopHumidity, WorkingStatus
+from .const import CommandResult, FanLevel, MopHumidity, MopStrengthLevel, WorkMode, WorkingStatus
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState, RoomInfo
 from .protocol import build_frame, parse_frame
 
@@ -17,7 +17,9 @@ __all__ = [
     "MapData",
     "MapDisplayData",
     "MopHumidity",
+    "MopStrengthLevel",
     "RoomInfo",
+    "WorkMode",
     "WorkingStatus",
     "build_frame",
     "parse_frame",

--- a/narwal_client/__init__.py
+++ b/narwal_client/__init__.py
@@ -1,7 +1,15 @@
 """Narwal robot vacuum client library — local WebSocket API."""
 
 from .client import NarwalClient, NarwalCommandError, NarwalConnectionError
-from .const import CommandResult, FanLevel, MopHumidity, MopStrengthLevel, WorkMode, WorkingStatus
+from .const import (
+    CleaningRoute,
+    CommandResult,
+    FanLevel,
+    MopHumidity,
+    MopStrengthLevel,
+    WorkMode,
+    WorkingStatus,
+)
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState, RoomInfo
 from .protocol import build_frame, parse_frame
 
@@ -12,6 +20,7 @@ __all__ = [
     "NarwalState",
     "CommandResponse",
     "CommandResult",
+    "CleaningRoute",
     "DeviceInfo",
     "FanLevel",
     "MapData",

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -16,6 +16,7 @@ from .const import (
     BROADCAST_STALE_TIMEOUT,
     COMMAND_RESPONSE_TIMEOUT,
     DEFAULT_PORT,
+    DEFAULT_TOPIC_PREFIX,
     HEARTBEAT_INTERVAL,
     KEEPALIVE_INTERVAL,
     KNOWN_PRODUCT_KEYS,
@@ -26,37 +27,49 @@ from .const import (
     TOPIC_CMD_ACTIVE_ROBOT,
     TOPIC_CMD_APP_HEARTBEAT,
     TOPIC_CMD_CANCEL,
+    TOPIC_CMD_CLEAN_TASK,
+    TOPIC_CMD_DRY_DUST_BAG,
     TOPIC_CMD_DRY_MOP,
+    TOPIC_CMD_DRY_STATION_BAG,
     TOPIC_CMD_DUST_GATHERING,
     TOPIC_CMD_EASY_CLEAN,
     TOPIC_CMD_FORCE_END,
     TOPIC_CMD_GET_ALL_MAPS,
     TOPIC_CMD_GET_BASE_STATUS,
+    TOPIC_CMD_GET_CLEAN_PROGRESS_INFO,
     TOPIC_CMD_GET_CURRENT_TASK,
     TOPIC_CMD_GET_DEVICE_INFO,
+    TOPIC_CMD_GET_DRY_MOP_REMAIN_TIME,
     TOPIC_CMD_GET_FEATURE_LIST,
     TOPIC_CMD_GET_MAP,
+    TOPIC_CMD_GET_ROBOT_TASK_STATUS,
     TOPIC_CMD_NOTIFY_APP_EVENT,
     TOPIC_CMD_PAUSE,
-    TOPIC_CMD_PING,
+    TOPIC_CMD_PLAN_START,
     TOPIC_CMD_RECALL,
     TOPIC_CMD_RESUME,
     TOPIC_CMD_SET_FAN_LEVEL,
-    TOPIC_CMD_SET_MOP_HUMIDITY,
-    TOPIC_CMD_PLAN_START,
-    TOPIC_CMD_CLEAN_TASK,
-    TOPIC_CMD_TAKE_PICTURE,
     TOPIC_CMD_SET_LED,
+    TOPIC_CMD_SET_MOP_HUMIDITY,
+    TOPIC_CMD_TAKE_PICTURE,
+    TOPIC_CMD_WASH_AND_DRY_MOP,
     TOPIC_CMD_WASH_MOP,
+    TOPIC_CMD_WASH_MOP_BY_ROBOT_STATUS,
     TOPIC_CMD_YELL,
-    DEFAULT_TOPIC_PREFIX,
+    TOPIC_PLANNING_DEBUG,
+    TOPIC_POINT_NAVI_PLAN_TRAJ,
+    TOPIC_ROBOT_CURRENT_STATUS,
+    TOPIC_ROBOT_STATUS,
+    TOPIC_ROBOT_TASK_STATUS,
+    TOPIC_TIMELINE_STATUS,
     WAKE_TIMEOUT,
+    CleaningRoute,
     CommandResult,
     FanLevel,
     MopHumidity,
     MopStrengthLevel,
-    WorkMode,
     WorkingStatus,
+    WorkMode,
 )
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState
 from .protocol import (
@@ -68,6 +81,92 @@ from .protocol import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+_ACTIVE_WORKING_STATUS_TTL = 15.0
+_STALE_DOCK_BASE_STATUSES = {
+    WorkingStatus.UNKNOWN,
+    WorkingStatus.STANDBY,
+    WorkingStatus.DOCKED,
+    WorkingStatus.CHARGED,
+    WorkingStatus.DOCKED_V2,
+}
+_AUX_STATUS_TOPICS = {
+    TOPIC_TIMELINE_STATUS,
+    TOPIC_POINT_NAVI_PLAN_TRAJ,
+    TOPIC_PLANNING_DEBUG,
+    TOPIC_ROBOT_STATUS,
+    TOPIC_ROBOT_CURRENT_STATUS,
+    TOPIC_ROBOT_TASK_STATUS,
+}
+
+
+def _short_repr(value: Any, limit: int = 1200) -> str:
+    text = repr(value)
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}…"
+
+
+def _normalise_blackboxprotobuf_typedef(typedef: dict[str, Any]) -> dict[str, Any]:
+    """Add field names expected by some blackboxprotobuf releases."""
+    for info in typedef.values():
+        info.setdefault("name", "")
+        message_typedef = info.get("message_typedef")
+        if isinstance(message_typedef, dict):
+            _normalise_blackboxprotobuf_typedef(message_typedef)
+        alt_typedefs = info.get("alt_typedefs")
+        if isinstance(alt_typedefs, dict):
+            for alt_typedef in alt_typedefs.values():
+                if isinstance(alt_typedef, dict):
+                    _normalise_blackboxprotobuf_typedef(alt_typedef)
+    return typedef
+
+
+def _base_status_working_status(decoded: dict[str, Any] | object) -> WorkingStatus | None:
+    """Extract robot_base_status field 3.1."""
+    if not isinstance(decoded, dict):
+        return None
+    field3 = decoded.get("3")
+    if isinstance(field3, list):
+        field3 = field3[0] if field3 else None
+    if not isinstance(field3, dict) or "1" not in field3:
+        return None
+    try:
+        return WorkingStatus(int(field3["1"]))
+    except (TypeError, ValueError):
+        return None
+
+
+def _base_status_confirms_docked(
+    decoded: dict[str, Any] | object, status: WorkingStatus | None
+) -> bool:
+    """Return true when a terminal status also carries live dock indicators."""
+    if not isinstance(decoded, dict) or status not in {
+        WorkingStatus.STANDBY,
+        WorkingStatus.DOCKED,
+        WorkingStatus.CHARGED,
+        WorkingStatus.DOCKED_V2,
+    }:
+        return False
+    field3 = decoded.get("3")
+    if isinstance(field3, list):
+        field3 = field3[0] if field3 else None
+    field3 = field3 if isinstance(field3, dict) else {}
+
+    def int_field(container: dict[str, Any], field: str) -> int:
+        try:
+            return int(container.get(field, 0))
+        except (TypeError, ValueError):
+            return 0
+
+    return (
+        int_field(decoded, "11") >= 2
+        or int_field(decoded, "47") in (1, 3)
+        or int_field(field3, "3") in (1, 6)
+        or int_field(field3, "10") == 1
+        or int_field(field3, "12") > 0
+        or int_field(field3, "18") > 0
+    )
 
 
 class NarwalConnectionError(Exception):
@@ -115,7 +214,11 @@ class NarwalClient:
         self._listener_active = False  # True when start_listening() is running recv loop
         self._robot_awake = False  # True once we receive a broadcast
         self._last_broadcast_time: float = 0.0  # monotonic time of last broadcast
+        self._last_status_time: float = 0.0  # monotonic time of last status/base broadcast
         self._last_display_map_time: float = 0.0  # monotonic time of last display_map
+        self._last_active_working_status_time: float = 0.0
+        self._last_aux_log_time: dict[str, float] = {}
+        self._last_base_status_log: tuple[Any, Any, Any] | None = None
         # Queue for field5 command responses
         self._response_queue: asyncio.Queue[NarwalMessage] = asyncio.Queue()
         # Lock to prevent concurrent send_command calls from racing on the queue
@@ -148,6 +251,89 @@ class NarwalClient:
         if self._last_display_map_time <= 0:
             return 999.0
         return time.monotonic() - self._last_display_map_time
+
+    @property
+    def last_status_age(self) -> float:
+        """Seconds since last status/base broadcast (999.0 if none received)."""
+        if self._last_status_time <= 0:
+            return 999.0
+        return time.monotonic() - self._last_status_time
+
+    def _active_working_status_is_recent(self, now: float | None = None) -> bool:
+        """Return true while fresh working_status telemetry is contradicting base_status."""
+        if self._last_active_working_status_time <= 0:
+            return False
+        now = time.monotonic() if now is None else now
+        return now - self._last_active_working_status_time <= _ACTIVE_WORKING_STATUS_TTL
+
+    def _state_needs_keepalive(self) -> bool:
+        """Return true when the app-style keepalive should keep the robot awake."""
+        state = self.state
+        if state.working_status == WorkingStatus.UNKNOWN:
+            return True
+        if state.working_status == WorkingStatus.ERROR:
+            return True
+        if state.is_cleaning or state.is_returning:
+            return True
+        if state.is_station_active:
+            return True
+        if (
+            state.is_paused
+            and state._working_status_is_cleaning_like()
+            and not state.is_docked
+        ):
+            return True
+        if state.working_status == WorkingStatus.CLEANING_ALT and state.is_docked:
+            return True
+        return not state.is_docked
+
+    def _update_from_working_status_broadcast(
+        self, decoded: dict[str, Any], now: float | None = None
+    ) -> None:
+        """Update state from a working_status broadcast."""
+        self.state.update_from_working_status(decoded)
+        if self.state.has_recent_active_working_status:
+            self._last_active_working_status_time = (
+                self.state.last_active_working_status_time
+            )
+
+    def _update_from_base_status_broadcast(
+        self, decoded: dict[str, Any], now: float | None = None
+    ) -> None:
+        """Update state from robot_base_status, ignoring stale dock overlays mid-task."""
+        now = time.monotonic() if now is None else now
+        base_status = _base_status_working_status(decoded)
+        signature = (decoded.get("3"), decoded.get("11"), decoded.get("47"))
+        if signature != self._last_base_status_log:
+            self._last_base_status_log = signature
+            _LOGGER.debug(
+                "%s robot_base_status field3=%r field11=%r field47=%r",
+                self.host,
+                decoded.get("3"),
+                decoded.get("11"),
+                decoded.get("47"),
+            )
+        if (
+            base_status in _STALE_DOCK_BASE_STATUSES
+            and self._active_working_status_is_recent(now)
+            and not _base_status_confirms_docked(decoded, base_status)
+        ):
+            _LOGGER.debug(
+                "Ignoring stale %s base_status while active working_status is fresh",
+                base_status.name,
+            )
+            self.state.update_battery_from_base_status(decoded)
+            return
+        self.state.update_from_base_status(decoded)
+
+    def _update_from_aux_status_broadcast(
+        self, short_topic: str, decoded: dict[str, Any]
+    ) -> None:
+        self.state.update_from_aux_status(short_topic, decoded)
+        now = time.monotonic()
+        if now - self._last_aux_log_time.get(short_topic, 0.0) > 30.0:
+            self._last_aux_log_time[short_topic] = now
+            _LOGGER.debug("%s decoded status: %s", short_topic, _short_repr(decoded))
 
     async def connect(self) -> None:
         """Establish WebSocket connection to the vacuum.
@@ -255,6 +441,9 @@ class NarwalClient:
                     else:
                         raw_id = str(raw_id).strip()
                     if raw_id:
+                        parts = msg.topic.split("/") if msg.topic else []
+                        if len(parts) >= 2 and parts[1]:
+                            self.topic_prefix = f"/{parts[1]}"
                         self.device_id = raw_id
                         _LOGGER.info("Discovered device_id from response: %s", self.device_id)
                         return self.device_id
@@ -333,12 +522,11 @@ class NarwalClient:
             try:
                 if not self.connected:
                     await self.connect()
-                    # Immediate wake burst on (re)connect — the fresh TCP
-                    # connection may trigger the robot's deep-sleep wake
-                    # interrupt, but only if we send commands before it
-                    # expires.  Don't wait for the keepalive loop's first
-                    # tick (15s delay would be too late).
-                    await self._send_wake_burst()
+                    if self._state_needs_keepalive():
+                        await self._send_wake_burst()
+                    else:
+                        await self.subscribe_to_topics()
+                        _LOGGER.debug("Robot is docked/idle; not sending reconnect wake")
 
                 retry_delay = RECONNECT_INITIAL_DELAY  # reset on success
                 self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
@@ -413,10 +601,13 @@ class NarwalClient:
             _LOGGER.debug("Failed to decode protobuf for topic %s", short_topic)
             return
 
+        now = time.monotonic()
         if short_topic == "status/working_status":
-            self.state.update_from_working_status(decoded)
+            self._last_status_time = now
+            self._update_from_working_status_broadcast(decoded, now)
         elif short_topic == "status/robot_base_status":
-            self.state.update_from_base_status(decoded)
+            self._last_status_time = now
+            self._update_from_base_status_broadcast(decoded, now)
         elif short_topic == "upgrade/upgrade_status":
             self.state.update_from_upgrade_status(decoded)
         elif short_topic == "status/download_status":
@@ -430,6 +621,8 @@ class NarwalClient:
                 self.state.map_display_data.robot_y,
                 self.state.map_display_data.timestamp,
             )
+        elif short_topic in _AUX_STATUS_TOPICS:
+            self._update_from_aux_status_broadcast(short_topic, decoded)
         if self.on_state_update:
             self.on_state_update(self.state)
 
@@ -489,9 +682,12 @@ class NarwalClient:
         "upgrade/upgrade_status",
         "status/download_status",
         "map/display_map",
-        "status/time_line_status",
-        "status/point_navi_plan_traj",
-        "developer/planning_debug_info",
+        TOPIC_TIMELINE_STATUS,
+        TOPIC_POINT_NAVI_PLAN_TRAJ,
+        TOPIC_PLANNING_DEBUG,
+        TOPIC_ROBOT_STATUS,
+        TOPIC_ROBOT_CURRENT_STATUS,
+        TOPIC_ROBOT_TASK_STATUS,
     ]
 
     def _build_topic_subscription(self, duration: int = 600) -> bytes:
@@ -696,9 +892,12 @@ class NarwalClient:
                         except Exception:
                             _LOGGER.debug("Topic re-subscribe failed")
 
+                    if not self._state_needs_keepalive():
+                        _LOGGER.debug("Robot is docked/idle; skipping app keepalive")
+                        continue
+
                     # Send lightweight heartbeat to keep robot awake.
-                    # The Narwal app sends this continuously regardless of
-                    # robot state — it's safe during cleaning.
+                    # This is only needed while an active task is in progress.
                     try:
                         payload = self._encode_varint_field(1, 1)
                         frame = build_frame(
@@ -710,6 +909,11 @@ class NarwalClient:
                         _LOGGER.debug("Keepalive send failed")
                         break
                 else:
+                    if not self._state_needs_keepalive():
+                        consecutive_wake_failures = 0
+                        _LOGGER.debug("Robot is docked/idle; not waking")
+                        continue
+
                     # Robot appears asleep — send full wake burst
                     # (wake burst includes topic subscription)
                     consecutive_wake_failures += 1
@@ -857,16 +1061,19 @@ class NarwalClient:
             except Exception:
                 continue
 
+            now = time.monotonic()
             if short_topic == "status/working_status":
-                self.state.update_from_working_status(decoded)
+                self._update_from_working_status_broadcast(decoded, now)
             elif short_topic == "status/robot_base_status":
-                self.state.update_from_base_status(decoded)
+                self._update_from_base_status_broadcast(decoded, now)
             elif short_topic == "upgrade/upgrade_status":
                 self.state.update_from_upgrade_status(decoded)
             elif short_topic == "status/download_status":
                 self.state.update_from_download_status(decoded)
             elif short_topic == "map/display_map":
                 self.state.map_display_data = MapDisplayData.from_broadcast(decoded)
+            elif short_topic in _AUX_STATUS_TOPICS:
+                self._update_from_aux_status_broadcast(short_topic, decoded)
 
         raise NarwalCommandError(
             f"No field5 response within {timeout}s"
@@ -948,9 +1155,10 @@ class NarwalClient:
             len(room_ids),
         )
         payload = self._build_clean_payload_v2(room_ids)
-        return await self.send_command(
+        resp = await self.send_command(
             TOPIC_CMD_PLAN_START, payload=payload, timeout=10.0,
         )
+        return resp
 
     def _build_clean_payload_v2(
         self,
@@ -1047,7 +1255,9 @@ class NarwalClient:
                 },
             }
         }
-        return blackboxprotobuf.encode_message(msg, typedef)
+        return blackboxprotobuf.encode_message(
+            msg, _normalise_blackboxprotobuf_typedef(typedef)
+        )
 
     # WorkMode -> (CleanParam.mode tag 1, pass-count tags to set from `passes`). The robot's
     # execution mode is CleanTask.taskType (= the WorkMode value); CleanParam.mode and the
@@ -1070,13 +1280,14 @@ class NarwalClient:
         water: MopHumidity = MopHumidity.NORMAL,
         mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL,
         passes: int = 1,
+        route: CleaningRoute | None = None,
     ) -> bytes:
         """Build a clean/start_clean request for the given rooms.
 
         StartClean_Request{1: CleanTask{1: map_id, 2: [CleanItem...], 3: {} (TaskOption),
         5: taskType}}; CleanItem{1: ZoneOption{1: 1 (room zone), 2: room_id}, 2: CleanParam,
         3: order}. taskType (the execution-mode carrier) and CleanParam.mode/pass-tag are
-        derived from work_mode. overlapLevel is omitted — live-validated as ignored here.
+        derived from work_mode. overlapLevel is CleanParam tag 8 when supplied.
 
         Args:
             room_ids: Robot room IDs (RoomInfo.room_id).
@@ -1086,6 +1297,7 @@ class NarwalClient:
             water: Mop water volume (tag 4).
             mop_strength: Mop scrub intensity (tag 3).
             passes: Clean count, routed to the pass tag(s) for the mode.
+            route: Optional route overlap level (tag 8).
         """
         import blackboxprotobuf
 
@@ -1096,6 +1308,8 @@ class NarwalClient:
             "3": int(mop_strength),
             "4": int(water),
         }
+        if route is not None:
+            param["8"] = int(route)
         for tag in pass_tags:
             param[tag] = int(passes)
 
@@ -1130,7 +1344,9 @@ class NarwalClient:
             "3": {"type": "message", "message_typedef": {}},
             "5": {"type": "int"},
         }}}
-        return blackboxprotobuf.encode_message({"1": task}, typedef)
+        return blackboxprotobuf.encode_message(
+            {"1": task}, _normalise_blackboxprotobuf_typedef(typedef)
+        )
 
     def _build_room_clean_payload(self, room_ids: list[int]) -> bytes:
         """Build the legacy flat room-clean payload for older firmware."""
@@ -1194,6 +1410,7 @@ class NarwalClient:
         water: MopHumidity = MopHumidity.WET,
         mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL,
         passes: int = 1,
+        route: CleaningRoute | None = None,
     ) -> CommandResponse:
         """Start cleaning the given rooms via clean/start_clean.
 
@@ -1209,7 +1426,7 @@ class NarwalClient:
 
         Args:
             room_ids: Robot room IDs (RoomInfo.room_id), mapped from HA areas.
-            work_mode, fan, water, mop_strength, passes: CleanParam settings —
+            work_mode, fan, water, mop_strength, passes, route: CleanParam settings —
                 see _build_start_clean_payload.
         """
         if not room_ids:
@@ -1246,6 +1463,7 @@ class NarwalClient:
                 water=water,
                 mop_strength=mop_strength,
                 passes=passes,
+                route=route,
             )
             resp = await self.send_command(
                 TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
@@ -1390,6 +1608,10 @@ class NarwalClient:
         """Wash the mop pads at the station."""
         return await self.send_command(TOPIC_CMD_WASH_MOP)
 
+    async def wash_mop_by_robot_status(self) -> CommandResponse:
+        """Wash mop pads using the app's status-gated station command."""
+        return await self.send_command(TOPIC_CMD_WASH_MOP_BY_ROBOT_STATUS)
+
     async def dry_mop(self) -> CommandResponse:
         """Dry the mop pads at the station."""
         return await self.send_command(TOPIC_CMD_DRY_MOP)
@@ -1397,6 +1619,18 @@ class NarwalClient:
     async def empty_dustbin(self) -> CommandResponse:
         """Empty the dustbin at the station."""
         return await self.send_command(TOPIC_CMD_DUST_GATHERING)
+
+    async def wash_and_dry_mop(self) -> CommandResponse:
+        """Wash and dry the mop pads at the station."""
+        return await self.send_command(TOPIC_CMD_WASH_AND_DRY_MOP)
+
+    async def dry_dust_bag(self) -> CommandResponse:
+        """Dry/disinfect the robot dust bin/canister."""
+        return await self.send_command(TOPIC_CMD_DRY_DUST_BAG)
+
+    async def dry_station_bag(self) -> CommandResponse:
+        """Dry/disinfect the dock dust bag."""
+        return await self.send_command(TOPIC_CMD_DRY_STATION_BAG)
 
     # --- Query commands ---
 
@@ -1443,12 +1677,27 @@ class NarwalClient:
         """
         resp = await self.send_command(TOPIC_CMD_GET_BASE_STATUS)
         status_data = resp.data.get("2", {})
+        if status_data and not isinstance(status_data, dict):
+            _LOGGER.debug(
+                "%s get_status response field 2 is %s, not a base-status object: %r",
+                self.host,
+                type(status_data).__name__,
+                status_data,
+            )
+            return resp
         if status_data:
             _LOGGER.debug(
-                "get_status response (full=%s): field3=%r, field2=%r",
+                "%s get_status response (full=%s): field3=%r, field2=%r",
+                self.host,
                 full_update,
                 status_data.get("3") if isinstance(status_data, dict) else None,
                 status_data.get("2") if isinstance(status_data, dict) else None,
+            )
+            _LOGGER.debug(
+                "%s get_status decoded base_status (full=%s): %r",
+                self.host,
+                full_update,
+                status_data,
             )
             if full_update:
                 self.state.update_from_base_status(status_data)
@@ -1461,6 +1710,27 @@ class NarwalClient:
     async def get_current_task(self) -> CommandResponse:
         """Query the current clean task."""
         return await self.send_command(TOPIC_CMD_GET_CURRENT_TASK)
+
+    async def get_clean_progress_info(self) -> CommandResponse:
+        """Query active clean progress information."""
+        resp = await self.send_command(TOPIC_CMD_GET_CLEAN_PROGRESS_INFO)
+        self.state.update_from_aux_status(TOPIC_CMD_GET_CLEAN_PROGRESS_INFO, resp.data)
+        _LOGGER.debug("%s clean_progress_info response: %r", self.host, resp.data)
+        return resp
+
+    async def get_dry_mop_remain_time(self) -> CommandResponse:
+        """Query remaining mop drying time."""
+        resp = await self.send_command(TOPIC_CMD_GET_DRY_MOP_REMAIN_TIME)
+        self.state.update_from_aux_status(TOPIC_CMD_GET_DRY_MOP_REMAIN_TIME, resp.data)
+        _LOGGER.debug("%s dry_mop_remain_time response: %r", self.host, resp.data)
+        return resp
+
+    async def get_robot_task_status(self) -> CommandResponse:
+        """Query the robot task status model."""
+        resp = await self.send_command(TOPIC_CMD_GET_ROBOT_TASK_STATUS)
+        self.state.update_from_aux_status(TOPIC_CMD_GET_ROBOT_TASK_STATUS, resp.data)
+        _LOGGER.debug("%s robot_task_status response: %r", self.host, resp.data)
+        return resp
 
     async def get_map(self) -> MapData:
         """Download the full map data."""

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -19,6 +19,7 @@ from .const import (
     HEARTBEAT_INTERVAL,
     KEEPALIVE_INTERVAL,
     KNOWN_PRODUCT_KEYS,
+    LEGACY_ROOM_CLEAN_PRODUCT_KEYS,
     RECONNECT_BACKOFF_FACTOR,
     RECONNECT_INITIAL_DELAY,
     RECONNECT_MAX_DELAY,
@@ -42,7 +43,8 @@ from .const import (
     TOPIC_CMD_RESUME,
     TOPIC_CMD_SET_FAN_LEVEL,
     TOPIC_CMD_SET_MOP_HUMIDITY,
-    TOPIC_CMD_START_CLEAN,
+    TOPIC_CMD_PLAN_START,
+    TOPIC_CMD_CLEAN_TASK,
     TOPIC_CMD_TAKE_PICTURE,
     TOPIC_CMD_SET_LED,
     TOPIC_CMD_WASH_MOP,
@@ -52,6 +54,9 @@ from .const import (
     CommandResult,
     FanLevel,
     MopHumidity,
+    MopStrengthLevel,
+    WorkMode,
+    WorkingStatus,
 )
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState
 from .protocol import (
@@ -915,7 +920,7 @@ class NarwalClient:
         so we know which rooms to include.
         """
         resp = await self.send_command(
-            TOPIC_CMD_START_CLEAN,
+            TOPIC_CMD_PLAN_START,
             payload=self._DEFAULT_CLEAN_PAYLOAD,
             timeout=10.0,
         )
@@ -944,7 +949,7 @@ class NarwalClient:
         )
         payload = self._build_clean_payload_v2(room_ids)
         return await self.send_command(
-            TOPIC_CMD_START_CLEAN, payload=payload, timeout=10.0,
+            TOPIC_CMD_PLAN_START, payload=payload, timeout=10.0,
         )
 
     def _build_clean_payload_v2(
@@ -958,9 +963,7 @@ class NarwalClient:
         """Build clean task payload using the v2 schema (firmware v01.07.22+).
 
         Observed in issue #36 from a Flow on firmware v01.07.22.00.
-        Each room entry uses a nested room_id (different from the flat
-        schema in _build_room_clean_payload used for room-targeted cleans
-        on older firmware):
+        Each room entry uses a nested room_id:
 
             {
               1: {1: 1, 2: <room_id>},                # nested room ref
@@ -1046,41 +1049,100 @@ class NarwalClient:
         }
         return blackboxprotobuf.encode_message(msg, typedef)
 
-    def _build_room_clean_payload(self, room_ids: list[int]) -> bytes:
-        """Build CleanTask protobuf with per-room clean params in field 1.2.
+    # WorkMode -> (CleanParam.mode tag 1, pass-count tags to set from `passes`). The robot's
+    # execution mode is CleanTask.taskType (= the WorkMode value); CleanParam.mode and the
+    # pass tag are derived here so the two can't drift. Live-validated on a Flow 2; see
+    # project_history.md "CleanParam — fully decoded".
+    _WORK_MODE_PARAM: dict[WorkMode, tuple[int, tuple[str, ...]]] = {
+        WorkMode.VACUUM: (2, ("5",)),               # sweepTime
+        WorkMode.MOP: (3, ("6",)),                 # mopTime
+        WorkMode.VACUUM_THEN_MOP: (5, ("5", "6")),  # sweep + mop pass counts
+        WorkMode.VACUUM_AND_MOP: (4, ("7",)),      # sweepMopSyncTime
+    }
 
-        Each room entry in field 1.2 requires full MapCleanParamInfo fields
-        (from APK proto analysis):
-          field 1: roomId (uint32)
-          field 2: cleanMode (int32) — 0=sweep, 1=mop, 2=sweep+mop
-          field 3: cleanTimes (int32) — number of passes
-          field 6: sweepMode (int32) — suction level (3=max)
-          field 7: mopMode (int32) — mop humidity (2=wet)
+    def _build_start_clean_payload(
+        self,
+        room_ids: list[int],
+        map_id: int,
+        *,
+        work_mode: WorkMode = WorkMode.VACUUM_AND_MOP,
+        fan: FanLevel = FanLevel.NORMAL,
+        water: MopHumidity = MopHumidity.NORMAL,
+        mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL,
+        passes: int = 1,
+    ) -> bytes:
+        """Build a clean/start_clean request for the given rooms.
 
-        A bare roomId without clean params is silently ignored by the robot.
+        StartClean_Request{1: CleanTask{1: map_id, 2: [CleanItem...], 3: {} (TaskOption),
+        5: taskType}}; CleanItem{1: ZoneOption{1: 1 (room zone), 2: room_id}, 2: CleanParam,
+        3: order}. taskType (the execution-mode carrier) and CleanParam.mode/pass-tag are
+        derived from work_mode. overlapLevel is omitted — live-validated as ignored here.
 
         Args:
-            room_ids: List of room IDs from RoomInfo.room_id.
-
-        Returns:
-            Encoded protobuf bytes for clean/plan/start.
+            room_ids: Robot room IDs (RoomInfo.room_id).
+            map_id: Active map id (MapData.map_id, get_map field 2.1).
+            work_mode: Vacuum / mop / vacuum-then-mop / vacuum-and-mop.
+            fan: Suction level (CleanParam tag 2).
+            water: Mop water volume (tag 4).
+            mop_strength: Mop scrub intensity (tag 3).
+            passes: Clean count, routed to the pass tag(s) for the mode.
         """
+        import blackboxprotobuf
+
+        param_mode, pass_tags = self._WORK_MODE_PARAM[work_mode]
+        param: dict[str, int] = {
+            "1": int(param_mode),
+            "2": int(fan),
+            "3": int(mop_strength),
+            "4": int(water),
+        }
+        for tag in pass_tags:
+            param[tag] = int(passes)
+
+        items = [
+            {"1": {"1": 1, "2": rid}, "2": dict(param), "3": idx + 1}
+            for idx, rid in enumerate(room_ids)
+        ]
+        task = {
+            "1": map_id,
+            "2": items if len(items) > 1 else items[0],
+            "3": {},
+            "5": int(work_mode),  # CleanTask.taskType
+        }
+        item_typedef = {
+            "type": "message",
+            "seen_repeated": True,
+            "message_typedef": {
+                "1": {"type": "message", "message_typedef": {
+                    "1": {"type": "int"}, "2": {"type": "int"},
+                }},
+                # Derive the CleanParam typedef from the emitted dict — bbpb silently
+                # drops any tag absent from the typedef.
+                "2": {"type": "message", "message_typedef": {
+                    k: {"type": "int"} for k in param
+                }},
+                "3": {"type": "int"},
+            },
+        }
+        typedef = {"1": {"type": "message", "message_typedef": {
+            "1": {"type": "int"},
+            "2": item_typedef,
+            "3": {"type": "message", "message_typedef": {}},
+            "5": {"type": "int"},
+        }}}
+        return blackboxprotobuf.encode_message({"1": task}, typedef)
+
+    def _build_room_clean_payload(self, room_ids: list[int]) -> bytes:
+        """Build the legacy flat room-clean payload for older firmware."""
         if not room_ids:
             return self._DEFAULT_CLEAN_PAYLOAD
 
         import blackboxprotobuf
 
-        # Build per-room entries with default clean settings
-        room_entries = []
-        for rid in room_ids:
-            room_entries.append({
-                "1": rid,       # roomId
-                "2": 2,         # cleanMode = sweep+mop
-                "3": 1,         # cleanTimes = 1 pass
-                "6": 3,         # sweepMode = max suction
-                "7": 2,         # mopMode = wet
-            })
-
+        room_entries = [
+            {"1": room_id, "2": 2, "3": 1, "6": 3, "7": 2}
+            for room_id in room_ids
+        ]
         room_typedef = {
             "type": "message",
             "seen_repeated": True,
@@ -1090,19 +1152,13 @@ class NarwalClient:
                 "3": {"type": "int"},
                 "6": {"type": "int"},
                 "7": {"type": "int"},
-            }
+            },
         }
-
-        # Single room: field 1.2 is a message; multiple: repeated message
         field_2_value = room_entries[0] if len(room_entries) == 1 else room_entries
-
-        msg = {
+        message = {
             "1": {
                 "2": field_2_value,
-                "5": {
-                    "1": {"1": 3, "2": 2, "3": 1},
-                    "5": {}
-                }
+                "5": {"1": {"1": 3, "2": 2, "3": 1}, "5": {}},
             }
         }
         typedef = {
@@ -1118,53 +1174,143 @@ class NarwalClient:
                                 "message_typedef": {
                                     "1": {"type": "int"},
                                     "2": {"type": "int"},
-                                    "3": {"type": "int"}
-                                }
+                                    "3": {"type": "int"},
+                                },
                             },
-                            "5": {"type": "message", "message_typedef": {}}
-                        }
-                    }
-                }
+                            "5": {"type": "message", "message_typedef": {}},
+                        },
+                    },
+                },
             }
         }
-        return blackboxprotobuf.encode_message(msg, typedef)
+        return blackboxprotobuf.encode_message(message, typedef)
 
     async def start_rooms(
-        self, room_ids: list[int],
+        self,
+        room_ids: list[int],
+        *,
+        work_mode: WorkMode = WorkMode.VACUUM_AND_MOP,
+        fan: FanLevel = FanLevel.DEEP,
+        water: MopHumidity = MopHumidity.WET,
+        mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL,
+        passes: int = 1,
     ) -> CommandResponse:
-        """Start room-specific cleaning.
+        """Start cleaning the given rooms via clean/start_clean.
 
-        Sends clean/plan/start with the user-selected rooms. Tries the v2
-        nested-room schema first (required by firmware v01.07.22+, and fixes
-        the ack-but-ignore behavior in #37 where legacy schema returns
-        SUCCESS but the robot runs the app shortcut instead of HA-selected
-        rooms). Falls back to legacy flat-room schema on NOT_APPLICABLE
-        for older firmware.
+        Room cleaning must use clean/start_clean (StartClean → CleanTask), not
+        clean/plan/start: on Flow firmware the latter is StartWithPlan{planId,
+        mapId} and ignores any room payload — the root cause of #25/#37, where
+        the robot undocks and wanders instead of cleaning the selected rooms.
+        The CleanTask carries the active map id (get_map field 2.1).
+
+        clean/start_clean only works while docked; from STANDBY the robot
+        returns NOT_READY (4). Callers should start from the dock; this retries
+        briefly to cover the dock settling transition.
 
         Args:
-            room_ids: List of room IDs from RoomInfo.room_id.
-
-        Returns:
-            CommandResponse with result code from whichever schema landed.
+            room_ids: Robot room IDs (RoomInfo.room_id), mapped from HA areas.
+            work_mode, fan, water, mop_strength, passes: CleanParam settings —
+                see _build_start_clean_payload.
         """
         if not room_ids:
             return await self.start()
 
-        payload_v2 = self._build_clean_payload_v2(room_ids)
+        product_key = (
+            self.state.device_info.product_key
+            if self.state.device_info is not None
+            and self.state.device_info.product_key
+            else self.topic_prefix.removeprefix("/")
+        )
+        supports_legacy_room_clean = product_key in LEGACY_ROOM_CLEAN_PRODUCT_KEYS
+        map_data = self.state.map_data
+        if not map_data or not map_data.map_id:
+            try:
+                map_data = await self.get_map()
+            except NarwalCommandError:
+                if not supports_legacy_room_clean:
+                    raise
+                _LOGGER.debug(
+                    "start_rooms: map fetch failed; trying legacy room-clean commands"
+                )
+                map_data = None
+        map_id = map_data.map_id if map_data else 0
+        if not map_id and not supports_legacy_room_clean:
+            return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        resp = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        if map_id:
+            payload = self._build_start_clean_payload(
+                room_ids,
+                map_id,
+                work_mode=work_mode,
+                fan=fan,
+                water=water,
+                mop_strength=mop_strength,
+                passes=passes,
+            )
+            resp = await self.send_command(
+                TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
+            )
+            for _ in range(3):
+                if resp.result_code != CommandResult.NOT_READY:
+                    break
+                if not self.state.is_docked:
+                    _LOGGER.warning(
+                        "start_rooms: robot not docked (status=%s); "
+                        "clean/start_clean requires the robot on the dock",
+                        self.state.working_status.name,
+                    )
+                    break
+                _LOGGER.info(
+                    "start_rooms: robot docking/settling, retrying "
+                    "clean/start_clean"
+                )
+                await asyncio.sleep(3.0)
+                resp = await self.send_command(
+                    TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
+                )
+        else:
+            _LOGGER.warning(
+                "start_rooms: no active map id available; trying legacy room clean"
+            )
+        if resp.result_code != CommandResult.NOT_APPLICABLE:
+            return resp
+        if not supports_legacy_room_clean:
+            return resp
+
+        _LOGGER.info(
+            "start_rooms: clean/start_clean rejected, trying clean/plan/start "
+            "compatibility payloads"
+        )
+        legacy_suction = {
+            FanLevel.UNSPECIFIED: 3,
+            FanLevel.MUTE: 0,
+            FanLevel.NORMAL: 1,
+            FanLevel.STRONG: 2,
+            FanLevel.DEEP: 3,
+            FanLevel.SUPER: 3,
+        }[FanLevel(fan)]
+        legacy_water = {
+            MopHumidity.UNSPECIFIED: 2,
+            MopHumidity.DRY: 0,
+            MopHumidity.NORMAL: 1,
+            MopHumidity.WET: 2,
+        }[MopHumidity(water)]
+        legacy_v2 = self._build_clean_payload_v2(
+            room_ids,
+            suction=legacy_suction,
+            mop_humidity=legacy_water,
+            passes=passes,
+        )
         resp = await self.send_command(
-            TOPIC_CMD_START_CLEAN, payload=payload_v2, timeout=10.0,
+            TOPIC_CMD_PLAN_START, payload=legacy_v2, timeout=10.0,
         )
         if resp.result_code != CommandResult.NOT_APPLICABLE:
             return resp
 
-        # v2 rejected — try legacy flat-room schema (older firmware)
-        _LOGGER.info(
-            "start_rooms(): v2 payload rejected, retrying with legacy schema (%d rooms)",
-            len(room_ids),
-        )
-        payload_legacy = self._build_room_clean_payload(room_ids)
         return await self.send_command(
-            TOPIC_CMD_START_CLEAN, payload=payload_legacy, timeout=10.0,
+            TOPIC_CMD_PLAN_START,
+            payload=self._build_room_clean_payload(room_ids),
+            timeout=10.0,
         )
 
     async def start_easy_clean(self) -> CommandResponse:
@@ -1196,21 +1342,48 @@ class NarwalClient:
         return await self.send_command(TOPIC_CMD_RECALL, timeout=timeout)
 
     async def set_fan_speed(self, level: FanLevel | int) -> CommandResponse:
-        """Set suction fan speed.
+        """Set suction fan speed live (clean/set_fan_level, field 1 = SweepFanLevel).
 
-        Args:
-            level: FanLevel enum or int (0=quiet, 1=normal, 2=strong, 3=max).
+        The live command's enum is SweepFanLevel, which has no SUPER. Use its
+        highest available level, DEEP, when callers request SUPER. Bare integer
+        values retain the original 0=quiet through 3=max API mapping.
         """
-        payload = b"\x08" + bytes([int(level) & 0x7F])
+        if isinstance(level, FanLevel):
+            live = min(int(level), int(FanLevel.DEEP))
+        else:
+            legacy_levels = {
+                0: FanLevel.MUTE,
+                1: FanLevel.NORMAL,
+                2: FanLevel.STRONG,
+                3: FanLevel.DEEP,
+            }
+            try:
+                live = int(legacy_levels[level])
+            except KeyError as err:
+                raise ValueError(f"Invalid legacy fan level: {level}") from err
+        payload = b"\x08" + bytes([live & 0x7F])
         return await self.send_command(TOPIC_CMD_SET_FAN_LEVEL, payload)
 
     async def set_mop_humidity(self, level: MopHumidity | int) -> CommandResponse:
-        """Set mop wetness level.
+        """Set mop water volume live (clean/set_mop_humidity, field 1 = MopHumidity).
 
         Args:
-            level: MopHumidity enum or int (0=dry, 1=normal, 2=wet).
+            level: MopHumidity enum, or the legacy int mapping
+                (0=dry, 1=normal, 2=wet).
         """
-        payload = b"\x08" + bytes([int(level) & 0x7F])
+        if isinstance(level, MopHumidity):
+            live = int(level)
+        else:
+            legacy_levels = {
+                0: MopHumidity.DRY,
+                1: MopHumidity.NORMAL,
+                2: MopHumidity.WET,
+            }
+            try:
+                live = int(legacy_levels[level])
+            except KeyError as err:
+                raise ValueError(f"Invalid legacy mop humidity: {level}") from err
+        payload = b"\x08" + bytes([live & 0x7F])
         return await self.send_command(TOPIC_CMD_SET_MOP_HUMIDITY, payload)
 
     async def wash_mop(self) -> CommandResponse:

--- a/narwal_client/const.py
+++ b/narwal_client/const.py
@@ -51,6 +51,8 @@ KNOWN_PRODUCT_KEYS = [
     "cUlfJN5JYP",   # Unknown model (APK, contributed by @northwestsupra)
 ]
 
+LEGACY_ROOM_CLEAN_PRODUCT_KEYS = {"QoEsI5qYXO"}
+
 # --- Status topics (robot → client, field 4 / 0x22 frames) ---
 TOPIC_WORKING_STATUS = "status/working_status"
 TOPIC_ROBOT_BASE_STATUS = "status/robot_base_status"
@@ -82,8 +84,8 @@ TOPIC_CMD_DRY_MOP = "supply/dry_mop"
 TOPIC_CMD_DUST_GATHERING = "supply/dust_gathering"
 
 # Cleaning (Pita protocol — correct for AX12)
-TOPIC_CMD_START_CLEAN = "clean/plan/start"  # whole-house clean (empty payload)
-TOPIC_CMD_START_CLEAN_LEGACY = "clean/start_clean"  # does NOT work from STANDBY
+TOPIC_CMD_PLAN_START = "clean/plan/start"  # whole-house clean (empty payload)
+TOPIC_CMD_CLEAN_TASK = "clean/start_clean"  # room/zone CleanTask; only works docked
 TOPIC_CMD_EASY_CLEAN = "clean/easy_clean/start"
 TOPIC_CMD_SET_FAN_LEVEL = "clean/set_fan_level"
 TOPIC_CMD_SET_MOP_HUMIDITY = "clean/set_mop_humidity"
@@ -141,6 +143,7 @@ class CommandResult(IntEnum):
     SUCCESS = 1
     NOT_APPLICABLE = 2  # e.g., set_fan_level when not cleaning
     CONFLICT = 3  # e.g., recall when already recalling
+    NOT_READY = 4  # clean/start_clean while not docked (robot in STANDBY)
 
 
 class WorkingStatus(IntEnum):
@@ -179,20 +182,42 @@ class WorkingStatus(IntEnum):
 
 
 class FanLevel(IntEnum):
-    """Suction fan speed levels (SweepMode from APK)."""
+    """CleanParam suction level (CleanTask.pbenum FanLevel)."""
 
-    QUIET = 0
-    NORMAL = 1
-    STRONG = 2
-    MAX = 3
+    UNSPECIFIED = 0
+    MUTE = 1
+    QUIET = MUTE
+    NORMAL = 2
+    STRONG = 3
+    DEEP = 4
+    MAX = DEEP
+    SUPER = 5
 
 
 class MopHumidity(IntEnum):
-    """Mop wetness levels."""
+    """Water volume. CleanParam tag 4 and the live clean/set_mop_humidity command share these ints."""
 
-    DRY = 0
+    UNSPECIFIED = 0
+    DRY = 1
+    NORMAL = 2
+    WET = 3
+
+
+class MopStrengthLevel(IntEnum):
+    """Mop scrub intensity (CleanParam tag 3)."""
+
+    UNSPECIFIED = 0
     NORMAL = 1
-    WET = 2
+    HIGH = 2
+
+
+class WorkMode(IntEnum):
+    """Clean work mode — the app's robot_work_mode_* selector (Vacuum / Mop / Vacuum then mop / Vacuum and mop). Its value IS the CleanTask.taskType the robot executes; the per-item CleanParam.mode (the proto's own CleanMode enum) is derived separately in client._WORK_MODE_PARAM."""
+
+    VACUUM = 1
+    MOP = 2
+    VACUUM_THEN_MOP = 3
+    VACUUM_AND_MOP = 4
 
 
 # robot_base_status field numbers

--- a/narwal_client/const.py
+++ b/narwal_client/const.py
@@ -24,6 +24,7 @@ KNOWN_PRODUCT_KEYS = [
     # Confirmed working (local WebSocket)
     "QoEsI5qYXO",  # AX12 — Narwal Flow (primary, confirmed)
     "QxMSPG6VSO",  # Narwal Flow 2 (confirmed working via local WebSocket)
+    "iSuVlI1If2",  # Narwal Flow 2 alternate key (confirmed working locally)
     "DrzDKQ0MU8",   # CX4  — Freo Z10 Ultra (confirmed by @irekkl-maker)
     # Confirmed cloud-only (port 9002 open but no local broadcasts)
     "BYWBPqSxeC",   # CX7  — Freo Z Ultra (cloud-only, confirmed by @gabrielozcomidi)
@@ -60,7 +61,11 @@ TOPIC_UPGRADE_STATUS = "upgrade/upgrade_status"
 TOPIC_DOWNLOAD_STATUS = "status/download_status"
 TOPIC_DISPLAY_MAP = "map/display_map"
 TOPIC_TIMELINE_STATUS = "status/time_line_status"
+TOPIC_POINT_NAVI_PLAN_TRAJ = "status/point_navi_plan_traj"
 TOPIC_PLANNING_DEBUG = "developer/planning_debug_info"
+TOPIC_ROBOT_STATUS = "status/robot"
+TOPIC_ROBOT_CURRENT_STATUS = "status/robot/current"
+TOPIC_ROBOT_TASK_STATUS = "robot/task/status"
 
 # --- Command topics (client → robot, confirmed working) ---
 # Common
@@ -80,8 +85,12 @@ TOPIC_CMD_CANCEL = "task/cancel"
 # Supply/dock
 TOPIC_CMD_RECALL = "supply/recall"
 TOPIC_CMD_WASH_MOP = "supply/wash_mop"
+TOPIC_CMD_WASH_MOP_BY_ROBOT_STATUS = "supply/wash_mop_by_robot_status"
 TOPIC_CMD_DRY_MOP = "supply/dry_mop"
 TOPIC_CMD_DUST_GATHERING = "supply/dust_gathering"
+TOPIC_CMD_WASH_AND_DRY_MOP = "supply/wash_and_dry_mop"
+TOPIC_CMD_DRY_DUST_BAG = "supply/dry_dust_bag"
+TOPIC_CMD_DRY_STATION_BAG = "supply/dry_station_bag"
 
 # Cleaning (Pita protocol — correct for AX12)
 TOPIC_CMD_PLAN_START = "clean/plan/start"  # whole-house clean (empty payload)
@@ -90,6 +99,9 @@ TOPIC_CMD_EASY_CLEAN = "clean/easy_clean/start"
 TOPIC_CMD_SET_FAN_LEVEL = "clean/set_fan_level"
 TOPIC_CMD_SET_MOP_HUMIDITY = "clean/set_mop_humidity"
 TOPIC_CMD_GET_CURRENT_TASK = "clean/current_clean_task/get"
+TOPIC_CMD_GET_CLEAN_PROGRESS_INFO = "info/get_clean_progress_info"
+TOPIC_CMD_GET_DRY_MOP_REMAIN_TIME = "supply/get_dry_mop_remain_time"
+TOPIC_CMD_GET_ROBOT_TASK_STATUS = "robot/task/status/get"
 
 # Map
 TOPIC_CMD_GET_MAP = "map/get_map"
@@ -152,8 +164,10 @@ class WorkingStatus(IntEnum):
     Values confirmed via live WebSocket monitoring:
       1  = STANDBY (idle, transition state between cleaning and docked)
       2  = DOCKED_V2 (on dock; confirmed v01.07.23.00 while charging at 10-36%)
+      3  = CLEANING_V2 (active room clean; confirmed on Flow 2 v01.07.23)
       4  = CLEANING (plan-based start; also stays 4 while returning to dock on older FW)
       5  = CLEANING_ALT (observed live: robot was physically stuck when reporting 5)
+      7  = CLEANING_FLOW2 (active cleaning on Flow 2 v01.07.10.33)
       10 = DOCKED (on dock, charging)
       14 = CHARGED (on dock, fully charged)
       19 = TASK_COMPLETED (transitional: scheduled task finished, returning to base)
@@ -171,14 +185,26 @@ class WorkingStatus(IntEnum):
     UNKNOWN = 0
     STANDBY = 1       # idle / transition state
     DOCKED_V2 = 2     # on dock (v01.07.23.00+ — replaces DOCKED=10/CHARGED=14 from older FW)
+    CLEANING_V2 = 3   # active cleaning on Flow 2 firmware v01.07.23+
     CLEANING = 4      # active cleaning (stays 4 even while returning to dock)
     CLEANING_ALT = 5  # cleaning — observed when robot was physically stuck; may indicate error/stuck state
+    CLEANING_FLOW2 = 7  # active cleaning on Flow 2 v01.07.10.33
     DOCKED = 10       # on dock (does NOT reliably indicate charging vs charged)
     CHARGED = 14      # on dock (reported before 100% — use battery_level for charge state)
     TASK_COMPLETED = 19  # transitional: task finished, robot returning to base (#41)
     # PLACEHOLDER: error state value not yet observed live.
     # Trigger a real error (e.g., pick up robot mid-clean) to discover the value.
     ERROR = 99
+
+
+ACTIVE_CLEANING_STATUSES = frozenset(
+    {
+        WorkingStatus.CLEANING_V2,
+        WorkingStatus.CLEANING,
+        WorkingStatus.CLEANING_ALT,
+        WorkingStatus.CLEANING_FLOW2,
+    }
+)
 
 
 class FanLevel(IntEnum):
@@ -209,6 +235,13 @@ class MopStrengthLevel(IntEnum):
     UNSPECIFIED = 0
     NORMAL = 1
     HIGH = 2
+
+
+class CleaningRoute(IntEnum):
+    """Cleaning route overlap level (CleanParam tag 8)."""
+
+    STANDARD = 1
+    METICULOUS = 2
 
 
 class WorkMode(IntEnum):

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -254,6 +254,7 @@ class MapData:
     origin_y: int = 0  # y pixel offset from field 2.6.1
     obstacles: list[ObstacleInfo] = field(default_factory=list)
     raw: dict[str, Any] = field(default_factory=dict)
+    map_id: int = 0  # active map id (field 2.1) — required by clean/start_clean
 
     @classmethod
     def from_response(
@@ -344,6 +345,7 @@ class MapData:
             obstacles = _parse_obstacles(field32)
 
         return cls(
+            map_id=int(payload.get("1", 0)),
             width=int(payload.get("4", 0)),
             height=int(payload.get("5", 0)),
             resolution=resolution,

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -4,12 +4,20 @@ from __future__ import annotations
 
 import logging
 import struct
+import time
 from dataclasses import dataclass, field
 from typing import Any, ClassVar
 
 _LOGGER = logging.getLogger(__name__)
+_ACTIVE_WORKING_STATUS_TTL = 15.0
 
-from .const import CommandResult, FanLevel, MopHumidity, WorkingStatus
+from .const import (
+    ACTIVE_CLEANING_STATUSES,
+    TOPIC_CMD_GET_ROBOT_TASK_STATUS,
+    TOPIC_ROBOT_TASK_STATUS,
+    CommandResult,
+    WorkingStatus,
+)
 
 
 @dataclass
@@ -51,6 +59,11 @@ class RoomInfo:
     # Confirmed on Narwal Flow 2 (QxMSPG6VSO, firmware v01.07.16.01) — see #22.
     MODEL_ROOM_TYPE_OVERRIDES: ClassVar[dict[str, dict[int, str]]] = {
         "QxMSPG6VSO": {  # Flow 2
+            1: "Master Bedroom",
+            5: "Bathroom",
+            10: "Corridor",
+        },
+        "iSuVlI1If2": {  # Flow 2 alternate product key
             1: "Master Bedroom",
             5: "Bathroom",
             10: "Corridor",
@@ -237,6 +250,73 @@ def _parse_obstacles(field32: dict) -> list[ObstacleInfo]:
     return obstacles
 
 
+def _coerce_bytes(value: Any) -> bytes:
+    """Return a protobuf bytes value as bytes."""
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, bytearray):
+        return bytes(value)
+    if isinstance(value, str):
+        return value.encode("latin-1", "ignore")
+    return b""
+
+
+def _count_cleaned_pixels(value: Any, expected_pixels: int) -> int:
+    """Count non-zero cells in a display_map cleaned-area overlay."""
+    data = _coerce_bytes(value)
+    if not data:
+        return 0
+
+    from .map_renderer import _decode_packed_varints, decompress_map
+
+    decompressed = decompress_map(data)
+    pixels = _decode_packed_varints(decompressed)
+    if pixels:
+        if expected_pixels > 0:
+            pixels = pixels[:expected_pixels]
+        return sum(1 for pixel in pixels if pixel)
+
+    raw = decompressed or data
+    if expected_pixels > 0:
+        raw = raw[:expected_pixels]
+    return sum(1 for byte in raw if byte)
+
+
+def _extract_ints(value: Any) -> list[int]:
+    """Extract integer values from a loosely-decoded protobuf field."""
+    if isinstance(value, bool):
+        return []
+    if isinstance(value, int):
+        return [value]
+    if isinstance(value, list):
+        result: list[int] = []
+        for item in value:
+            result.extend(_extract_ints(item))
+        return result
+    if isinstance(value, dict):
+        result: list[int] = []
+        for item in value.values():
+            result.extend(_extract_ints(item))
+        return result
+    return []
+
+
+def _positive_int_field(decoded: dict[str, Any], field: str) -> bool:
+    """Return true when a decoded protobuf field is a positive integer."""
+    try:
+        return int(decoded.get(field, 0) or 0) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _optional_int(value: Any) -> int | None:
+    """Return value coerced to int, or None when it cannot be coerced."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 @dataclass
 class MapData:
     """Map data from get_map response."""
@@ -361,6 +441,43 @@ class MapData:
             raw=payload,
         )
 
+    def cleanable_area_cm2(self, room_ids: list[int] | None = None) -> int:
+        """Estimate cleanable area in cm² from room floor pixels."""
+        if not self.compressed_map or self.width <= 0 or self.height <= 0:
+            return 0
+        if self.resolution <= 0:
+            return 0
+
+        from .map_renderer import _decode_packed_varints, decompress_map
+
+        pixels = _decode_packed_varints(decompress_map(self.compressed_map))
+        expected = self.width * self.height
+        if len(pixels) < expected:
+            pixels.extend([0] * (expected - len(pixels)))
+        elif len(pixels) > expected:
+            pixels = pixels[:expected]
+
+        selected = {int(room_id) for room_id in room_ids or []}
+        floor_pixels = 0
+        for val in pixels:
+            if val in (0, 0x28):
+                continue
+            if val == 0x20:
+                if selected:
+                    continue
+                floor_pixels += 1
+                continue
+            room_id = val >> 8
+            pixel_type = val & 0xFF
+            if pixel_type & 0x10:
+                continue
+            if selected and room_id not in selected:
+                continue
+            floor_pixels += 1
+
+        cm_per_pixel = self.resolution / 10
+        return round(floor_pixels * cm_per_pixel * cm_per_pixel)
+
 
 @dataclass
 class MapDisplayData:
@@ -386,6 +503,10 @@ class MapDisplayData:
     # Dock/reference position from field 5 (same coordinate system as robot)
     dock_ref_x: float = 0.0
     dock_ref_y: float = 0.0
+    cleaned_width: int = 0
+    cleaned_height: int = 0
+    cleaned_pixel_count: int = 0
+    active_room_ids: list[int] = field(default_factory=list)
 
     def to_grid_coords(
         self, resolution: int, origin_x: int, origin_y: int,
@@ -457,7 +578,38 @@ class MapDisplayData:
             except (ValueError, TypeError):
                 pass
 
+        field7 = decoded.get("7")
+        if isinstance(field7, list):
+            field7 = field7[0] if field7 else None
+        if isinstance(field7, dict):
+            try:
+                result.cleaned_width = int(field7.get("1", 0))
+                result.cleaned_height = int(field7.get("2", 0))
+            except (ValueError, TypeError):
+                result.cleaned_width = 0
+                result.cleaned_height = 0
+            result.cleaned_pixel_count = _count_cleaned_pixels(
+                field7.get("3"),
+                result.cleaned_width * result.cleaned_height,
+            )
+
+        if "12" in decoded:
+            seen: set[int] = set()
+            room_ids: list[int] = []
+            for room_id in _extract_ints(decoded["12"]):
+                if room_id > 0 and room_id not in seen:
+                    seen.add(room_id)
+                    room_ids.append(room_id)
+            result.active_room_ids = room_ids
+
         return result
+
+    def cleaned_area_cm2(self, resolution: int) -> int:
+        """Return the cleaned overlay area in cm²."""
+        if self.cleaned_pixel_count <= 0 or resolution <= 0:
+            return 0
+        cm_per_pixel = resolution / 10
+        return round(self.cleaned_pixel_count * cm_per_pixel * cm_per_pixel)
 
 
 @dataclass
@@ -497,6 +649,7 @@ class NarwalState:
     working_status: WorkingStatus = WorkingStatus.UNKNOWN
     battery_level: int = 0  # real-time SOC from field 2 (float32)
     battery_health: int = 0  # static design capacity from field 38 (always 100)
+    inferred_docked_from_battery: bool = False
     firmware_version: str = ""
     firmware_target: str = ""
 
@@ -513,6 +666,12 @@ class NarwalState:
     # Cleaning stats
     cleaning_area: int = 0  # cm²
     cleaning_time: int = 0  # seconds
+    last_active_working_status_time: float = 0.0
+    task_progress_percent: int | None = None
+    task_elapsed_time: int = 0
+    current_room_id: int | None = None
+    current_room_name: str = ""
+    dry_mop_remaining_time: int | None = None
 
     # Map
     map_data: MapData | None = None
@@ -536,9 +695,21 @@ class NarwalState:
     # Dock activity (field 3 sub-field 12: 2/6 observed when docked)
     dock_activity: int = 0
 
+    # Station activity (field 3 sub-field 18)
+    # Observed: 1 during dust gathering, 4 during dock dry/disinfection work.
+    station_activity: int = 0
+
     # Dock presence (field 3 sub-field 3)
     # Values observed: 1=on dock, 2=off dock, 6=on dock (charged idle)
     dock_presence: int = 0
+
+    # Newer Flow firmware sub-state (field 3 sub-field 4).
+    # Observed during active clean startup/navigation: 8 -> 7 -> 3.
+    flow_activity: int = 0
+
+    # Newer Flow firmware task flag (field 3 sub-field 14). Observed as 1
+    # during active cleaning/navigation.
+    flow_task_flag: int = 0
 
     # Dock indicator from field 11 (top-level base_status field)
     # Validated via dock_research.py guided test (5 captures):
@@ -557,12 +728,67 @@ class NarwalState:
     # Raw data for fields we haven't fully decoded yet
     raw_base_status: dict[str, Any] = field(default_factory=dict)
     raw_working_status: dict[str, Any] = field(default_factory=dict)
+    raw_aux_status: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    def _working_status_is_cleaning_like(self) -> bool:
+        """True when the cached working_status looks like a cleaning task."""
+        return self.working_status in (
+            WorkingStatus.CLEANING,
+            WorkingStatus.CLEANING_V2,
+            WorkingStatus.CLEANING_ALT,
+            WorkingStatus.CLEANING_FLOW2,
+        )
+
+    def _dock_fields_indicate_docked(self) -> bool:
+        """True when base-status dock fields indicate the robot is on dock."""
+        if self.dock_sub_state == 1:
+            return True
+        if self.dock_activity > 0:
+            return True
+        if self.station_activity > 0:
+            return True
+        if self.dock_field11 >= 2:
+            return True
+        if self.dock_field47 in (1, 3):
+            return True
+        return False
+
+    @property
+    def is_station_active(self) -> bool:
+        """True when the base station is running a dock-side task."""
+        return self.station_activity > 0 or (
+            self.working_status == WorkingStatus.CLEANING_ALT and self.is_docked
+        )
+
+    def _set_battery_level(self, battery_level: int) -> None:
+        """Update battery level and infer docked state from charging trend."""
+        if (
+            self.battery_level > 0
+            and battery_level > self.battery_level
+            and self._working_status_is_cleaning_like()
+            and not self.has_recent_active_working_status
+        ):
+            self.inferred_docked_from_battery = True
+        self.battery_level = battery_level
+
+    @property
+    def has_recent_active_working_status(self) -> bool:
+        """True while working_status is actively reporting task counters."""
+        if self.working_status not in ACTIVE_CLEANING_STATUSES:
+            return False
+        if self.last_active_working_status_time <= 0:
+            return False
+        return time.monotonic() - self.last_active_working_status_time <= _ACTIVE_WORKING_STATUS_TTL
 
     @property
     def is_cleaning(self) -> bool:
         """True when actively cleaning (not paused, not returning to dock)."""
+        if self.has_recent_active_working_status:
+            return not self.is_paused and not self.is_returning
+        if self._dock_fields_indicate_docked() or self.inferred_docked_from_battery:
+            return False
         return (
-            self.working_status in (WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT)
+            self._working_status_is_cleaning_like()
             and not self.is_paused
             and not self.is_returning_to_dock
         )
@@ -583,25 +809,21 @@ class NarwalState:
         cleaning is not active, since the robot can report unmapped states
         (e.g. self-test) while physically docked.
         """
+        if self.has_recent_active_working_status:
+            return False
         if self.working_status in (
             WorkingStatus.DOCKED, WorkingStatus.CHARGED, WorkingStatus.DOCKED_V2,
         ):
             return True
-        if self.working_status in (WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT):
-            return False
         # For STANDBY, UNKNOWN, or any other status: check dock field signals.
         # Values differ across firmware versions:
         #   Old FW: dock_sub_state=1, dock_field11=2, dock_field47=3
         #   v01.07.23.00: dock_sub_state absent, dock_field11=3, dock_field47=1
-        if self.dock_sub_state == 1:
-            return True
-        if self.dock_activity > 0:
-            return True
-        if self.dock_field11 >= 2:
-            return True
-        if self.dock_field47 in (1, 3):
-            return True
-        return False
+        #
+        # Narwal can keep reporting a stale CLEANING working_status after the
+        # active working_status payload has stopped. Once that live payload is
+        # no longer recent, dock fields are a better source of truth.
+        return self._dock_fields_indicate_docked() or self.inferred_docked_from_battery
 
     @property
     def is_returning(self) -> bool:
@@ -620,8 +842,11 @@ class NarwalState:
         transitions to STANDBY/DOCKED/CHARGED, it has already docked
         even if field 3.7 is momentarily still set.
         """
-        if self.working_status not in (
-            WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT,
+        if not self.has_recent_active_working_status and self.working_status not in (
+            WorkingStatus.CLEANING,
+            WorkingStatus.CLEANING_V2,
+            WorkingStatus.CLEANING_ALT,
+            WorkingStatus.CLEANING_FLOW2,
         ):
             return False
         return self.is_returning_to_dock and self.dock_sub_state == 2
@@ -636,6 +861,8 @@ class NarwalState:
           Field 15 = 600 during cleaning (purpose uncertain)
         """
         self.raw_working_status = decoded
+        previous_cleaning_time = self.cleaning_time
+        previous_cleaning_area = self.cleaning_area
         if "3" in decoded:
             try:
                 self.cleaning_time = int(decoded["3"])
@@ -646,6 +873,34 @@ class NarwalState:
         if "15" in decoded:
             # Field 15 may be cumulative time; prefer field 3 for current session
             pass
+        has_active_payload = any(
+            _positive_int_field(decoded, field) for field in ("3", "13")
+        )
+        active_payload_changed = (
+            self.cleaning_time != previous_cleaning_time
+            or self.cleaning_area != previous_cleaning_area
+        )
+        if has_active_payload and active_payload_changed:
+            self.last_active_working_status_time = time.monotonic()
+            self.inferred_docked_from_battery = False
+        if (
+            has_active_payload
+            and active_payload_changed
+            and self.working_status
+            in (
+                WorkingStatus.UNKNOWN,
+                WorkingStatus.STANDBY,
+                WorkingStatus.DOCKED,
+                WorkingStatus.CHARGED,
+                WorkingStatus.DOCKED_V2,
+            )
+        ):
+            self.working_status = WorkingStatus.CLEANING
+            self.dock_field11 = 1
+            self.dock_field47 = 2
+            self.dock_sub_state = 0
+            self.dock_activity = 0
+            self.station_activity = 0
 
     def update_from_base_status(self, decoded: dict[str, Any]) -> None:
         """Update state from a decoded robot_base_status message.
@@ -661,6 +916,7 @@ class NarwalState:
           3.7  = 1 means RETURNING to dock (live-validated)
           3.10 = dock sub-state (1=docked, 2=docking in progress)
           3.12 = dock activity (values 2, 6 observed)
+          3.18 = station activity (1=dust gathering, 4=dry/disinfection observed)
 
         Dock indicators (validated via dock_research.py, 5 captures):
           Field 11 = 2 when docked, 1 when undocked
@@ -717,13 +973,41 @@ class NarwalState:
                     self.dock_activity = int(field3["12"])
                 except (ValueError, TypeError):
                     pass
+            self.station_activity = 0
+            if "18" in field3:
+                try:
+                    self.station_activity = int(field3["18"])
+                except (ValueError, TypeError):
+                    pass
             if "3" in field3:
                 try:
                     self.dock_presence = int(field3["3"])
                 except (ValueError, TypeError):
                     pass
+            self.flow_activity = 0
+            if "4" in field3:
+                try:
+                    self.flow_activity = int(field3["4"])
+                except (ValueError, TypeError):
+                    pass
+            self.flow_task_flag = 0
+            if "14" in field3:
+                try:
+                    self.flow_task_flag = int(field3["14"])
+                except (ValueError, TypeError):
+                    pass
+            if self.working_status in ACTIVE_CLEANING_STATUSES:
+                if "11" not in decoded:
+                    self.dock_field11 = 1
+                if "47" not in decoded:
+                    self.dock_field47 = 2
+                if "10" not in field3:
+                    self.dock_sub_state = 0
+                if "12" not in field3:
+                    self.dock_activity = 0
+                self.inferred_docked_from_battery = False
             # Log unrecognized sub-fields for future firmware mapping
-            _known_f3 = {"1", "2", "3", "7", "10", "12"}
+            _known_f3 = {"1", "2", "3", "4", "7", "10", "11", "12", "14", "18"}
             _unknown_f3 = set(field3.keys()) - _known_f3
             if _unknown_f3:
                 _LOGGER.debug(
@@ -736,12 +1020,21 @@ class NarwalState:
                 "Please report this at the GitHub repo.",
                 type(field3).__name__, field3,
             )
+        explicitly_off_dock = (
+            ("11" in decoded and self.dock_field11 == 1)
+            or ("47" in decoded and self.dock_field47 == 2)
+        )
+        if not self.is_returning_to_dock and explicitly_off_dock:
+            self.dock_sub_state = 0
+            self.dock_activity = 0
         if "2" in decoded:
             # Field 2 = real-time battery SOC as float32
             # (e.g. 1118175232 → 83.0%; bbp may return int or float)
             bat = _to_float32(decoded["2"])
             if bat is not None:
-                self.battery_level = round(bat)
+                self._set_battery_level(round(bat))
+        if explicitly_off_dock:
+            self.inferred_docked_from_battery = False
         if "38" in decoded:
             # Field 38 = static battery health (always 100, design capacity)
             self.battery_health = int(decoded["38"])
@@ -768,7 +1061,7 @@ class NarwalState:
         if "2" in decoded:
             bat = _to_float32(decoded["2"])
             if bat is not None:
-                self.battery_level = round(bat)
+                self._set_battery_level(round(bat))
         if "38" in decoded:
             self.battery_health = int(decoded["38"])
         if "36" in decoded:
@@ -799,3 +1092,46 @@ class NarwalState:
         """Update state from a decoded download_status message."""
         if "1" in decoded:
             self.download_status = int(decoded["1"])
+
+    def update_from_aux_status(self, topic: str, decoded: dict[str, Any]) -> None:
+        """Store decoded status payloads that are not mapped yet."""
+        self.raw_aux_status[topic] = decoded
+        if topic in {TOPIC_ROBOT_TASK_STATUS, TOPIC_CMD_GET_ROBOT_TASK_STATUS}:
+            payload = decoded.get("2")
+            if not isinstance(payload, dict):
+                return
+            progress = _optional_int(payload.get("1"))
+            if progress is not None:
+                self.task_progress_percent = max(0, min(100, progress))
+            elapsed = _optional_int(payload.get("2"))
+            if elapsed is not None:
+                self.task_elapsed_time = elapsed
+            room = payload.get("6")
+            if not isinstance(room, dict):
+                room = payload.get("8")
+            if isinstance(room, dict):
+                self.current_room_id = _optional_int(room.get("1"))
+                name = room.get("3")
+                if isinstance(name, (bytes, bytearray)):
+                    self.current_room_name = bytes(name).decode(
+                        "utf-8", errors="replace"
+                    )
+                else:
+                    self.current_room_name = str(name) if name else ""
+                    if self.current_room_name.startswith(
+                        "b'"
+                    ) and self.current_room_name.endswith("'"):
+                        self.current_room_name = self.current_room_name[2:-1]
+                if self.current_room_id is not None and self.map_data is not None:
+                    map_room = next(
+                        (
+                            candidate
+                            for candidate in self.map_data.rooms
+                            if candidate.room_id == self.current_room_id
+                        ),
+                        None,
+                    )
+                    if map_room is not None:
+                        self.current_room_name = map_room.display_name
+        elif topic == "supply/get_dry_mop_remain_time":
+            self.dry_mop_remaining_time = _optional_int(decoded.get("2"))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from narwal_client.client import NarwalClient, NarwalConnectionError
-from narwal_client.const import CommandResult
+from narwal_client.const import CommandResult, WorkingStatus
 from narwal_client.models import CommandResponse, MapData, RoomInfo
 
 
@@ -31,10 +31,113 @@ class TestNarwalClientInit:
         assert not client.connected
         assert client.state.battery_level == 0
 
+    def test_confirmed_dock_status_ends_active_marker(self) -> None:
+        """Fresh dock indicators are not discarded as stale task state."""
+        client = NarwalClient("10.0.0.1")
+        client.state.working_status = WorkingStatus.CLEANING
+        client._last_active_working_status_time = 100.0
+
+        client._update_from_base_status_broadcast(
+            {"3": {"1": 10}, "11": 2, "47": 3}, now=101.0
+        )
+
+        assert client.state.working_status == WorkingStatus.DOCKED
+        assert client.state.is_docked
+
+    @pytest.mark.parametrize("dock_field", [{"10": 1}, {"12": 2}])
+    def test_nested_dock_status_ends_active_marker(
+        self, dock_field: dict[str, int]
+    ) -> None:
+        """Nested old-firmware dock indicators confirm a terminal status."""
+        client = NarwalClient("10.0.0.1")
+        client.state.working_status = WorkingStatus.CLEANING
+        client._last_active_working_status_time = 100.0
+
+        client._update_from_base_status_broadcast(
+            {"3": {"1": 10, **dock_field}}, now=101.0
+        )
+
+        assert client.state.working_status == WorkingStatus.DOCKED
+        assert client.state.is_docked
+
+    def test_unconfirmed_standby_status_remains_stale(self) -> None:
+        """An idle overlay does not replace a newly accepted clean."""
+        client = NarwalClient("10.0.0.1")
+        client.state.working_status = WorkingStatus.CLEANING
+        client._last_active_working_status_time = 100.0
+
+        client._update_from_base_status_broadcast(
+            {"3": {"1": 1}, "11": 1, "47": 2}, now=101.0
+        )
+
+        assert client.state.working_status == WorkingStatus.CLEANING
+
     def test_commands_require_connection(self) -> None:
         client = NarwalClient("10.0.0.1")
         with pytest.raises(NarwalConnectionError):
             asyncio.run(client.start())
+
+    def test_idle_keepalive_renews_topic_subscription(self) -> None:
+        client = NarwalClient("10.0.0.1")
+        client._connected.set()
+        client._ws = AsyncMock()
+        client._robot_awake = True
+        client._TOPIC_RESUB_INTERVAL = -1
+
+        sleep_count = 0
+
+        async def stop_after_first_iteration(_delay: float) -> None:
+            nonlocal sleep_count
+            sleep_count += 1
+            if sleep_count == 2:
+                client._connected.clear()
+
+        with (
+            patch("narwal_client.client.asyncio.sleep", stop_after_first_iteration),
+            patch.object(client, "_state_needs_keepalive", return_value=False),
+        ):
+            asyncio.run(client._keepalive_loop())
+
+        client._ws.send.assert_awaited_once()
+
+    def test_idle_reconnect_subscribes_without_waking(self) -> None:
+        """An idle reconnect restores subscriptions without a wake burst."""
+        client = NarwalClient("10.0.0.1")
+
+        class EmptyWebSocket:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                client._should_reconnect = False
+                raise StopAsyncIteration
+
+        async def connect() -> None:
+            client._ws = EmptyWebSocket()
+            client._connected.set()
+
+        client.connect = AsyncMock(side_effect=connect)
+        client.subscribe_to_topics = AsyncMock()
+        client._send_wake_burst = AsyncMock()
+        client._heartbeat_loop = AsyncMock()
+        client._keepalive_loop = AsyncMock()
+
+        with patch.object(client, "_state_needs_keepalive", return_value=False):
+            asyncio.run(client.start_listening())
+
+        client.subscribe_to_topics.assert_awaited_once_with()
+        client._send_wake_burst.assert_not_awaited()
+
+    def test_stale_paused_overlay_does_not_wake_docked_robot(self) -> None:
+        """Dock fields override stale pause bits for keepalive decisions."""
+        client = NarwalClient("10.0.0.1")
+        client.state.working_status = WorkingStatus.CLEANING
+        client.state.is_paused = True
+        client.state.dock_field11 = 2
+        client.state.dock_field47 = 3
+
+        assert client.state.is_docked
+        assert not client._state_needs_keepalive()
 
     def test_send_raw_without_connection_raises(self) -> None:
         client = NarwalClient("10.0.0.1")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -34,12 +34,12 @@ class TestNarwalClientInit:
     def test_commands_require_connection(self) -> None:
         client = NarwalClient("10.0.0.1")
         with pytest.raises(NarwalConnectionError):
-            asyncio.get_event_loop().run_until_complete(client.start())
+            asyncio.run(client.start())
 
     def test_send_raw_without_connection_raises(self) -> None:
         client = NarwalClient("10.0.0.1")
         with pytest.raises(NarwalConnectionError):
-            asyncio.get_event_loop().run_until_complete(
+            asyncio.run(
                 client.send_raw("test/topic", b"\x08\x01")
             )
 
@@ -132,7 +132,7 @@ class TestStartLegacyAndV2Fallback:
             client, "send_command", new_callable=AsyncMock
         ) as mock_send:
             mock_send.return_value = success
-            result = asyncio.get_event_loop().run_until_complete(client.start())
+            result = asyncio.run(client.start())
 
         assert result is success
         mock_send.assert_awaited_once()  # no fallback fired
@@ -152,7 +152,7 @@ class TestStartLegacyAndV2Fallback:
             client, "send_command", new_callable=AsyncMock
         ) as mock_send:
             mock_send.side_effect = [not_applicable, success]
-            result = asyncio.get_event_loop().run_until_complete(client.start())
+            result = asyncio.run(client.start())
 
         assert mock_send.await_count == 2
         # Second call's payload must be v2 (different bytes from legacy)
@@ -173,7 +173,7 @@ class TestStartLegacyAndV2Fallback:
             client, "send_command", new_callable=AsyncMock
         ) as mock_send:
             mock_send.return_value = not_applicable
-            result = asyncio.get_event_loop().run_until_complete(client.start())
+            result = asyncio.run(client.start())
 
         mock_send.assert_awaited_once()  # no v2 retry without rooms
         assert result.result_code == CommandResult.NOT_APPLICABLE
@@ -189,7 +189,7 @@ class TestStartLegacyAndV2Fallback:
             client, "send_command", new_callable=AsyncMock
         ) as mock_send:
             mock_send.return_value = not_applicable
-            result = asyncio.get_event_loop().run_until_complete(client.start())
+            result = asyncio.run(client.start())
 
         mock_send.assert_awaited_once()
         assert result.result_code == CommandResult.NOT_APPLICABLE

--- a/tests/test_client_rooms.py
+++ b/tests/test_client_rooms.py
@@ -11,6 +11,7 @@ import pytest
 from narwal_client.client import NarwalClient, NarwalCommandError
 from narwal_client.const import (
     CommandResult,
+    CleaningRoute,
     FanLevel,
     MopHumidity,
     MopStrengthLevel,
@@ -87,6 +88,15 @@ class TestBuildStartCleanPayload:
         param = _items(_task(client._build_start_clean_payload([2], 1)))[0]["2"]
         assert "8" not in param
 
+    def test_route_encoded_when_requested(self) -> None:
+        """Route overlap is encoded in CleanParam tag 8."""
+        client = NarwalClient("127.0.0.1")
+        payload = client._build_start_clean_payload(
+            [2], 1, route=CleaningRoute.METICULOUS,
+        )
+        param = _items(_task(payload))[0]["2"]
+        assert param["8"] == CleaningRoute.METICULOUS
+
     def test_map_zone_and_order(self) -> None:
         """map_id, room zone refs, and 1-based order encode correctly."""
         client = NarwalClient("127.0.0.1")
@@ -124,6 +134,7 @@ class TestStartRooms:
             _run(client.start_rooms(
                 [5], work_mode=WorkMode.MOP, fan=FanLevel.STRONG,
                 water=MopHumidity.DRY, mop_strength=MopStrengthLevel.HIGH, passes=3,
+                route=CleaningRoute.METICULOUS,
             ))
         mock_send.assert_awaited_once()
         param = _items(_task(mock_send.await_args.kwargs["payload"]))[0]["2"]
@@ -132,6 +143,7 @@ class TestStartRooms:
         assert param["3"] == MopStrengthLevel.HIGH
         assert param["4"] == MopHumidity.DRY
         assert param["6"] == 3  # mopTime pass count
+        assert param["8"] == CleaningRoute.METICULOUS
 
     def test_defaults_match_documented_clean(self) -> None:
         """Default room cleaning uses max suction and wet mopping."""

--- a/tests/test_client_rooms.py
+++ b/tests/test_client_rooms.py
@@ -1,195 +1,350 @@
-"""Tests for narwal_client room-specific clean payload and start_rooms."""
+"""Tests for the room-clean payload (_build_start_clean_payload) and start_rooms."""
 
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import blackboxprotobuf
 import pytest
 
-from narwal_client.client import NarwalClient
-from narwal_client.const import CommandResult
+from narwal_client.client import NarwalClient, NarwalCommandError
+from narwal_client.const import (
+    CommandResult,
+    FanLevel,
+    MopHumidity,
+    MopStrengthLevel,
+    WorkMode,
+)
 from narwal_client.models import CommandResponse
 
 
-class TestBuildRoomCleanPayload:
-    """Tests for _build_room_clean_payload protobuf encoding."""
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
-    def test_single_room_encodes_room_id_and_params(self) -> None:
-        """Single room has roomId + clean params in field 1.2."""
-        import blackboxprotobuf
 
+def _task(payload: bytes) -> dict:
+    """Decode a StartClean payload to its CleanTask (field 1)."""
+    decoded, _ = blackboxprotobuf.decode_message(payload)
+    return decoded["1"]
+
+
+def _items(task: dict) -> list[dict]:
+    items = task["2"]
+    return items if isinstance(items, list) else [items]
+
+
+# WorkMode -> (expected taskType, expected CleanParam.mode, expected pass tags)
+_MODE_EXPECT = {
+    WorkMode.VACUUM: (1, 2, {"5"}),
+    WorkMode.MOP: (2, 3, {"6"}),
+    WorkMode.VACUUM_THEN_MOP: (3, 5, {"5", "6"}),
+    WorkMode.VACUUM_AND_MOP: (4, 4, {"7"}),
+}
+
+
+class TestBuildStartCleanPayload:
+    """The CleanTask/CleanParam encoding."""
+
+    def test_legacy_fan_level_names_remain_available(self) -> None:
+        """External client users keep the original QUIET and MAX names."""
+        assert FanLevel.QUIET is FanLevel.MUTE
+        assert FanLevel.MAX is FanLevel.DEEP
+
+    def test_task_type_and_param_mode_per_mode(self) -> None:
+        """taskType (the carrier) and CleanParam.mode/pass-tags follow work_mode."""
         client = NarwalClient("127.0.0.1")
-        payload = client._build_room_clean_payload([11])
-        decoded, _ = blackboxprotobuf.decode_message(payload)
+        for mode, (task_type, param_mode, pass_tags) in _MODE_EXPECT.items():
+            payload = client._build_start_clean_payload([2], 1, work_mode=mode, passes=2)
+            task = _task(payload)
+            assert task["5"] == task_type, f"taskType for {mode.name}"
+            param = _items(task)[0]["2"]
+            assert param["1"] == param_mode, f"CleanParam.mode for {mode.name}"
+            for tag in pass_tags:
+                assert param[tag] == 2, f"pass tag {tag} for {mode.name}"
+            for tag in {"5", "6", "7"} - pass_tags:
+                assert tag not in param, f"unexpected pass tag {tag} for {mode.name}"
 
-        field1_2 = decoded["1"]["2"]
-        # Single room: field 1.2.1 = roomId
-        assert field1_2["1"] == 11
-        # Per-room clean params must be present (robot ignores bare roomId)
-        assert field1_2["2"] == 2, "cleanMode should be 2 (sweep+mop)"
-        assert field1_2["3"] == 1, "cleanTimes should be 1"
-        assert field1_2["6"] == 3, "sweepMode should be 3 (max suction)"
-        assert field1_2["7"] == 2, "mopMode should be 2 (wet)"
-
-    def test_multiple_rooms_encodes_all(self) -> None:
-        """Multiple rooms encode as repeated messages in field 1.2."""
-        import blackboxprotobuf
-
+    def test_fan_water_strength_encoded(self) -> None:
+        """fan/water/mop_strength land in their CleanParam tags."""
         client = NarwalClient("127.0.0.1")
-        payload = client._build_room_clean_payload([11, 9])
-        decoded, _ = blackboxprotobuf.decode_message(payload)
+        payload = client._build_start_clean_payload(
+            [2], 1, work_mode=WorkMode.MOP,
+            fan=FanLevel.DEEP, water=MopHumidity.WET, mop_strength=MopStrengthLevel.HIGH,
+        )
+        param = _items(_task(payload))[0]["2"]
+        assert param["2"] == FanLevel.DEEP
+        assert param["4"] == MopHumidity.WET
+        assert param["3"] == MopStrengthLevel.HIGH
 
-        field1_2 = decoded["1"]["2"]
-        assert isinstance(field1_2, list), "Multiple rooms should be a list"
-        room_ids = [entry["1"] for entry in field1_2]
-        assert 11 in room_ids
-        assert 9 in room_ids
-        # Each entry has clean params
-        for entry in field1_2:
-            assert entry["2"] == 2, "cleanMode"
-            assert entry["6"] == 3, "sweepMode"
-
-    def test_preserves_global_clean_settings(self) -> None:
-        """Payload preserves suction=3, mop=2, passes=1 in field 1.5."""
-        import blackboxprotobuf
-
+    def test_overlap_not_sent(self) -> None:
+        """overlapLevel (tag 8) is omitted — live-validated as ignored."""
         client = NarwalClient("127.0.0.1")
-        payload = client._build_room_clean_payload([11])
-        decoded, _ = blackboxprotobuf.decode_message(payload)
+        param = _items(_task(client._build_start_clean_payload([2], 1)))[0]["2"]
+        assert "8" not in param
 
-        settings = decoded["1"]["5"]["1"]
-        assert settings["1"] == 3, "Suction should be 3 (max)"
-        assert settings["2"] == 2, "Mop humidity should be 2 (wet)"
-        assert settings["3"] == 1, "Passes should be 1 (single)"
-
-    def test_empty_room_ids_returns_default(self) -> None:
-        """Empty room list returns the default whole-house payload."""
+    def test_map_zone_and_order(self) -> None:
+        """map_id, room zone refs, and 1-based order encode correctly."""
         client = NarwalClient("127.0.0.1")
-        payload = client._build_room_clean_payload([])
-        assert payload == client._DEFAULT_CLEAN_PAYLOAD
-
-    def test_room_payload_differs_from_default(self) -> None:
-        """Room-specific payload is different from whole-house default."""
-        client = NarwalClient("127.0.0.1")
-        room_payload = client._build_room_clean_payload([11])
-        assert room_payload != client._DEFAULT_CLEAN_PAYLOAD
-        assert len(room_payload) > 0
+        task = _task(client._build_start_clean_payload([2, 12], 7))
+        assert task["1"] == 7
+        items = _items(task)
+        assert [it["1"]["2"] for it in items] == [2, 12]
+        assert all(it["1"]["1"] == 1 for it in items)  # zoneType = ROOM
+        assert [it["3"] for it in items] == [1, 2]
 
 
 class TestStartRooms:
-    """Tests for start_rooms async method."""
+    """start_rooms dispatch and settings threading."""
+
+    def _client(self) -> NarwalClient:
+        client = NarwalClient("127.0.0.1")
+        client._ws = AsyncMock()
+        client.state.device_info = MagicMock(product_key="QoEsI5qYXO")
+        client.state.map_data = MagicMock(map_id=1)
+        return client
 
     def test_empty_rooms_calls_start(self) -> None:
         """start_rooms([]) falls back to whole-house start()."""
-        client = NarwalClient("127.0.0.1")
-        client._ws = AsyncMock()  # fake connected state
-        client._connected = True
-
+        client = self._client()
         with patch.object(client, "start", new_callable=AsyncMock) as mock_start:
-            mock_start.return_value = AsyncMock()
-            asyncio.get_event_loop().run_until_complete(client.start_rooms([]))
+            _run(client.start_rooms([]))
             mock_start.assert_awaited_once()
 
-    def test_room_ids_sends_room_payload(self) -> None:
-        """start_rooms with IDs sends room-specific payload via send_command."""
-        client = NarwalClient("127.0.0.1")
-        client._ws = AsyncMock()
-        client._connected = True
+    def test_forwards_settings_to_payload(self) -> None:
+        """Settings passed to start_rooms reach the encoded CleanTask."""
+        client = self._client()
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = success
+            _run(client.start_rooms(
+                [5], work_mode=WorkMode.MOP, fan=FanLevel.STRONG,
+                water=MopHumidity.DRY, mop_strength=MopStrengthLevel.HIGH, passes=3,
+            ))
+        mock_send.assert_awaited_once()
+        param = _items(_task(mock_send.await_args.kwargs["payload"]))[0]["2"]
+        assert param["1"] == 3  # CleanParam.mode MOP
+        assert param["2"] == FanLevel.STRONG
+        assert param["3"] == MopStrengthLevel.HIGH
+        assert param["4"] == MopHumidity.DRY
+        assert param["6"] == 3  # mopTime pass count
 
+    def test_defaults_match_documented_clean(self) -> None:
+        """Default room cleaning uses max suction and wet mopping."""
+        client = self._client()
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = success
+            _run(client.start_rooms([5]))
+
+        param = _items(_task(mock_send.await_args.kwargs["payload"]))[0]["2"]
+        assert param["2"] == FanLevel.DEEP
+        assert param["4"] == MopHumidity.WET
+
+    def test_no_map_id_uses_legacy_fallback(self) -> None:
+        """No active map id skips start_clean but retains the legacy path."""
+        client = self._client()
+        client.state.device_info = MagicMock(product_key="QoEsI5qYXO")
+        client.state.map_data = MagicMock(map_id=0)
+        with patch.object(client, "get_map", new_callable=AsyncMock) as mock_get_map, \
+             patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_get_map.return_value = MagicMock(map_id=0)
+            mock_send.return_value = CommandResponse(result_code=CommandResult.SUCCESS)
+            result = _run(client.start_rooms([5]))
+        mock_send.assert_awaited_once()
+        assert mock_send.await_args.args[0] == "clean/plan/start"
+        assert result.result_code == CommandResult.SUCCESS
+
+    def test_map_fetch_failure_uses_legacy_fallback(self) -> None:
+        """A sleeping robot can still receive the legacy cached-room command."""
+        client = self._client()
+        client.state.device_info = MagicMock(product_key="QoEsI5qYXO")
+        client.state.map_data = None
         success = CommandResponse(result_code=CommandResult.SUCCESS)
         with patch.object(
-            client, "send_command", new_callable=AsyncMock
+            client,
+            "get_map",
+            new_callable=AsyncMock,
+            side_effect=NarwalCommandError("timeout"),
+        ), patch.object(
+            client, "send_command", new_callable=AsyncMock, return_value=success
         ) as mock_send:
-            mock_send.return_value = success
-            asyncio.get_event_loop().run_until_complete(client.start_rooms([11, 9]))
-            mock_send.assert_awaited_once()
-            payload_arg = mock_send.await_args.kwargs.get("payload")
-            assert payload_arg is not None
-            assert payload_arg != client._DEFAULT_CLEAN_PAYLOAD
-
-
-class TestStartRoomsV2First:
-    """Tests for the v2-first schema order in start_rooms (#37 fix).
-
-    start_rooms() now tries v2 nested-room schema first (fixes ack-and-ignore
-    on newer firmware), falling back to legacy flat-room on NOT_APPLICABLE.
-    """
-
-    def _connected_client(self) -> NarwalClient:
-        client = NarwalClient("127.0.0.1")
-        client._ws = AsyncMock()
-        client._connected = True
-        return client
-
-    def test_success_on_v2_does_not_retry(self) -> None:
-        """If the v2 room payload is accepted, no legacy retry happens."""
-        client = self._connected_client()
-        success = CommandResponse(result_code=CommandResult.SUCCESS)
-
-        with patch.object(
-            client, "send_command", new_callable=AsyncMock
-        ) as mock_send:
-            mock_send.return_value = success
-            result = asyncio.get_event_loop().run_until_complete(
-                client.start_rooms([5])
-            )
+            result = _run(client.start_rooms([5]))
 
         assert result is success
         mock_send.assert_awaited_once()
+        assert mock_send.await_args.args[0] == "clean/plan/start"
 
-    def test_v2_sends_correct_room_ids(self) -> None:
-        """v2 payload encodes exactly the requested rooms."""
-        client = self._connected_client()
-        success = CommandResponse(result_code=CommandResult.SUCCESS)
-
+    def test_flow2_map_fetch_failure_does_not_start_legacy_clean(self) -> None:
+        """A missing Flow 2 map cannot fall back to an unsafe whole-home clean."""
+        client = self._client()
+        client.state.device_info = MagicMock(product_key="QxMSPG6VSO")
+        client.state.map_data = None
         with patch.object(
-            client, "send_command", new_callable=AsyncMock
-        ) as mock_send:
-            mock_send.return_value = success
-            asyncio.get_event_loop().run_until_complete(
-                client.start_rooms([5, 7])
-            )
+            client,
+            "get_map",
+            new_callable=AsyncMock,
+            side_effect=NarwalCommandError("timeout"),
+        ), patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            try:
+                _run(client.start_rooms([5]))
+            except NarwalCommandError:
+                pass
+            else:
+                raise AssertionError("Flow 2 map failure should surface to the caller")
 
-        import blackboxprotobuf
-        payload = mock_send.await_args.kwargs.get("payload")
-        decoded, _ = blackboxprotobuf.decode_message(payload)
-        entries = decoded["1"]["2"]
-        ids = [e["1"]["2"] for e in entries]
-        assert ids == [5, 7]
+        mock_send.assert_not_awaited()
 
-    def test_not_applicable_triggers_legacy_retry(self) -> None:
-        """NOT_APPLICABLE on v2 triggers a legacy flat-room retry."""
-        client = self._connected_client()
-        not_applicable = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+    def test_super_live_fan_uses_highest_supported_level(self) -> None:
+        """The live command never reports an unavailable SUPER level."""
+        client = self._client()
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            _run(client.set_fan_speed(FanLevel.SUPER))
+
+        assert mock_send.await_args.args[0] == "clean/set_fan_level"
+        assert mock_send.await_args.args[1] == b"\x08\x04"
+
+    @pytest.mark.parametrize(
+        ("legacy_level", "wire_level"),
+        ((0, 1), (1, 2), (2, 3), (3, 4)),
+    )
+    def test_live_fan_preserves_legacy_integer_levels(
+        self, legacy_level: int, wire_level: int
+    ) -> None:
+        client = self._client()
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            _run(client.set_fan_speed(legacy_level))
+
+        assert mock_send.await_args.args[1] == bytes((0x08, wire_level))
+
+    @pytest.mark.parametrize(
+        ("legacy_level", "wire_level"),
+        ((0, 1), (1, 2), (2, 3)),
+    )
+    def test_live_mop_preserves_legacy_integer_levels(
+        self, legacy_level: int, wire_level: int
+    ) -> None:
+        client = self._client()
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            _run(client.set_mop_humidity(legacy_level))
+
+        assert mock_send.await_args.args[1] == bytes((0x08, wire_level))
+
+    def test_not_ready_retries_while_docked(self) -> None:
+        """NOT_READY on the dock retries clean/start_clean (dock settling)."""
+        client = self._client()
+        client.state.update_from_base_status({"3": {"1": 10, "10": 1}})  # docked
+        assert client.state.is_docked
+        not_ready = CommandResponse(result_code=CommandResult.NOT_READY)
         success = CommandResponse(result_code=CommandResult.SUCCESS)
-
-        with patch.object(
-            client, "send_command", new_callable=AsyncMock
-        ) as mock_send:
-            mock_send.side_effect = [not_applicable, success]
-            result = asyncio.get_event_loop().run_until_complete(
-                client.start_rooms([5, 7])
-            )
-
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send, \
+             patch("narwal_client.client.asyncio.sleep", new_callable=AsyncMock):
+            mock_send.side_effect = [not_ready, success]
+            result = _run(client.start_rooms([5]))
         assert mock_send.await_count == 2
-        v2_payload = mock_send.await_args_list[0].kwargs.get("payload")
-        legacy_payload = mock_send.await_args_list[1].kwargs.get("payload")
-        assert v2_payload != legacy_payload
         assert result is success
 
-    def test_conflict_does_not_trigger_retry(self) -> None:
-        """A CONFLICT response (robot busy) surfaces as-is — no retry."""
-        client = self._connected_client()
+    def test_not_ready_off_dock_does_not_retry(self) -> None:
+        """NOT_READY off the dock surfaces as-is — start_clean needs the dock."""
+        client = self._client()
+        assert not client.state.is_docked
+        not_ready = CommandResponse(result_code=CommandResult.NOT_READY)
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = not_ready
+            result = _run(client.start_rooms([5]))
+        mock_send.assert_awaited_once()
+        assert result.result_code == CommandResult.NOT_READY
+
+    def test_conflict_surfaces_without_retry(self) -> None:
+        """A CONFLICT response (robot busy) is returned as-is."""
+        client = self._client()
         conflict = CommandResponse(result_code=CommandResult.CONFLICT)
-
-        with patch.object(
-            client, "send_command", new_callable=AsyncMock
-        ) as mock_send:
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
             mock_send.return_value = conflict
-            result = asyncio.get_event_loop().run_until_complete(
-                client.start_rooms([5])
-            )
-
+            result = _run(client.start_rooms([5]))
         mock_send.assert_awaited_once()
         assert result.result_code == CommandResult.CONFLICT
+
+    def test_not_applicable_falls_back_to_plan_start(self) -> None:
+        """Older firmware retains the clean/plan/start compatibility path."""
+        client = self._client()
+        not_applicable = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.side_effect = [not_applicable, success]
+            result = _run(client.start_rooms([5]))
+
+        assert result is success
+        assert mock_send.await_count == 2
+        assert mock_send.await_args_list[0].args[0] == "clean/start_clean"
+        assert mock_send.await_args_list[1].args[0] == "clean/plan/start"
+
+    def test_flow2_rejection_does_not_start_legacy_clean(self) -> None:
+        """Flow 2 never falls back to plan/start whole-home behaviour."""
+        client = self._client()
+        client.state.device_info = MagicMock(product_key="QxMSPG6VSO")
+        not_applicable = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = not_applicable
+            result = _run(client.start_rooms([5]))
+
+        assert result is not_applicable
+        mock_send.assert_awaited_once()
+
+    def test_legacy_fallback_translates_water_level(self) -> None:
+        """CleanParam wet maps to the legacy plan/start wet value."""
+        client = self._client()
+        not_applicable = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.side_effect = [not_applicable, success]
+            _run(client.start_rooms([5], water=MopHumidity.WET))
+
+        legacy_payload = mock_send.await_args_list[1].kwargs["payload"]
+        decoded, _ = blackboxprotobuf.decode_message(legacy_payload)
+        assert decoded["1"]["2"]["2"]["7"] == 2
+
+    def test_legacy_fallback_translates_fan_level(self) -> None:
+        """Flow 2 suction levels stay within the legacy plan/start range."""
+        client = self._client()
+        not_applicable = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.side_effect = [not_applicable, success]
+            _run(client.start_rooms([5], fan=FanLevel.SUPER))
+
+        legacy_payload = mock_send.await_args_list[1].kwargs["payload"]
+        decoded, _ = blackboxprotobuf.decode_message(legacy_payload)
+        assert decoded["1"]["2"]["2"]["1"] == 3
+
+    def test_legacy_fallback_translates_strong_fan_level(self) -> None:
+        """CleanParam strong maps to the legacy strong value."""
+        client = self._client()
+        not_applicable = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.side_effect = [not_applicable, success]
+            _run(client.start_rooms([5], fan=FanLevel.STRONG))
+
+        legacy_payload = mock_send.await_args_list[1].kwargs["payload"]
+        decoded, _ = blackboxprotobuf.decode_message(legacy_payload)
+        assert decoded["1"]["2"]["2"]["1"] == 2
+
+    def test_both_new_payloads_rejected_use_legacy_payload(self) -> None:
+        """Older firmware receives the legacy flat-room payload last."""
+        client = self._client()
+        not_applicable = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.side_effect = [not_applicable, not_applicable, success]
+            result = _run(client.start_rooms([5]))
+
+        assert result is success
+        assert mock_send.await_count == 3
+        legacy_payload = mock_send.await_args_list[2].kwargs["payload"]
+        decoded, _ = blackboxprotobuf.decode_message(legacy_payload)
+        assert decoded["1"]["2"]["1"] == 5

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -101,7 +101,7 @@ class TestNarwalConfigFlow:
         flow.async_show_form.assert_called_once()
         call_kwargs = flow.async_show_form.call_args.kwargs
         assert call_kwargs["errors"] == {"base": "cannot_connect"}
-        mock_client.disconnect.assert_awaited_once()
+        assert mock_client.disconnect.await_count == 2
 
     async def test_duplicate_device_aborts(self) -> None:
         """async_step_user with duplicate unique_id aborts with already_configured."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import struct
+import time
+import zlib
 
 from narwal_client.const import WorkingStatus
 from narwal_client.models import (
@@ -54,13 +56,27 @@ class TestNarwalState:
         assert not state.is_returning
 
     def test_update_from_working_status(self) -> None:
-        """working_status topic sets cleaning metrics, not robot state."""
+        """working_status topic sets cleaning metrics and infers active cleaning."""
         state = NarwalState()
         state.update_from_working_status({"3": 120, "13": 18000, "15": 600})
         assert state.cleaning_time == 120
         assert state.cleaning_area == 18000
-        # working_status is NOT set by this method (comes from base_status)
-        assert state.working_status == WorkingStatus.UNKNOWN
+        assert state.working_status == WorkingStatus.CLEANING
+
+    def test_working_status_clears_stale_station_activity(self) -> None:
+        """A fresh clean must override stale dock-side activity."""
+        state = NarwalState(
+            working_status=WorkingStatus.DOCKED,
+            dock_sub_state=1,
+            station_activity=4,
+        )
+
+        state.update_from_working_status({"3": 120, "13": 18000})
+
+        assert state.working_status == WorkingStatus.CLEANING
+        assert state.station_activity == 0
+        assert state.is_cleaning
+        assert not state.is_docked
 
     def test_update_from_base_status_cleaning(self) -> None:
         state = NarwalState()
@@ -142,6 +158,22 @@ class TestNarwalState:
         assert state.working_status == WorkingStatus.STANDBY
         assert state.is_docked
 
+    def test_update_from_base_status_station_activity(self) -> None:
+        """field3.18 means station-side work is active."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 19, "18": 4}})
+        assert state.station_activity == 4
+        assert state.is_station_active
+        assert state.is_docked
+
+    def test_station_activity_resets_when_absent(self) -> None:
+        """field3.18 resets when later base status omits it."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 19, "18": 4}})
+        state.update_from_base_status({"3": {"1": 1, "3": 1}})
+        assert state.station_activity == 0
+        assert not state.is_station_active
+
     def test_update_from_base_status_paused(self) -> None:
         """Paused overlay: field 3 sub-field 2 = 1."""
         state = NarwalState()
@@ -168,6 +200,37 @@ class TestNarwalState:
         # Should not raise — unknown sub-fields logged at debug level
         state.update_from_base_status({"3": {"1": 2, "4": 99, "11": 3}})
         assert state.working_status == WorkingStatus.DOCKED_V2
+
+    def test_off_dock_fields_clear_stale_dock_subfields(self) -> None:
+        """Flow 2 off-dock fields override dock subfields omitted by new firmware."""
+        state = NarwalState()
+        state.update_from_base_status(
+            {"3": {"1": 10, "10": 1, "12": 2}, "11": 2, "47": 3}
+        )
+        assert state.is_docked
+
+        state.update_from_base_status(
+            {"3": {"1": 3, "4": 7}, "11": 1, "47": 2}
+        )
+
+        assert state.dock_sub_state == 0
+        assert state.dock_activity == 0
+        assert state.is_cleaning
+        assert not state.is_docked
+
+    def test_active_status_clears_stale_dock_subfields(self) -> None:
+        """An active status clears dock fields omitted by Flow 2 firmware."""
+        state = NarwalState()
+        state.update_from_base_status(
+            {"3": {"1": 10, "10": 1, "12": 2}, "11": 2, "47": 3}
+        )
+
+        state.update_from_base_status({"3": {"1": 3, "4": 7}})
+
+        assert state.dock_sub_state == 0
+        assert state.dock_activity == 0
+        assert state.is_cleaning
+        assert not state.is_docked
 
     def test_new_fw_dock_field11_gte2(self) -> None:
         """v01.07.23 dock_field11=3 detected as docked via >= 2 check."""
@@ -246,6 +309,50 @@ class TestNarwalState:
         state.update_from_download_status({"1": 2})
         assert state.download_status == 2
 
+    def test_update_from_robot_task_status(self) -> None:
+        """Polled and broadcast task status expose progress and room."""
+        for topic in ("robot/task/status/get", "robot/task/status"):
+            state = NarwalState()
+            state.update_from_aux_status(
+                topic,
+                {
+                    "1": 1,
+                    "2": {
+                        "1": 93,
+                        "2": 694,
+                        "6": {"1": 5, "2": 1, "3": "Landing"},
+                    },
+                },
+            )
+            assert state.task_progress_percent == 93
+            assert state.task_elapsed_time == 694
+            assert state.current_room_id == 5
+            assert state.current_room_name == "Landing"
+
+    def test_update_from_robot_task_status_decodes_room_name(self) -> None:
+        """Task room names are decoded from protobuf bytes."""
+        state = NarwalState()
+
+        state.update_from_aux_status(
+            "robot/task/status",
+            {"2": {"1": 42, "6": {"1": 5, "3": b"Landing"}}},
+        )
+
+        assert state.current_room_name == "Landing"
+
+    def test_task_room_uses_current_map_display_name(self) -> None:
+        """Task telemetry uses the current user-facing map room name."""
+        state = NarwalState(
+            map_data=MapData(rooms=[RoomInfo(room_id=6, name="Bathroom")])
+        )
+
+        state.update_from_aux_status(
+            "robot/task/status",
+            {"2": {"1": 42, "6": {"1": 6, "3": "浴室"}}},
+        )
+
+        assert state.current_room_name == "Bathroom"
+
     def test_incremental_updates(self) -> None:
         """State should accumulate across multiple topic updates."""
         state = NarwalState()
@@ -264,6 +371,12 @@ class TestNarwalState:
         raw = {"2": _float_to_uint32(100.0), "38": 100, "47": 2, "unknown_field": "value"}
         state.update_from_base_status(raw)
         assert state.raw_base_status == raw
+
+    def test_aux_status_preserved(self) -> None:
+        state = NarwalState()
+        raw = {"1": {"2": 40}, "3": 120}
+        state.update_from_aux_status("status/robot", raw)
+        assert state.raw_aux_status["status/robot"] == raw
 
     def test_battery_field2_float32_83(self) -> None:
         """Field 2 = 1118175232 → 83.0% battery (confirmed from monitor capture)."""
@@ -322,11 +435,107 @@ class TestNarwalState:
         assert state.working_status == WorkingStatus.DOCKED  # NOT overwritten
         assert state.is_docked  # still correct
 
+    def test_repeated_stale_working_status_does_not_refresh_activity(self) -> None:
+        """Unchanged working_status counters are stale, not active cleaning."""
+        state = NarwalState()
+        state.update_from_base_status({
+            "3": {"1": 4},
+            "11": 1,
+            "47": 2,
+            "2": _float_to_uint32(80.0),
+        })
+        state.update_from_working_status({"3": 120, "13": 18000})
+        assert state.has_recent_active_working_status
+
+        state.last_active_working_status_time = time.monotonic() - 20
+        state.update_from_working_status({"3": 120, "13": 18000})
+
+        assert not state.has_recent_active_working_status
+
+    def test_explicit_docked_status_ends_recent_activity(self) -> None:
+        """A terminal base status wins immediately over recent task counters."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 4}, "11": 1, "47": 2})
+        state.update_from_working_status({"3": 120, "13": 18000})
+        assert state.has_recent_active_working_status
+
+        state.update_from_base_status({"3": {"1": 10}, "11": 2, "47": 3})
+
+        assert not state.has_recent_active_working_status
+        assert state.is_docked
+        assert not state.is_cleaning
+
+    def test_rising_battery_infers_stale_cleaning_is_docked(self) -> None:
+        """A rising battery after stale cleaning telemetry means charging/docked."""
+        state = NarwalState()
+        state.update_from_base_status({
+            "3": {"1": 4},
+            "11": 1,
+            "47": 2,
+            "2": _float_to_uint32(80.0),
+        })
+        state.update_from_working_status({"3": 120, "13": 18000})
+        state.last_active_working_status_time = time.monotonic() - 20
+
+        state.update_battery_from_base_status({"2": _float_to_uint32(81.0)})
+
+        assert state.inferred_docked_from_battery
+        assert state.is_docked
+        assert not state.is_cleaning
+
+    def test_explicit_off_dock_status_clears_inferred_docked_state(self) -> None:
+        """Fresh off-dock fields override battery-based dock inference."""
+        state = NarwalState(inferred_docked_from_battery=True)
+
+        state.update_from_base_status({"3": {"1": 4}, "11": 1, "47": 2})
+
+        assert not state.inferred_docked_from_battery
+        assert not state.is_docked
+
+    def test_explicit_off_dock_status_wins_over_rising_battery(self) -> None:
+        """Battery inference cannot override off-dock fields in the same packet."""
+        state = NarwalState(
+            working_status=WorkingStatus.CLEANING,
+            battery_level=80,
+        )
+
+        state.update_from_base_status(
+            {"3": {"1": 4}, "11": 1, "47": 2, "2": _float_to_uint32(81.0)}
+        )
+
+        assert not state.inferred_docked_from_battery
+        assert not state.is_docked
+
+    def test_dock_fields_override_stale_task_completed_status(self) -> None:
+        """Flow 2 can report TASK_COMPLETED while dock fields already say docked."""
+        state = NarwalState()
+        state.update_from_base_status({
+            "3": {"1": 4},
+            "11": 1,
+            "47": 2,
+            "2": _float_to_uint32(80.0),
+        })
+        state.update_from_working_status({"3": 120, "13": 18000})
+        state.last_active_working_status_time = time.monotonic() - 20
+
+        state.update_from_base_status({
+            "3": {"1": 19, "18": 4},
+            "11": 2,
+            "47": 3,
+            "2": _float_to_uint32(82.0),
+        })
+
+        assert state.working_status == WorkingStatus.TASK_COMPLETED
+        assert state.is_docked
+        assert not state.is_cleaning
+
     def test_returning_to_dock_field7(self) -> None:
         """Field 3.7=1 indicates returning to dock (confirmed live)."""
         state = NarwalState()
         # Live data: {1=4, 7=1, 10=2} — CLEANING + returning + docking
-        state.update_from_base_status({"3": {"1": 4, "7": 1, "10": 2}})
+        state.update_from_base_status(
+            {"3": {"1": 4, "7": 1, "10": 2}, "11": 1, "47": 2}
+        )
         assert state.working_status == WorkingStatus.CLEANING
         assert state.is_returning_to_dock
         assert state.dock_sub_state == 2
@@ -380,6 +589,17 @@ def _float_to_uint32(f: float) -> int:
 
 class TestMapData:
     """Tests for MapData.from_response()."""
+
+    def test_unassigned_obstacles_are_not_cleanable_floor(self) -> None:
+        """Whole-map estimates exclude unassigned obstacle pixels."""
+        map_data = MapData(
+            width=2,
+            height=1,
+            resolution=10,
+            compressed_map=zlib.compress(bytes([0x0A, 0x02, 0x20, 0x28])),
+        )
+
+        assert map_data.cleanable_area_cm2() == 1
 
     def test_basic_map_parsing(self) -> None:
         decoded = {"2": {
@@ -630,10 +850,13 @@ class TestRoomInfoModelOverrides:
 
     def test_flow_2_overrides_apply(self) -> None:
         """Flow 2 product key renames sub-types 1, 5, 10."""
-        flow2 = "QxMSPG6VSO"
-        assert RoomInfo(room_sub_type=1, model_key=flow2).display_name == "Master Bedroom"
-        assert RoomInfo(room_sub_type=5, model_key=flow2).display_name == "Bathroom"
-        assert RoomInfo(room_sub_type=10, model_key=flow2).display_name == "Corridor"
+        for flow2 in ("QxMSPG6VSO", "iSuVlI1If2"):
+            assert (
+                RoomInfo(room_sub_type=1, model_key=flow2).display_name
+                == "Master Bedroom"
+            )
+            assert RoomInfo(room_sub_type=5, model_key=flow2).display_name == "Bathroom"
+            assert RoomInfo(room_sub_type=10, model_key=flow2).display_name == "Corridor"
 
     def test_flow_2_non_overridden_types_use_defaults(self) -> None:
         """Sub-types not in the Flow 2 override map use the base names."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,6 +14,33 @@ from narwal_client.models import (
 )
 
 
+def test_map_data_preserves_existing_positional_arguments() -> None:
+    room = RoomInfo(room_id=7)
+    obstacle = ObstacleInfo(id=1)
+
+    map_data = MapData(
+        10,
+        20,
+        5,
+        [room],
+        b"map",
+        200,
+        1234,
+        1.5,
+        2.5,
+        3,
+        4,
+        [obstacle],
+        {"source": "test"},
+    )
+
+    assert map_data.width == 10
+    assert map_data.height == 20
+    assert map_data.rooms == [room]
+    assert map_data.raw == {"source": "test"}
+    assert map_data.map_id == 0
+
+
 class TestNarwalState:
     """Tests for NarwalState data model."""
 

--- a/tests/test_vacuum_segments.py
+++ b/tests/test_vacuum_segments.py
@@ -17,6 +17,7 @@ import tests.ha_stubs  # noqa: E402
 tests.ha_stubs.install()
 
 from narwal_client.models import MapData, NarwalState, RoomInfo  # noqa: E402
+from narwal_client.const import WorkingStatus  # noqa: E402
 from custom_components.narwal.vacuum import NarwalVacuum  # noqa: E402
 
 # Grab Segment class from stubs for assertions
@@ -193,6 +194,41 @@ class TestAsyncCleanSegments:
         await vac.async_clean_segments(["11", "9"])
 
         vac.coordinator.client.start_rooms.assert_awaited_once_with([11, 9])
+
+
+class TestAsyncStart:
+    """Tests for starting and resuming cleans."""
+
+    async def test_docked_stale_pause_starts_new_clean(self) -> None:
+        """A stale paused status on the dock must not resume an old task."""
+        state = NarwalState()
+        state.working_status = WorkingStatus.CLEANING
+        state.is_paused = True
+        state.dock_sub_state = 1
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start = AsyncMock(
+            return_value=MagicMock(result_code=1, success=True)
+        )
+        vac.coordinator.client.resume = AsyncMock()
+
+        await vac.async_start()
+
+        vac.coordinator.client.start.assert_awaited_once()
+        vac.coordinator.client.resume.assert_not_awaited()
+
+
+class TestVacuumActivity:
+    """Tests for derived vacuum activity."""
+
+    def test_docked_state_wins_over_stale_pause(self) -> None:
+        """Stale cleaning and pause fields must not hide a docked robot."""
+        state = NarwalState()
+        state.working_status = WorkingStatus.CLEANING_FLOW2
+        state.is_paused = True
+        state.dock_sub_state = 1
+
+        assert _make_vacuum(state=state).activity == "docked"
 
 
 class TestCheckSegmentChanges:

--- a/tests/test_vacuum_segments.py
+++ b/tests/test_vacuum_segments.py
@@ -51,6 +51,20 @@ def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
     return vac
 
 
+class TestFanSpeed:
+    """Live suction controls expose only levels accepted by the robot."""
+
+    async def test_max_alias_reports_highest_live_level(self) -> None:
+        """The legacy max alias reports the level actually sent."""
+        vac = _make_vacuum()
+        vac.coordinator.client.set_fan_speed = AsyncMock()
+
+        await vac.async_set_fan_speed("max")
+
+        vac.coordinator.client.set_fan_speed.assert_awaited_once()
+        assert vac._last_fan_speed == "Super powerful"
+
+
 class TestAsyncGetSegments:
     """Tests for async_get_segments."""
 


### PR DESCRIPTION
## What

Decode Flow 2 task and status details for reliable room, progress, station, and active-task state.

## Why

This keeps the Flow 2 behaviour local, explicit, and reviewable without mixing unrelated changes.

## Stack

Part 2 of 8.

Depends on https://github.com/sjmotew/NarwalIntegration/pull/58. The diff includes earlier stack commits until those land upstream.

## Validation

- Full stack: `300 passed`
- Home Assistant configuration check
- Live validation against two Narwal Flow 2 vacuums
