### PR TITLE
fix: keep active vacuum status from working_status telemetry

### DIFF
--- a/custom_components/narwal/coordinator.py
+++ b/custom_components/narwal/coordinator.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .narwal_client import NarwalClient, NarwalConnectionError, NarwalState
-from .narwal_client.const import WorkingStatus
+from .narwal_client.const import ACTIVE_CLEANING_STATUSES, WorkingStatus
 
 from .const import DOMAIN
 
@@ -79,7 +79,9 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
             _LOGGER.debug("Could not fetch device info at startup")
 
         try:
-            await self.client.get_status(full_update=True)
+            await self.client.get_status(
+                full_update=not self.client.state.has_recent_active_working_status
+            )
         except Exception:
             _LOGGER.debug("Could not fetch initial status")
 
@@ -145,7 +147,7 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
                 WorkingStatus.STANDBY, WorkingStatus.DOCKED_V2,
             )
             and self._prev_working_status
-            in (WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT)
+            in ACTIVE_CLEANING_STATUSES
         ):
             _LOGGER.info("Return-to-dock detected, refreshing dock status")
             self.hass.async_create_task(self._refresh_dock_status())
@@ -154,8 +156,13 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         # display_map dropout recovery: if cleaning but no display_map for
         # 30s, re-send topic subscription. Only subscription — no wake burst
         # (wake bursts during cleaning cause pause bouncing).
