### PR TITLE
feat: add Narwal dock light entity

### DIFF
--- a/custom_components/narwal/const.py
+++ b/custom_components/narwal/const.py
@@ -2,7 +2,7 @@
 
 from homeassistant.const import Platform
 
-from .narwal_client import FanLevel
+from .narwal_client import AmbientLightCtrlType, FanLevel
 
 DOMAIN = "narwal"
 DEFAULT_PORT = 9002
@@ -32,7 +32,30 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
     Platform.CAMERA,
+    Platform.LIGHT,
 ]
+
+CONF_DOCK_LIGHT_SUPPORTED = "dock_light_supported"
+
+DOCK_LIGHT_PRODUCT_KEYS = {"QxMSPG6VSO", "iSuVlI1If2"}
+
+
+def is_dock_light_supported(data: dict, options: dict | None = None) -> bool:
+    """Return whether this configured model exposes dock ambient lighting."""
+    if options and CONF_DOCK_LIGHT_SUPPORTED in options:
+        return bool(options[CONF_DOCK_LIGHT_SUPPORTED])
+    return data.get(CONF_PRODUCT_KEY) in DOCK_LIGHT_PRODUCT_KEYS
+
+
+DOCK_LIGHT_MODES: dict[str, AmbientLightCtrlType] = {
+    "Off": AmbientLightCtrlType.OFF,
+    "Fireplace": AmbientLightCtrlType.WINTER_WARMTH,
+    "Nightlight": AmbientLightCtrlType.NIGHT_LIGHT,
+    "Purple": AmbientLightCtrlType.PURPLE_LIGHT,
+}
+DOCK_LIGHT_MODE_NAMES: dict[int, str] = {
+    int(value): key for key, value in DOCK_LIGHT_MODES.items()
+}
 
 FAN_SPEED_MAP: dict[str, FanLevel] = {
     "quiet": FanLevel.QUIET,

--- a/custom_components/narwal/light.py
+++ b/custom_components/narwal/light.py
@@ -1,0 +1,113 @@
+"""Light entities for Narwal dock lighting."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.light import (
+    ATTR_EFFECT,
+    ColorMode,
+    LightEntity,
+    LightEntityFeature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import NarwalConfigEntry
+from .const import DOCK_LIGHT_MODE_NAMES, DOCK_LIGHT_MODES, is_dock_light_supported
+from .coordinator import NarwalCoordinator
+from .entity import NarwalEntity
+from .narwal_client import CommandResult
+
+_EFFECTS = tuple(mode for mode in DOCK_LIGHT_MODES if mode != "Off")
+_DEFAULT_EFFECT = "Nightlight"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: NarwalConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Narwal dock light entities."""
+    if not is_dock_light_supported(entry.data, entry.options):
+        return
+    async_add_entities([NarwalDockLight(entry.runtime_data)])
+
+
+class NarwalDockLight(NarwalEntity, LightEntity):
+    """Narwal dock ambient light with app effects."""
+
+    _attr_translation_key = "dock_light"
+    _attr_icon = "mdi:led-strip-variant"
+    _attr_supported_features = LightEntityFeature.EFFECT
+    _attr_supported_color_modes = {ColorMode.ONOFF}
+    _attr_color_mode = ColorMode.ONOFF
+    _attr_effect_list = list(_EFFECTS)
+
+    def __init__(self, coordinator: NarwalCoordinator) -> None:
+        """Initialize the dock light."""
+        super().__init__(coordinator)
+        device_id = coordinator.config_entry.data["device_id"]
+        self._attr_unique_id = f"{device_id}_dock_light"
+        self._last_effect = _DEFAULT_EFFECT
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True when the dock light is on."""
+        mode = self._current_mode
+        if mode is None:
+            return None
+        return mode != "Off"
+
+    @property
+    def effect(self) -> str | None:
+        """Return the active dock light effect."""
+        mode = self._current_mode
+        if mode is None or mode == "Off":
+            return None
+        self._last_effect = mode
+        return mode
+
+    @property
+    def _current_mode(self) -> str | None:
+        """Return the current dock light mode name."""
+        state = self.coordinator.data
+        if state is None:
+            return None
+        if state.dock_light_mode is None:
+            return None
+        return DOCK_LIGHT_MODE_NAMES.get(state.dock_light_mode)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the dock light on with the requested effect."""
+        effect = kwargs.get(ATTR_EFFECT)
+        if effect is None:
+            effect = self.effect or self._last_effect
+        if effect not in _EFFECTS:
+            raise HomeAssistantError(f"Unsupported Narwal dock light effect: {effect}")
+        await self._set_mode(effect)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the dock light off."""
+        await self._set_mode("Off")
+
+    async def _set_mode(self, mode: str) -> None:
+        """Send the dock light command."""
+        client = self.coordinator.client
+        if not client.robot_awake:
+            await client.wake(timeout=10.0)
+        response = await client.set_ambient_light_mode(DOCK_LIGHT_MODES[mode])
+        if response is None:
+            raise HomeAssistantError("Narwal dock light command failed")
+        if response.result_code not in (0, CommandResult.SUCCESS, CommandResult.APPLIED):
+            try:
+                result_name = CommandResult(response.result_code).name
+            except ValueError:
+                result_name = f"UNKNOWN({response.result_code})"
+            raise HomeAssistantError(f"Narwal dock light command failed: {result_name}")
+
+        if mode != "Off":
+            self._last_effect = mode
+        await self.coordinator.async_request_refresh()
+        self.async_write_ha_state()

--- a/custom_components/narwal/narwal_client/__init__.py
+++ b/custom_components/narwal/narwal_client/__init__.py
@@ -1,7 +1,7 @@
 """Narwal robot vacuum client library — local WebSocket API."""
 
 from .client import NarwalClient, NarwalCommandError, NarwalConnectionError
-from .const import CommandResult, FanLevel, MopHumidity, WorkingStatus
+from .const import AmbientLightCtrlType, CommandResult, FanLevel, MopHumidity, WorkingStatus
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState, RoomInfo
 from .protocol import build_frame, parse_frame
 
@@ -13,6 +13,7 @@ __all__ = [
     "CommandResponse",
     "CommandResult",
     "DeviceInfo",
+    "AmbientLightCtrlType",
     "FanLevel",
     "MapData",
     "MapDisplayData",

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -24,6 +24,7 @@ from .const import (
     RECONNECT_MAX_DELAY,
     TOPIC_CMD_ACTIVE_ROBOT,
     TOPIC_CMD_APP_HEARTBEAT,
+    TOPIC_CMD_AMBIENT_LIGHT_CTRL,
     TOPIC_CMD_CANCEL,
     TOPIC_CMD_DRY_MOP,
     TOPIC_CMD_DUST_GATHERING,
@@ -50,6 +51,7 @@ from .const import (
     TOPIC_CMD_YELL,
     DEFAULT_TOPIC_PREFIX,
     WAKE_TIMEOUT,
+    AmbientLightCtrlType,
     CommandResult,
     FanLevel,
     MopHumidity,
@@ -1369,3 +1371,30 @@ class NarwalClient:
             _LOGGER.warning(
                 "set_led(%s) unexpected result_code=%d", on, resp.result_code
             )
+
+    async def set_ambient_light_mode(
+        self, mode: AmbientLightCtrlType | int
+    ) -> CommandResponse | None:
+        """Set the base station ambient light mode."""
+        mode = AmbientLightCtrlType(mode)
+        payload = self._encode_varint_field(1, int(mode))
+        try:
+            resp = await self.send_command(
+                TOPIC_CMD_AMBIENT_LIGHT_CTRL,
+                payload=payload,
+            )
+        except Exception:
+            _LOGGER.warning("set_ambient_light_mode(%s) command failed", mode)
+            return None
+        if resp.result_code not in (
+            0,
+            CommandResult.SUCCESS,
+            CommandResult.NOT_APPLICABLE,
+            CommandResult.APPLIED,
+        ):
+            _LOGGER.warning(
+                "set_ambient_light_mode(%s) unexpected result_code=%d",
+                mode,
+                resp.result_code,
+            )
+        return resp

--- a/custom_components/narwal/narwal_client/const.py
+++ b/custom_components/narwal/narwal_client/const.py
@@ -24,6 +24,7 @@ KNOWN_PRODUCT_KEYS = [
     # Confirmed working (local WebSocket)
     "QoEsI5qYXO",  # AX12 — Narwal Flow (primary, confirmed)
     "QxMSPG6VSO",  # Narwal Flow 2 (confirmed working via local WebSocket)
+    "iSuVlI1If2",  # Narwal Flow 2 alternate key (confirmed working locally)
     "DrzDKQ0MU8",   # CX4  — Freo Z10 Ultra (confirmed by @irekkl-maker)
     # AX26 — sold as both "Freo Z10 Turbo" (@romedtino, #40) and "Freo Z10 Pro"
     # (@shin906710, #70); same key, same FW v01.02.00.15, so one platform.
@@ -79,6 +80,7 @@ TOPIC_CMD_FORCE_END = "task/force_end"
 TOPIC_CMD_CANCEL = "task/cancel"
 
 # Supply/dock
+TOPIC_CMD_AMBIENT_LIGHT_CTRL = "supply/ambient_light_ctrl"
 TOPIC_CMD_RECALL = "supply/recall"
 TOPIC_CMD_WASH_MOP = "supply/wash_mop"
 TOPIC_CMD_DRY_MOP = "supply/dry_mop"
@@ -145,6 +147,16 @@ class CommandResult(IntEnum):
     SUCCESS = 1
     NOT_APPLICABLE = 2  # e.g., set_fan_level when not cleaning
     CONFLICT = 3  # e.g., recall when already recalling
+    APPLIED = 6  # observed on ambient light commands after the dock light changes
+
+
+class AmbientLightCtrlType(IntEnum):
+    """Base station ambient light mode."""
+
+    OFF = 0
+    NIGHT_LIGHT = 1
+    WINTER_WARMTH = 2
+    PURPLE_LIGHT = 3
 
 
 class WorkingStatus(IntEnum):

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -537,6 +537,12 @@ class NarwalState:
     # Secondary confirmation signal.
     dock_field47: int = 0
 
+    # Base station ambient light mode from top-level base_status field 50.
+    # Values validated against the app: 1=Nightlight,
+    # 2=Fireplace / Winter warmth, 3=Purple. When the light is off the robot
+    # omits field 50 from base_status, so missing field 50 is treated as 0.
+    dock_light_mode: int | None = None
+
     # Raw data for fields we haven't fully decoded yet
     raw_base_status: dict[str, Any] = field(default_factory=dict)
     raw_working_status: dict[str, Any] = field(default_factory=dict)
@@ -665,6 +671,13 @@ class NarwalState:
                 self.dock_field47 = int(decoded["47"])
             except (ValueError, TypeError):
                 self.dock_field47 = 0
+        if "50" in decoded:
+            try:
+                self.dock_light_mode = int(decoded["50"])
+            except (ValueError, TypeError):
+                self.dock_light_mode = None
+        else:
+            self.dock_light_mode = 0
         # Field 3 is a nested message: {1: state_int, ...}
         # Sub-field layout differs across firmware versions:
         #   Old FW: {1: ws, 2: paused, 3: dock_presence, 7: returning, 10: dock_sub, 12: dock_activity}

--- a/custom_components/narwal/strings.json
+++ b/custom_components/narwal/strings.json
@@ -80,6 +80,11 @@
       "station_bag": {
         "name": "Station dust bag"
       }
+    },
+    "light": {
+      "dock_light": {
+        "name": "Dock light"
+      }
     }
   }
 }

--- a/custom_components/narwal/translations/en.json
+++ b/custom_components/narwal/translations/en.json
@@ -80,6 +80,11 @@
       "station_bag": {
         "name": "Station dust bag"
       }
+    },
+    "light": {
+      "dock_light": {
+        "name": "Dock light"
+      }
     }
   }
 }

--- a/custom_components/narwal/translations/fr.json
+++ b/custom_components/narwal/translations/fr.json
@@ -80,6 +80,11 @@
       "station_bag": {
         "name": "Sac à poussière de la station"
       }
+    },
+    "light": {
+      "dock_light": {
+        "name": "Éclairage de la station"
+      }
     }
   }
 }

--- a/narwal_client/__init__.py
+++ b/narwal_client/__init__.py
@@ -1,7 +1,7 @@
 """Narwal robot vacuum client library — local WebSocket API."""
 
 from .client import NarwalClient, NarwalCommandError, NarwalConnectionError
-from .const import CommandResult, FanLevel, MopHumidity, WorkingStatus
+from .const import AmbientLightCtrlType, CommandResult, FanLevel, MopHumidity, WorkingStatus
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState, RoomInfo
 from .protocol import build_frame, parse_frame
 
@@ -13,6 +13,7 @@ __all__ = [
     "CommandResponse",
     "CommandResult",
     "DeviceInfo",
+    "AmbientLightCtrlType",
     "FanLevel",
     "MapData",
     "MapDisplayData",

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -24,6 +24,7 @@ from .const import (
     RECONNECT_MAX_DELAY,
     TOPIC_CMD_ACTIVE_ROBOT,
     TOPIC_CMD_APP_HEARTBEAT,
+    TOPIC_CMD_AMBIENT_LIGHT_CTRL,
     TOPIC_CMD_CANCEL,
     TOPIC_CMD_DRY_MOP,
     TOPIC_CMD_DUST_GATHERING,
@@ -50,6 +51,7 @@ from .const import (
     TOPIC_CMD_YELL,
     DEFAULT_TOPIC_PREFIX,
     WAKE_TIMEOUT,
+    AmbientLightCtrlType,
     CommandResult,
     FanLevel,
     MopHumidity,
@@ -1369,3 +1371,30 @@ class NarwalClient:
             _LOGGER.warning(
                 "set_led(%s) unexpected result_code=%d", on, resp.result_code
             )
+
+    async def set_ambient_light_mode(
+        self, mode: AmbientLightCtrlType | int
+    ) -> CommandResponse | None:
+        """Set the base station ambient light mode."""
+        mode = AmbientLightCtrlType(mode)
+        payload = self._encode_varint_field(1, int(mode))
+        try:
+            resp = await self.send_command(
+                TOPIC_CMD_AMBIENT_LIGHT_CTRL,
+                payload=payload,
+            )
+        except Exception:
+            _LOGGER.warning("set_ambient_light_mode(%s) command failed", mode)
+            return None
+        if resp.result_code not in (
+            0,
+            CommandResult.SUCCESS,
+            CommandResult.NOT_APPLICABLE,
+            CommandResult.APPLIED,
+        ):
+            _LOGGER.warning(
+                "set_ambient_light_mode(%s) unexpected result_code=%d",
+                mode,
+                resp.result_code,
+            )
+        return resp

--- a/narwal_client/const.py
+++ b/narwal_client/const.py
@@ -24,6 +24,7 @@ KNOWN_PRODUCT_KEYS = [
     # Confirmed working (local WebSocket)
     "QoEsI5qYXO",  # AX12 — Narwal Flow (primary, confirmed)
     "QxMSPG6VSO",  # Narwal Flow 2 (confirmed working via local WebSocket)
+    "iSuVlI1If2",  # Narwal Flow 2 alternate key (confirmed working locally)
     "DrzDKQ0MU8",   # CX4  — Freo Z10 Ultra (confirmed by @irekkl-maker)
     # AX26 — sold as both "Freo Z10 Turbo" (@romedtino, #40) and "Freo Z10 Pro"
     # (@shin906710, #70); same key, same FW v01.02.00.15, so one platform.
@@ -79,6 +80,7 @@ TOPIC_CMD_FORCE_END = "task/force_end"
 TOPIC_CMD_CANCEL = "task/cancel"
 
 # Supply/dock
+TOPIC_CMD_AMBIENT_LIGHT_CTRL = "supply/ambient_light_ctrl"
 TOPIC_CMD_RECALL = "supply/recall"
 TOPIC_CMD_WASH_MOP = "supply/wash_mop"
 TOPIC_CMD_DRY_MOP = "supply/dry_mop"
@@ -145,6 +147,16 @@ class CommandResult(IntEnum):
     SUCCESS = 1
     NOT_APPLICABLE = 2  # e.g., set_fan_level when not cleaning
     CONFLICT = 3  # e.g., recall when already recalling
+    APPLIED = 6  # observed on ambient light commands after the dock light changes
+
+
+class AmbientLightCtrlType(IntEnum):
+    """Base station ambient light mode."""
+
+    OFF = 0
+    NIGHT_LIGHT = 1
+    WINTER_WARMTH = 2
+    PURPLE_LIGHT = 3
 
 
 class WorkingStatus(IntEnum):

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -537,6 +537,12 @@ class NarwalState:
     # Secondary confirmation signal.
     dock_field47: int = 0
 
+    # Base station ambient light mode from top-level base_status field 50.
+    # Values validated against the app: 1=Nightlight,
+    # 2=Fireplace / Winter warmth, 3=Purple. When the light is off the robot
+    # omits field 50 from base_status, so missing field 50 is treated as 0.
+    dock_light_mode: int | None = None
+
     # Raw data for fields we haven't fully decoded yet
     raw_base_status: dict[str, Any] = field(default_factory=dict)
     raw_working_status: dict[str, Any] = field(default_factory=dict)
@@ -665,6 +671,13 @@ class NarwalState:
                 self.dock_field47 = int(decoded["47"])
             except (ValueError, TypeError):
                 self.dock_field47 = 0
+        if "50" in decoded:
+            try:
+                self.dock_light_mode = int(decoded["50"])
+            except (ValueError, TypeError):
+                self.dock_light_mode = None
+        else:
+            self.dock_light_mode = 0
         # Field 3 is a nested message: {1: state_int, ...}
         # Sub-field layout differs across firmware versions:
         #   Old FW: {1: ws, 2: paused, 3: dock_presence, 7: returning, 10: dock_sub, 12: dock_activity}

--- a/tests/ha_stubs.py
+++ b/tests/ha_stubs.py
@@ -58,6 +58,9 @@ def install() -> None:
     # homeassistant.exceptions
     ha_exc = _mod("homeassistant.exceptions", ha)
     ha_exc.ConfigEntryNotReady = type("ConfigEntryNotReady", (Exception,), {})  # type: ignore[attr-defined]
+    ha_exc.HomeAssistantError = type(  # type: ignore[attr-defined]
+        "HomeAssistantError", (Exception,), {}
+    )
 
     # homeassistant.config_entries
     ha_ce = _mod("homeassistant.config_entries", ha)
@@ -231,3 +234,26 @@ def install() -> None:
             pass
 
     ha_cam.Camera = _Camera  # type: ignore[attr-defined]
+
+    ha_light = _mod("homeassistant.components.light", ha_comp)
+    ha_light.ATTR_EFFECT = "effect"  # type: ignore[attr-defined]
+    ha_light.DOMAIN = "light"  # type: ignore[attr-defined]
+
+    class _LightEntity:
+        """Stub for LightEntity base class."""
+
+        def __init_subclass__(cls, **kw: object) -> None:
+            pass
+
+        def async_write_ha_state(self) -> None:
+            pass
+
+    class _ColorMode:
+        ONOFF = "onoff"
+
+    class _LightEntityFeature:
+        EFFECT = 1
+
+    ha_light.LightEntity = _LightEntity  # type: ignore[attr-defined]
+    ha_light.ColorMode = _ColorMode  # type: ignore[attr-defined]
+    ha_light.LightEntityFeature = _LightEntityFeature  # type: ignore[attr-defined]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from narwal_client.client import NarwalClient, NarwalConnectionError
-from narwal_client.const import CommandResult
+from narwal_client.const import AmbientLightCtrlType, CommandResult
 from narwal_client.models import CommandResponse, MapData, RoomInfo
 
 
@@ -42,6 +42,26 @@ class TestNarwalClientInit:
         client = NarwalClient("10.0.0.1")
         with pytest.raises(NarwalConnectionError):
             await client.send_raw("test/topic", b"\x08\x01")
+
+    @pytest.mark.asyncio
+    async def test_set_ambient_light_mode_accepts_applied(self) -> None:
+        """Dock light command accepts the observed applied result code."""
+        client = NarwalClient("10.0.0.1")
+        applied = CommandResponse(result_code=CommandResult.APPLIED)
+
+        with patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send:
+            mock_send.return_value = applied
+            result = await client.set_ambient_light_mode(
+                AmbientLightCtrlType.NIGHT_LIGHT
+            )
+
+        assert result is applied
+        mock_send.assert_awaited_once_with(
+            "supply/ambient_light_ctrl",
+            payload=b"\x08\x01",
+        )
 
 
 class TestBuildCleanPayloadV2:

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,0 +1,46 @@
+"""Tests for integration constants and capability helpers."""
+
+from __future__ import annotations
+
+import tests.ha_stubs
+
+tests.ha_stubs.install()
+
+from custom_components.narwal.const import (  # noqa: E402
+    CONF_DOCK_LIGHT_SUPPORTED,
+    CONF_MODEL,
+    CONF_PRODUCT_KEY,
+    is_dock_light_supported,
+)
+
+
+def test_dock_light_supported_for_flow_2_product_keys() -> None:
+    """Flow 2 product keys expose the dock light."""
+    assert is_dock_light_supported({CONF_PRODUCT_KEY: "QxMSPG6VSO"})
+    assert is_dock_light_supported({CONF_PRODUCT_KEY: "iSuVlI1If2"})
+
+
+def test_dock_light_hidden_for_flow_1_by_default() -> None:
+    """Flow 1 does not expose the Flow 2 dock light by label alone."""
+    assert not is_dock_light_supported(
+        {CONF_PRODUCT_KEY: "QoEsI5qYXO", CONF_MODEL: "Narwal Flow"}
+    )
+
+
+def test_dock_light_ignores_stale_model_label() -> None:
+    """The product key, not the possibly stale model label, controls support."""
+    assert not is_dock_light_supported(
+        {CONF_PRODUCT_KEY: "QoEsI5qYXO", CONF_MODEL: "Narwal Flow 2"}
+    )
+
+
+def test_dock_light_option_override() -> None:
+    """Config options can override the product-key support default."""
+    assert is_dock_light_supported(
+        {CONF_PRODUCT_KEY: "QoEsI5qYXO"},
+        {CONF_DOCK_LIGHT_SUPPORTED: True},
+    )
+    assert not is_dock_light_supported(
+        {CONF_PRODUCT_KEY: "QxMSPG6VSO"},
+        {CONF_DOCK_LIGHT_SUPPORTED: False},
+    )

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,0 +1,49 @@
+"""Tests for Narwal light entities."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import tests.ha_stubs
+
+tests.ha_stubs.install()
+
+from custom_components.narwal.light import NarwalDockLight  # noqa: E402
+from custom_components.narwal.narwal_client import CommandResult  # noqa: E402
+from custom_components.narwal.narwal_client.models import CommandResponse  # noqa: E402
+
+
+def _coordinator() -> MagicMock:
+    """Return a minimal coordinator stub for light entity tests."""
+    coordinator = MagicMock()
+    coordinator.config_entry.data = {"device_id": "test_device"}
+    coordinator.config_entry.title = "Narwal Test"
+    coordinator.client.state.firmware_version = "test"
+    coordinator.last_update_success = True
+    return coordinator
+
+
+def test_dock_light_preserves_unknown_state() -> None:
+    """An unread dock-light mode must not be presented as off."""
+    coordinator = _coordinator()
+    coordinator.data.dock_light_mode = None
+
+    dock_light = NarwalDockLight(coordinator)
+
+    assert dock_light.is_on is None
+
+
+async def test_dock_light_accepts_applied_result_code() -> None:
+    """Result code 6 is accepted when the dock light applies the command."""
+    coordinator = _coordinator()
+    coordinator.client.robot_awake = True
+    coordinator.client.set_ambient_light_mode = AsyncMock(
+        return_value=CommandResponse(result_code=CommandResult.APPLIED)
+    )
+    coordinator.async_request_refresh = AsyncMock()
+
+    dock_light = NarwalDockLight(coordinator)
+    await dock_light._set_mode("Nightlight")
+
+    coordinator.client.set_ambient_light_mode.assert_awaited_once()
+    coordinator.async_request_refresh.assert_awaited_once()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -272,6 +272,19 @@ class TestNarwalState:
         assert state.clean_water_tank_state == 2  # EMPTY
         assert state.station_bag_state == 3  # SUGGEST_REPLACE
 
+    def test_base_status_dock_light_mode(self) -> None:
+        """Field 50 exposes the base station ambient light mode."""
+        state = NarwalState()
+        state.update_from_base_status({"50": 2})
+        assert state.dock_light_mode == 2
+
+    def test_base_status_missing_dock_light_means_off(self) -> None:
+        """When the dock omits field 50, the ambient light is off."""
+        state = NarwalState()
+        state.update_from_base_status({"50": 2})
+        state.update_from_base_status({"2": _float_to_uint32(100.0)})
+        assert state.dock_light_mode == 0
+
     def test_update_from_upgrade_status(self) -> None:
         state = NarwalState()
         state.update_from_upgrade_status({


### PR DESCRIPTION
## What

Adds a Home Assistant `light` entity for supported Narwal dock ambient lighting. The entity exposes the app modes as effects (`Fireplace`, `Nightlight`, `Purple`) and sends the local `supply/ambient_light_ctrl` command.

The branch also parses base-status field 50 as the current dock light mode and gates the entity to known Flow 2 product keys, with an options override for development/testing.

## Why

This is the standalone dock-light piece requested from the old stacked Flow 2 series. It no longer depends on the room-clean/control stack.

## Validation

No live robot validation in this pass. Non-hardware checks only:

- `python -m compileall -q custom_components/narwal narwal_client tests`
- `git diff --check`
- direct Python smoke assertions for support gating, base-status field 50, command payload, and unknown light state

`pytest` is not installed in this checkout, so the focused unit files were added but not run here.