-        is_cleaning = state.working_status in (
-            WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT,
+        is_cleaning = (
+            state.is_cleaning
+            or state.has_recent_active_working_status
+            or (
+                not state.is_docked
+                and state.working_status in ACTIVE_CLEANING_STATUSES
+            )
         )
         if is_cleaning:
             display_age = self.client.last_display_map_age
@@ -211,7 +218,9 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
     async def _refresh_dock_status(self) -> None:
         """Immediate get_status() after return-to-dock to refresh dock fields."""
         try:
-            await self.client.get_status(full_update=True)
+            await self.client.get_status(
+                full_update=not self.client.state.has_recent_active_working_status
+            )
             self.async_set_updated_data(self.client.state)
         except Exception:
             _LOGGER.debug("Failed to refresh dock status after transition")
@@ -229,7 +238,9 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         try:
             if not self.client.connected:
                 raise NarwalConnectionError("Not connected")
-            await self.client.get_status(full_update=True)
+            await self.client.get_status(
+                full_update=not self.client.state.has_recent_active_working_status
+            )
         except Exception as err:
             self._consecutive_failures += 1
             if self._consecutive_failures >= self._max_failures:

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -53,6 +53,7 @@ from .const import (
     CommandResult,
     FanLevel,
     MopHumidity,
+    WorkingStatus,
 )
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState
 from .protocol import (
@@ -64,6 +65,56 @@ from .protocol import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+_STALE_DOCK_BASE_STATUSES = {
+    WorkingStatus.UNKNOWN,
+    WorkingStatus.STANDBY,
+    WorkingStatus.DOCKED,
+    WorkingStatus.CHARGED,
+    WorkingStatus.DOCKED_V2,
+}
+
+
+def _base_status_working_status(decoded: dict[str, Any] | object) -> WorkingStatus | None:
+    """Extract robot_base_status field 3.1."""
+    if not isinstance(decoded, dict):
+        return None
+    field3 = decoded.get("3")
+    if isinstance(field3, list):
+        field3 = field3[0] if field3 else None
+    if not isinstance(field3, dict) or "1" not in field3:
+        return None
+    try:
+        return WorkingStatus(int(field3["1"]))
+    except (TypeError, ValueError):
+        return None
+
+
+def _base_status_confirms_docked(
+    decoded: dict[str, Any] | object, status: WorkingStatus | None
+) -> bool:
+    """Return true when a terminal status also carries live dock indicators."""
+    if not isinstance(decoded, dict) or status not in _STALE_DOCK_BASE_STATUSES:
+        return False
+
+    field3 = decoded.get("3")
+    if isinstance(field3, list):
+        field3 = field3[0] if field3 else None
+    field3 = field3 if isinstance(field3, dict) else {}
+
+    def int_field(container: dict[str, Any], field: str) -> int:
+        try:
+            return int(container.get(field, 0))
+        except (TypeError, ValueError):
+            return 0
+
+    return (
+        int_field(decoded, "11") >= 2
+        or int_field(decoded, "47") in (1, 3)
+        or int_field(field3, "3") in (1, 6)
+        or int_field(field3, "10") == 1
+        or int_field(field3, "12") > 0
+    )
 
 
 class NarwalConnectionError(Exception):
@@ -144,6 +195,27 @@ class NarwalClient:
         if self._last_display_map_time <= 0:
             return 999.0
         return time.monotonic() - self._last_display_map_time
+
+    def _update_from_working_status_broadcast(self, decoded: dict[str, Any]) -> None:
+        """Apply live task metrics from the working_status broadcast."""
+        self.state.update_from_working_status(decoded)
+
+    def _update_from_base_status_broadcast(self, decoded: dict[str, Any]) -> None:
+        """Apply a base-status broadcast without clobbering fresh task metrics."""
+        status = _base_status_working_status(decoded)
+        if (
+            self.state.has_recent_active_working_status
+            and status in _STALE_DOCK_BASE_STATUSES
+            and not _base_status_confirms_docked(decoded, status)
+        ):
+            self.state.update_battery_from_base_status(decoded)
+            _LOGGER.debug(
+                "Ignoring stale base_status=%s while working_status task metrics are fresh",
+                status.name if status else "unknown",
+            )
+            return
+
+        self.state.update_from_base_status(decoded)
 
     async def connect(self) -> None:
         """Establish WebSocket connection to the vacuum.
@@ -410,9 +482,9 @@ class NarwalClient:
             return
 
         if short_topic == "status/working_status":
-            self.state.update_from_working_status(decoded)
+            self._update_from_working_status_broadcast(decoded)
         elif short_topic == "status/robot_base_status":
-            self.state.update_from_base_status(decoded)
+            self._update_from_base_status_broadcast(decoded)
         elif short_topic == "upgrade/upgrade_status":
             self.state.update_from_upgrade_status(decoded)
         elif short_topic == "status/download_status":
@@ -854,9 +926,9 @@ class NarwalClient:
                 continue
 
             if short_topic == "status/working_status":
-                self.state.update_from_working_status(decoded)
+                self._update_from_working_status_broadcast(decoded)
             elif short_topic == "status/robot_base_status":
-                self.state.update_from_base_status(decoded)
+                self._update_from_base_status_broadcast(decoded)
             elif short_topic == "upgrade/upgrade_status":
                 self.state.update_from_upgrade_status(decoded)
             elif short_topic == "status/download_status":

--- a/custom_components/narwal/narwal_client/const.py
+++ b/custom_components/narwal/narwal_client/const.py
@@ -158,6 +158,7 @@ class WorkingStatus(IntEnum):
     Values confirmed via live WebSocket monitoring:
       1  = STANDBY (idle, transition state between cleaning and docked)
       2  = DOCKED_V2 (on dock; confirmed v01.07.23.00 while charging at 10-36%)
+      3  = CLEANING_V2 (active cleaning; observed on newer Flow 2 firmware)
       4  = CLEANING (plan-based start; also stays 4 while returning to dock on older FW)
       5  = CLEANING_ALT (observed live: robot was physically stuck when reporting 5)
       7  = REMAPPING (live 2026-07-09: robot exploring/rebuilding the map; camera
@@ -179,6 +180,7 @@ class WorkingStatus(IntEnum):
     UNKNOWN = 0
     STANDBY = 1       # idle / transition state
     DOCKED_V2 = 2     # on dock (v01.07.23.00+ — replaces DOCKED=10/CHARGED=14 from older FW)
+    CLEANING_V2 = 3   # active cleaning on newer Flow 2 firmware
     CLEANING = 4      # active cleaning (stays 4 even while returning to dock)
     CLEANING_ALT = 5  # cleaning — observed when robot was physically stuck; may indicate error/stuck state
     REMAPPING = 7     # mapping/exploration (live 2026-07-09); camera active, take_picture accepted
@@ -188,6 +190,16 @@ class WorkingStatus(IntEnum):
     # PLACEHOLDER: error state value not yet observed live.
     # Trigger a real error (e.g., pick up robot mid-clean) to discover the value.
     ERROR = 99
+
+
+ACTIVE_CLEANING_STATUSES = frozenset(
+    {
+        WorkingStatus.CLEANING_V2,
+        WorkingStatus.CLEANING,
+        WorkingStatus.CLEANING_ALT,
+        WorkingStatus.REMAPPING,
+    }
+)
 
 
 class FanLevel(IntEnum):

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import struct
+import time
 from dataclasses import dataclass, field
 from typing import Any, ClassVar
 
@@ -14,7 +15,15 @@ _LOGGER = logging.getLogger(__name__)
 # identical lines (#46). Warn once per distinct value instead.
 _WARNED_WORKING_STATUS: set[Any] = set()
 
-from .const import CommandResult, FanLevel, MopHumidity, WorkingStatus
+from .const import (
+    ACTIVE_CLEANING_STATUSES,
+    CommandResult,
+    FanLevel,
+    MopHumidity,
+    WorkingStatus,
+)
+
+_ACTIVE_WORKING_STATUS_TTL = 15.0
 
 
 @dataclass
@@ -479,6 +488,7 @@ class NarwalState:
     # Cleaning stats
     cleaning_area: float = 0.0  # m² (coveredArea)
     cleaning_time: int = 0  # seconds
+    last_active_working_status_time: float = 0.0
 
     # Consumables / station / fault (base_status; present on dock and during cleaning)
     dust_bag_health: float = 0.0  # field 35 stationBagHealthScore (%)
@@ -542,10 +552,26 @@ class NarwalState:
     raw_working_status: dict[str, Any] = field(default_factory=dict)
 
     @property
+    def has_recent_active_working_status(self) -> bool:
+        """True while live working_status task metrics are still fresh."""
+        if self.working_status not in ACTIVE_CLEANING_STATUSES:
+            return False
+        if self.last_active_working_status_time <= 0:
+            return False
+        return (
+            time.monotonic() - self.last_active_working_status_time
+            <= _ACTIVE_WORKING_STATUS_TTL
+        )
+
+    @property
     def is_cleaning(self) -> bool:
         """True when actively cleaning (not paused, not returning to dock)."""
+        if self.has_recent_active_working_status:
+            return not self.is_paused and not self.is_returning
+        if self.is_docked:
+            return False
         return (
-            self.working_status in (WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT)
+            self.working_status in ACTIVE_CLEANING_STATUSES
             and not self.is_paused
             and not self.is_returning_to_dock
         )
@@ -570,7 +596,9 @@ class NarwalState:
             WorkingStatus.DOCKED, WorkingStatus.CHARGED, WorkingStatus.DOCKED_V2,
         ):
             return True
-        if self.working_status in (WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT):
+        if self.has_recent_active_working_status:
+            return False
+        if self.working_status in ACTIVE_CLEANING_STATUSES:
             return False
         # For STANDBY, UNKNOWN, or any other status: check dock field signals.
         # Values differ across firmware versions:
@@ -603,9 +631,7 @@ class NarwalState:
         transitions to STANDBY/DOCKED/CHARGED, it has already docked
         even if field 3.7 is momentarily still set.
         """
-        if self.working_status not in (
-            WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT,
-        ):
+        if self.working_status not in ACTIVE_CLEANING_STATUSES:
             return False
         return self.is_returning_to_dock and self.dock_sub_state == 2
 
@@ -621,15 +647,28 @@ class NarwalState:
         not area — reading it as area is why the sensor was stuck at 1.8 m².
         """
         self.raw_working_status = decoded
+        active_payload = False
         if "3" in decoded:
             try:
                 self.cleaning_time = int(decoded["3"])
+                active_payload = True
             except (ValueError, TypeError):
                 pass
         if "2" in decoded:
             area = _to_float32(decoded["2"])
             if area is not None and area >= 0:
                 self.cleaning_area = area
+                active_payload = True
+        if active_payload:
+            self.working_status = WorkingStatus.CLEANING
+            self.last_active_working_status_time = time.monotonic()
+            self.is_paused = False
+            self.is_returning_to_dock = False
+            self.dock_sub_state = 0
+            self.dock_activity = 0
+            self.dock_presence = 2
+            self.dock_field11 = 1
+            self.dock_field47 = 2
 
     def update_from_base_status(self, decoded: dict[str, Any]) -> None:
         """Update state from a decoded robot_base_status message.
@@ -688,6 +727,8 @@ class NarwalState:
                             raw_val,
                         )
                     self.working_status = WorkingStatus.UNKNOWN
+                if self.working_status not in ACTIVE_CLEANING_STATUSES:
+                    self.last_active_working_status_time = 0.0
             # Sub-field 2: paused overlay (0 or absent = not paused, 1 = paused)
             self.is_paused = bool(field3.get("2"))
             # Sub-field 7: returning to dock on old FW (value 1 = returning).
@@ -709,6 +750,17 @@ class NarwalState:
                     self.dock_presence = int(field3["3"])
                 except (ValueError, TypeError):
                     pass
+            if self.working_status in ACTIVE_CLEANING_STATUSES:
+                if "10" not in field3:
+                    self.dock_sub_state = 0
+                if "12" not in field3:
+                    self.dock_activity = 0
+                if "3" not in field3:
+                    self.dock_presence = 2
+                if "11" not in decoded:
+                    self.dock_field11 = 1
+                if "47" not in decoded:
+                    self.dock_field47 = 2
             # Log unrecognized sub-fields for future firmware mapping
             _known_f3 = {"1", "2", "3", "7", "10", "12"}
             _unknown_f3 = set(field3.keys()) - _known_f3

--- a/custom_components/narwal/vacuum.py
+++ b/custom_components/narwal/vacuum.py
@@ -20,6 +20,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .narwal_client import CommandResult, FanLevel, NarwalCommandError, WorkingStatus
+from .narwal_client.const import ACTIVE_CLEANING_STATUSES
 
 from . import NarwalConfigEntry
 from .const import FAN_SPEED_LIST, FAN_SPEED_MAP
@@ -38,6 +39,7 @@ WORKING_STATUS_TO_ACTIVITY: dict[WorkingStatus, VacuumActivity] = {
     WorkingStatus.CHARGED: VacuumActivity.DOCKED,
     WorkingStatus.DOCKED_V2: VacuumActivity.DOCKED,
     WorkingStatus.STANDBY: VacuumActivity.IDLE,
+    WorkingStatus.CLEANING_V2: VacuumActivity.CLEANING,
     WorkingStatus.CLEANING: VacuumActivity.CLEANING,
     WorkingStatus.CLEANING_ALT: VacuumActivity.CLEANING,
     WorkingStatus.REMAPPING: VacuumActivity.CLEANING,  # mapping/exploration — robot is actively busy
@@ -83,8 +85,9 @@ class NarwalVacuum(NarwalEntity, StateVacuumEntity):
         state = self.coordinator.data
         if state is None:
             return VacuumActivity.IDLE
-        is_cleaning_state = state.working_status in (
-            WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT,
+        is_cleaning_state = (
+            state.working_status in ACTIVE_CLEANING_STATUSES
+            or state.has_recent_active_working_status
         )
         # is_paused (field 3.2) stays stale after docking — only trust
         # during cleaning states. Paused takes priority over returning
@@ -147,9 +150,7 @@ class NarwalVacuum(NarwalEntity, StateVacuumEntity):
         await self._ensure_awake()
         state = self.coordinator.data
         # is_paused stays stale after docking — only trust it during cleaning
-        is_cleaning = state and state.working_status in (
-            WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT,
-        )
+        is_cleaning = state and state.working_status in ACTIVE_CLEANING_STATUSES
         if is_cleaning and state.is_paused:
             await self.coordinator.client.resume(timeout=self._ACTION_TIMEOUT)
         else:

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -53,6 +53,7 @@ from .const import (
     CommandResult,
     FanLevel,
     MopHumidity,
+    WorkingStatus,
 )
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState
 from .protocol import (
@@ -64,6 +65,56 @@ from .protocol import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+_STALE_DOCK_BASE_STATUSES = {
+    WorkingStatus.UNKNOWN,
+    WorkingStatus.STANDBY,
+    WorkingStatus.DOCKED,
+    WorkingStatus.CHARGED,
+    WorkingStatus.DOCKED_V2,
+}
+
+
+def _base_status_working_status(decoded: dict[str, Any] | object) -> WorkingStatus | None:
+    """Extract robot_base_status field 3.1."""
+    if not isinstance(decoded, dict):
+        return None
+    field3 = decoded.get("3")
+    if isinstance(field3, list):
+        field3 = field3[0] if field3 else None
+    if not isinstance(field3, dict) or "1" not in field3:
+        return None
+    try:
+        return WorkingStatus(int(field3["1"]))
+    except (TypeError, ValueError):
+        return None
+
+
+def _base_status_confirms_docked(
+    decoded: dict[str, Any] | object, status: WorkingStatus | None
+) -> bool:
+    """Return true when a terminal status also carries live dock indicators."""
+    if not isinstance(decoded, dict) or status not in _STALE_DOCK_BASE_STATUSES:
+        return False
+
+    field3 = decoded.get("3")
+    if isinstance(field3, list):
+        field3 = field3[0] if field3 else None
+    field3 = field3 if isinstance(field3, dict) else {}
+
+    def int_field(container: dict[str, Any], field: str) -> int:
+        try:
+            return int(container.get(field, 0))
+        except (TypeError, ValueError):
+            return 0
+
+    return (
+        int_field(decoded, "11") >= 2
+        or int_field(decoded, "47") in (1, 3)
+        or int_field(field3, "3") in (1, 6)
+        or int_field(field3, "10") == 1
+        or int_field(field3, "12") > 0
+    )
 
 
 class NarwalConnectionError(Exception):
@@ -144,6 +195,27 @@ class NarwalClient:
         if self._last_display_map_time <= 0:
             return 999.0
         return time.monotonic() - self._last_display_map_time
+
+    def _update_from_working_status_broadcast(self, decoded: dict[str, Any]) -> None:
+        """Apply live task metrics from the working_status broadcast."""
+        self.state.update_from_working_status(decoded)
+
+    def _update_from_base_status_broadcast(self, decoded: dict[str, Any]) -> None:
+        """Apply a base-status broadcast without clobbering fresh task metrics."""
+        status = _base_status_working_status(decoded)
+        if (
+            self.state.has_recent_active_working_status
+            and status in _STALE_DOCK_BASE_STATUSES
+            and not _base_status_confirms_docked(decoded, status)
+        ):
+            self.state.update_battery_from_base_status(decoded)
+            _LOGGER.debug(
+                "Ignoring stale base_status=%s while working_status task metrics are fresh",
+                status.name if status else "unknown",
+            )
+            return
+
+        self.state.update_from_base_status(decoded)
 
     async def connect(self) -> None:
         """Establish WebSocket connection to the vacuum.
@@ -410,9 +482,9 @@ class NarwalClient:
             return
 
         if short_topic == "status/working_status":
-            self.state.update_from_working_status(decoded)
+            self._update_from_working_status_broadcast(decoded)
         elif short_topic == "status/robot_base_status":
-            self.state.update_from_base_status(decoded)
+            self._update_from_base_status_broadcast(decoded)
         elif short_topic == "upgrade/upgrade_status":
             self.state.update_from_upgrade_status(decoded)
         elif short_topic == "status/download_status":
@@ -854,9 +926,9 @@ class NarwalClient:
                 continue
 
             if short_topic == "status/working_status":
-                self.state.update_from_working_status(decoded)
+                self._update_from_working_status_broadcast(decoded)
             elif short_topic == "status/robot_base_status":
-                self.state.update_from_base_status(decoded)
+                self._update_from_base_status_broadcast(decoded)
             elif short_topic == "upgrade/upgrade_status":
                 self.state.update_from_upgrade_status(decoded)
             elif short_topic == "status/download_status":

--- a/narwal_client/const.py
+++ b/narwal_client/const.py
@@ -158,6 +158,7 @@ class WorkingStatus(IntEnum):
     Values confirmed via live WebSocket monitoring:
       1  = STANDBY (idle, transition state between cleaning and docked)
       2  = DOCKED_V2 (on dock; confirmed v01.07.23.00 while charging at 10-36%)
+      3  = CLEANING_V2 (active cleaning; observed on newer Flow 2 firmware)
       4  = CLEANING (plan-based start; also stays 4 while returning to dock on older FW)
       5  = CLEANING_ALT (observed live: robot was physically stuck when reporting 5)
       7  = REMAPPING (live 2026-07-09: robot exploring/rebuilding the map; camera
@@ -179,6 +180,7 @@ class WorkingStatus(IntEnum):
     UNKNOWN = 0
     STANDBY = 1       # idle / transition state
     DOCKED_V2 = 2     # on dock (v01.07.23.00+ — replaces DOCKED=10/CHARGED=14 from older FW)
+    CLEANING_V2 = 3   # active cleaning on newer Flow 2 firmware
     CLEANING = 4      # active cleaning (stays 4 even while returning to dock)
     CLEANING_ALT = 5  # cleaning — observed when robot was physically stuck; may indicate error/stuck state
     REMAPPING = 7     # mapping/exploration (live 2026-07-09); camera active, take_picture accepted
@@ -188,6 +190,16 @@ class WorkingStatus(IntEnum):
     # PLACEHOLDER: error state value not yet observed live.
     # Trigger a real error (e.g., pick up robot mid-clean) to discover the value.
     ERROR = 99
+
+
+ACTIVE_CLEANING_STATUSES = frozenset(
+    {
+        WorkingStatus.CLEANING_V2,
+        WorkingStatus.CLEANING,
+        WorkingStatus.CLEANING_ALT,
+        WorkingStatus.REMAPPING,
+    }
+)
 
 
 class FanLevel(IntEnum):

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import struct
+import time
 from dataclasses import dataclass, field
 from typing import Any, ClassVar
 
@@ -14,7 +15,15 @@ _LOGGER = logging.getLogger(__name__)
 # identical lines (#46). Warn once per distinct value instead.
 _WARNED_WORKING_STATUS: set[Any] = set()
 
-from .const import CommandResult, FanLevel, MopHumidity, WorkingStatus
+from .const import (
+    ACTIVE_CLEANING_STATUSES,
+    CommandResult,
+    FanLevel,
+    MopHumidity,
+    WorkingStatus,
+)
+
+_ACTIVE_WORKING_STATUS_TTL = 15.0
 
 
 @dataclass
@@ -479,6 +488,7 @@ class NarwalState:
     # Cleaning stats
     cleaning_area: float = 0.0  # m² (coveredArea)
     cleaning_time: int = 0  # seconds
+    last_active_working_status_time: float = 0.0
 
     # Consumables / station / fault (base_status; present on dock and during cleaning)
     dust_bag_health: float = 0.0  # field 35 stationBagHealthScore (%)
@@ -542,10 +552,26 @@ class NarwalState:
     raw_working_status: dict[str, Any] = field(default_factory=dict)
 
     @property
+    def has_recent_active_working_status(self) -> bool:
+        """True while live working_status task metrics are still fresh."""
+        if self.working_status not in ACTIVE_CLEANING_STATUSES:
+            return False
+        if self.last_active_working_status_time <= 0:
+            return False
+        return (
+            time.monotonic() - self.last_active_working_status_time
+            <= _ACTIVE_WORKING_STATUS_TTL
+        )
+
+    @property
     def is_cleaning(self) -> bool:
         """True when actively cleaning (not paused, not returning to dock)."""
+        if self.has_recent_active_working_status:
+            return not self.is_paused and not self.is_returning
+        if self.is_docked:
+            return False
         return (
-            self.working_status in (WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT)
+            self.working_status in ACTIVE_CLEANING_STATUSES
             and not self.is_paused
             and not self.is_returning_to_dock
         )
@@ -570,7 +596,9 @@ class NarwalState:
             WorkingStatus.DOCKED, WorkingStatus.CHARGED, WorkingStatus.DOCKED_V2,
         ):
             return True
-        if self.working_status in (WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT):
+        if self.has_recent_active_working_status:
+            return False
+        if self.working_status in ACTIVE_CLEANING_STATUSES:
             return False
         # For STANDBY, UNKNOWN, or any other status: check dock field signals.
         # Values differ across firmware versions:
@@ -603,9 +631,7 @@ class NarwalState:
         transitions to STANDBY/DOCKED/CHARGED, it has already docked
         even if field 3.7 is momentarily still set.
         """
-        if self.working_status not in (
-            WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT,
-        ):
+        if self.working_status not in ACTIVE_CLEANING_STATUSES:
             return False
         return self.is_returning_to_dock and self.dock_sub_state == 2
 
@@ -621,15 +647,28 @@ class NarwalState:
         not area — reading it as area is why the sensor was stuck at 1.8 m².
         """
         self.raw_working_status = decoded
+        active_payload = False
         if "3" in decoded:
             try:
                 self.cleaning_time = int(decoded["3"])
+                active_payload = True
             except (ValueError, TypeError):
                 pass
         if "2" in decoded:
             area = _to_float32(decoded["2"])
             if area is not None and area >= 0:
                 self.cleaning_area = area
+                active_payload = True
+        if active_payload:
+            self.working_status = WorkingStatus.CLEANING
+            self.last_active_working_status_time = time.monotonic()
+            self.is_paused = False
+            self.is_returning_to_dock = False
+            self.dock_sub_state = 0
+            self.dock_activity = 0
+            self.dock_presence = 2
+            self.dock_field11 = 1
+            self.dock_field47 = 2
 
     def update_from_base_status(self, decoded: dict[str, Any]) -> None:
         """Update state from a decoded robot_base_status message.
@@ -688,6 +727,8 @@ class NarwalState:
                             raw_val,
                         )
                     self.working_status = WorkingStatus.UNKNOWN
+                if self.working_status not in ACTIVE_CLEANING_STATUSES:
+                    self.last_active_working_status_time = 0.0
             # Sub-field 2: paused overlay (0 or absent = not paused, 1 = paused)
             self.is_paused = bool(field3.get("2"))
             # Sub-field 7: returning to dock on old FW (value 1 = returning).
@@ -709,6 +750,17 @@ class NarwalState:
                     self.dock_presence = int(field3["3"])
                 except (ValueError, TypeError):
                     pass
+            if self.working_status in ACTIVE_CLEANING_STATUSES:
+                if "10" not in field3:
+                    self.dock_sub_state = 0
+                if "12" not in field3:
+                    self.dock_activity = 0
+                if "3" not in field3:
+                    self.dock_presence = 2
+                if "11" not in decoded:
+                    self.dock_field11 = 1
+                if "47" not in decoded:
+                    self.dock_field47 = 2
             # Log unrecognized sub-fields for future firmware mapping
             _known_f3 = {"1", "2", "3", "7", "10", "12"}
             _unknown_f3 = set(field3.keys()) - _known_f3

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from narwal_client.client import NarwalClient, NarwalConnectionError
-from narwal_client.const import CommandResult
+from narwal_client.const import CommandResult, WorkingStatus
 from narwal_client.models import CommandResponse, MapData, RoomInfo
 
 
@@ -30,6 +30,32 @@ class TestNarwalClientInit:
         client = NarwalClient("10.0.0.1")
         assert not client.connected
         assert client.state.battery_level == 0
+
+    def test_unconfirmed_idle_base_status_preserves_active_metrics(self) -> None:
+        """Stale idle base_status must not hide a fresh working_status task."""
+        client = NarwalClient("10.0.0.1")
+        client._update_from_working_status_broadcast({"3": 120})
+
+        client._update_from_base_status_broadcast(
+            {"3": {"1": 1}, "11": 1, "47": 2, "2": 87.0}
+        )
+
+        assert client.state.working_status == WorkingStatus.CLEANING
+        assert client.state.battery_level == 87
+        assert client.state.is_cleaning
+
+    def test_confirmed_dock_base_status_ends_active_metrics(self) -> None:
+        """Fresh dock indicators are trusted even after active task metrics."""
+        client = NarwalClient("10.0.0.1")
+        client._update_from_working_status_broadcast({"3": 120})
+
+        client._update_from_base_status_broadcast(
+            {"3": {"1": 10}, "11": 2, "47": 3}
+        )
+
+        assert client.state.working_status == WorkingStatus.DOCKED
+        assert not client.state.has_recent_active_working_status
+        assert client.state.is_docked
 
     @pytest.mark.asyncio
     async def test_commands_require_connection(self) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -109,6 +109,18 @@ class TestCoordinatorResilience:
         assert coordinator._consecutive_failures == 0
         assert result is coordinator.client.state
 
+    async def test_poll_preserves_recent_active_working_status(self) -> None:
+        """Poll only refreshes hardware fields while task metrics are fresh."""
+        coordinator = self._make_coordinator()
+        type(coordinator.client).connected = PropertyMock(return_value=True)
+        coordinator.client.state.update_from_working_status({"3": 120})
+        coordinator.client.get_status = AsyncMock()
+
+        result = await coordinator._async_update_data()
+
+        coordinator.client.get_status.assert_awaited_once_with(full_update=False)
+        assert result is coordinator.client.state
+
     async def test_push_update_resets_failure_counter(self) -> None:
         """_on_state_update resets _consecutive_failures to 0."""
         coordinator = self._make_coordinator()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -28,7 +28,7 @@ class TestNarwalState:
         assert not state.is_returning
 
     def test_update_from_working_status(self) -> None:
-        """working_status topic sets cleaning metrics, not robot state."""
+        """working_status topic sets cleaning metrics and marks active cleaning."""
         state = NarwalState()
         # Field 2 = coveredArea (float32, m²); field 13 = totalDryStationBagTime, ignored.
         state.update_from_working_status(
@@ -36,8 +36,32 @@ class TestNarwalState:
         )
         assert state.cleaning_time == 120
         assert state.cleaning_area == 12.5
-        # working_status is NOT set by this method (comes from base_status)
+        assert state.working_status == WorkingStatus.CLEANING
+        assert state.has_recent_active_working_status
+
+    def test_working_status_station_timers_do_not_mark_cleaning(self) -> None:
+        """Station-only working_status timers are not active clean telemetry."""
+        state = NarwalState()
+        state.update_from_working_status({"13": 18000})
         assert state.working_status == WorkingStatus.UNKNOWN
+        assert not state.has_recent_active_working_status
+
+    def test_working_status_clears_stale_dock_fields(self) -> None:
+        """Fresh task metrics override stale dock indicators."""
+        state = NarwalState(working_status=WorkingStatus.DOCKED)
+        state.dock_sub_state = 1
+        state.dock_activity = 2
+        state.dock_field11 = 2
+        state.dock_field47 = 3
+
+        state.update_from_working_status({"3": 120})
+
+        assert state.is_cleaning
+        assert not state.is_docked
+        assert state.dock_sub_state == 0
+        assert state.dock_activity == 0
+        assert state.dock_field11 == 1
+        assert state.dock_field47 == 2
 
     def test_update_from_base_status_cleaning(self) -> None:
         state = NarwalState()
@@ -138,6 +162,14 @@ class TestNarwalState:
         })
         assert state.working_status == WorkingStatus.DOCKED_V2
         assert state.is_docked
+
+    def test_cleaning_v2_working_status(self) -> None:
+        """CLEANING_V2(3) on newer Flow 2 firmware maps to active cleaning."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 3}, "11": 1, "47": 2})
+        assert state.working_status == WorkingStatus.CLEANING_V2
+        assert state.is_cleaning
+        assert not state.is_docked
 
     def test_new_fw_field3_unknown_subfields_logged(self) -> None:
         """New firmware sub-fields (4, 11) are parsed without error."""


### PR DESCRIPTION
## What

Rebuilds the old Flow 2 status work as a focused fix for #73. Fresh `status/working_status` task metrics now keep the vacuum entity in an active state briefly, while unconfirmed stale `robot_base_status` dock/idle overlays only refresh battery/consumables instead of clobbering activity. Confirmed dock indicators still end the active state.

Also maps `working_status=3` as an active cleaning state observed on newer Flow 2 firmware.

## Why

#73 reports the vacuum entity freezing on its last base-status state, usually `docked`, while the robot is actually cleaning and other sensors continue updating. The activity path was effectively trusting `robot_base_status` over the live task metrics topic.

## Validation

No live robot validation yet. Non-hardware checks only:

- `python -m compileall -q custom_components/narwal narwal_client tests`
- `git diff --check`
- direct Python smoke assertions for model/client/coordinator stale-status handling

`pytest` is not installed in this checkout, so the focused unit files were added but not run here.