### PR TITLE
feat(camera): carpet-map debug image; map working_status 7 to REMAPPING

### DIFF
--- a/custom_components/narwal/camera.py
+++ b/custom_components/narwal/camera.py
@@ -39,10 +39,48 @@ async def async_setup_entry(
     entry: NarwalConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up the Narwal map camera entity."""
+    """Set up the Narwal camera entities."""
     coordinator = entry.runtime_data
-    entity = NarwalMapCamera(coordinator)
-    async_add_entities([entity])
+    async_add_entities([NarwalMapCamera(coordinator), NarwalCarpetCamera(coordinator)])
+
+
+class NarwalCarpetCamera(NarwalEntity, Camera):
+    """On-demand camera showing the robot's carpet-detection debug image.
+
+    Backed by developer/get_robot_debug_image, which returns cleartext PNGs (no
+    crypto). Images are only produced while the robot is mapping/cleaning, so this
+    only polls in an active state and otherwise serves the last image.
+    """
+
+    _attr_name = "Carpet map"
+
+    def __init__(self, coordinator: NarwalCoordinator) -> None:
+        """Initialize the carpet debug camera entity."""
+        NarwalEntity.__init__(self, coordinator)
+        Camera.__init__(self)
+        device_id = coordinator.config_entry.data["device_id"]
+        self._attr_unique_id = f"{device_id}_carpet_map"
+        self._cached: bytes | None = None
+        self._cached_at: float = 0.0
+
+    async def async_camera_image(
+        self, width: int | None = None, height: int | None = None,
+    ) -> bytes | None:
+        """Return the latest carpet-detection PNG; poll only while active."""
+        state = self.coordinator.data
+        active = state is not None and (
+            state.is_cleaning or state.working_status == WorkingStatus.REMAPPING
+        )
+        if not active:
+            return self._cached  # keep last image; don't hit the WS while idle
+        now = time.monotonic()
+        if self._cached is not None and now - self._cached_at < 8.0:
+            return self._cached
+        img = await self.coordinator.client.get_robot_debug_image()
+        if img is not None:
+            self._cached = img
+            self._cached_at = now
+        return self._cached
 
 
 class NarwalMapCamera(NarwalEntity, Camera):

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -44,6 +44,7 @@ from .const import (
     TOPIC_CMD_SET_MOP_HUMIDITY,
     TOPIC_CMD_START_CLEAN,
     TOPIC_CMD_TAKE_PICTURE,
+    TOPIC_CMD_GET_DEBUG_IMAGE,
     TOPIC_CMD_SET_LED,
     TOPIC_CMD_WASH_MOP,
     TOPIC_CMD_YELL,
@@ -1319,6 +1320,42 @@ class NarwalClient:
             return resp.data.get("2")
         _LOGGER.warning("take_picture returned result_code=%d", resp.result_code)
         return None
+
+    async def get_robot_debug_image(self) -> bytes | None:
+        """Fetch the robot's latest debug/planning image (cleartext PNG).
+
+        developer/get_robot_debug_image returns a batch of carpet-detection and
+        planning overlays as UNENCRYPTED PNGs (222x232 RGB), keyed by filename
+        (InitCarpet/GlobalCarpet/UpdateRoomN_PlanningCarpet). Only produced while
+        the robot is mapping/cleaning; returns None when idle or unavailable.
+
+        Response shape: field 1 = repeated {1: filename, 2: png_bytes}. Returns the
+        most recent whole-map ("GlobalCarpet") PNG if present, else the last image
+        in the batch, else None.
+        """
+        try:
+            resp = await self.send_command(TOPIC_CMD_GET_DEBUG_IMAGE, timeout=15.0)
+        except Exception:
+            _LOGGER.warning("get_robot_debug_image command failed")
+            return None
+        entries = resp.data.get("1")
+        if isinstance(entries, dict):
+            entries = [entries]
+        if not isinstance(entries, list):
+            return None
+        best: bytes | None = None
+        last: bytes | None = None
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            img = entry.get("2")
+            if not isinstance(img, (bytes, bytearray)):
+                continue
+            last = bytes(img)
+            name = entry.get("1")
+            if isinstance(name, str) and "GlobalCarpet" in name:
+                best = bytes(img)  # prefer the most recent whole-map carpet overlay
+        return best or last
 
     async def set_led(self, on: bool) -> None:
         """Turn the camera LED fill light on or off.

--- a/custom_components/narwal/narwal_client/const.py
+++ b/custom_components/narwal/narwal_client/const.py
@@ -96,6 +96,7 @@ TOPIC_CMD_GET_ALL_MAPS = "map/get_all_reduced_maps"
 # Camera (developer commands)
 TOPIC_CMD_TAKE_PICTURE = "developer/take_picture"
 TOPIC_CMD_SET_LED = "developer/led_control"
+TOPIC_CMD_GET_DEBUG_IMAGE = "developer/get_robot_debug_image"  # cleartext carpet/planning PNGs
 
 # Wake / Keep-alive (from APK analysis — candidates for waking sleeping robot)
 TOPIC_CMD_ACTIVE_ROBOT = "common/active_robot_publish"  # TopicDuration keepalive
@@ -151,6 +152,8 @@ class WorkingStatus(IntEnum):
       2  = DOCKED_V2 (on dock; confirmed v01.07.23.00 while charging at 10-36%)
       4  = CLEANING (plan-based start; also stays 4 while returning to dock on older FW)
       5  = CLEANING_ALT (observed live: robot was physically stuck when reporting 5)
+      7  = REMAPPING (live 2026-07-09: robot exploring/rebuilding the map; camera
+           active — developer/take_picture is accepted in this state)
       10 = DOCKED (on dock, charging)
       14 = CHARGED (on dock, fully charged)
       19 = TASK_COMPLETED (transitional: scheduled task finished, returning to base)
@@ -170,6 +173,7 @@ class WorkingStatus(IntEnum):
     DOCKED_V2 = 2     # on dock (v01.07.23.00+ — replaces DOCKED=10/CHARGED=14 from older FW)
     CLEANING = 4      # active cleaning (stays 4 even while returning to dock)
     CLEANING_ALT = 5  # cleaning — observed when robot was physically stuck; may indicate error/stuck state
+    REMAPPING = 7     # mapping/exploration (live 2026-07-09); camera active, take_picture accepted
     DOCKED = 10       # on dock (does NOT reliably indicate charging vs charged)
     CHARGED = 14      # on dock (reported before 100% — use battery_level for charge state)
     TASK_COMPLETED = 19  # transitional: task finished, robot returning to base (#41)

--- a/custom_components/narwal/vacuum.py
+++ b/custom_components/narwal/vacuum.py
@@ -35,6 +35,7 @@ WORKING_STATUS_TO_ACTIVITY: dict[WorkingStatus, VacuumActivity] = {
     WorkingStatus.STANDBY: VacuumActivity.IDLE,
     WorkingStatus.CLEANING: VacuumActivity.CLEANING,
     WorkingStatus.CLEANING_ALT: VacuumActivity.CLEANING,
+    WorkingStatus.REMAPPING: VacuumActivity.CLEANING,  # mapping/exploration — robot is actively busy
     WorkingStatus.TASK_COMPLETED: VacuumActivity.RETURNING,
     WorkingStatus.ERROR: VacuumActivity.ERROR,
 }

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -44,6 +44,7 @@ from .const import (
     TOPIC_CMD_SET_MOP_HUMIDITY,
     TOPIC_CMD_START_CLEAN,
     TOPIC_CMD_TAKE_PICTURE,
+    TOPIC_CMD_GET_DEBUG_IMAGE,
     TOPIC_CMD_SET_LED,
     TOPIC_CMD_WASH_MOP,
     TOPIC_CMD_YELL,
@@ -1319,6 +1320,42 @@ class NarwalClient:
             return resp.data.get("2")
         _LOGGER.warning("take_picture returned result_code=%d", resp.result_code)
         return None
+
+    async def get_robot_debug_image(self) -> bytes | None:
+        """Fetch the robot's latest debug/planning image (cleartext PNG).
+
+        developer/get_robot_debug_image returns a batch of carpet-detection and
+        planning overlays as UNENCRYPTED PNGs (222x232 RGB), keyed by filename
+        (InitCarpet/GlobalCarpet/UpdateRoomN_PlanningCarpet). Only produced while
+        the robot is mapping/cleaning; returns None when idle or unavailable.
+
+        Response shape: field 1 = repeated {1: filename, 2: png_bytes}. Returns the
+        most recent whole-map ("GlobalCarpet") PNG if present, else the last image
+        in the batch, else None.
+        """
+        try:
+            resp = await self.send_command(TOPIC_CMD_GET_DEBUG_IMAGE, timeout=15.0)
+        except Exception:
+            _LOGGER.warning("get_robot_debug_image command failed")
+            return None
+        entries = resp.data.get("1")
+        if isinstance(entries, dict):
+            entries = [entries]
+        if not isinstance(entries, list):
+            return None
+        best: bytes | None = None
+        last: bytes | None = None
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            img = entry.get("2")
+            if not isinstance(img, (bytes, bytearray)):
+                continue
+            last = bytes(img)
+            name = entry.get("1")
+            if isinstance(name, str) and "GlobalCarpet" in name:
+                best = bytes(img)  # prefer the most recent whole-map carpet overlay
+        return best or last
 
     async def set_led(self, on: bool) -> None:
         """Turn the camera LED fill light on or off.

--- a/narwal_client/const.py
+++ b/narwal_client/const.py
@@ -96,6 +96,7 @@ TOPIC_CMD_GET_ALL_MAPS = "map/get_all_reduced_maps"
 # Camera (developer commands)
 TOPIC_CMD_TAKE_PICTURE = "developer/take_picture"
 TOPIC_CMD_SET_LED = "developer/led_control"
+TOPIC_CMD_GET_DEBUG_IMAGE = "developer/get_robot_debug_image"  # cleartext carpet/planning PNGs
 
 # Wake / Keep-alive (from APK analysis — candidates for waking sleeping robot)
 TOPIC_CMD_ACTIVE_ROBOT = "common/active_robot_publish"  # TopicDuration keepalive
@@ -151,6 +152,8 @@ class WorkingStatus(IntEnum):
       2  = DOCKED_V2 (on dock; confirmed v01.07.23.00 while charging at 10-36%)
       4  = CLEANING (plan-based start; also stays 4 while returning to dock on older FW)
       5  = CLEANING_ALT (observed live: robot was physically stuck when reporting 5)
+      7  = REMAPPING (live 2026-07-09: robot exploring/rebuilding the map; camera
+           active — developer/take_picture is accepted in this state)
       10 = DOCKED (on dock, charging)
       14 = CHARGED (on dock, fully charged)
       19 = TASK_COMPLETED (transitional: scheduled task finished, returning to base)
@@ -170,6 +173,7 @@ class WorkingStatus(IntEnum):
     DOCKED_V2 = 2     # on dock (v01.07.23.00+ — replaces DOCKED=10/CHARGED=14 from older FW)
     CLEANING = 4      # active cleaning (stays 4 even while returning to dock)
     CLEANING_ALT = 5  # cleaning — observed when robot was physically stuck; may indicate error/stuck state
+    REMAPPING = 7     # mapping/exploration (live 2026-07-09); camera active, take_picture accepted
     DOCKED = 10       # on dock (does NOT reliably indicate charging vs charged)
     CHARGED = 14      # on dock (reported before 100% — use battery_level for charge state)
     TASK_COMPLETED = 19  # transitional: task finished, robot returning to base (#41)


### PR DESCRIPTION
Rebased onto v1.0.1 and reduced to only what's unique here, per your note in #66. Now one commit, no conflicts.

## What's left

- **Carpet-map debug camera** — `developer/get_robot_debug_image` serves the robot's cleartext carpet-detection PNGs (no crypto involved). Polls only while the robot is active, so it never holds the WebSocket while docked.
- **`working_status` 7 → REMAPPING** — observed live during map exploration, mapped to the CLEANING activity. Also clears the `Unknown working_status value: 7` warnings.

## What I dropped

- The cleaning-area fix and config-flow i18n — now upstream via #51 and #47.
- Room cleaning, clean settings, current room, last-clean-result, consumables — these duplicate #49, #50, #24, #53 and #54, which are yours to sequence.

## Two things that didn't survive the split

- **`18d5520a` (base-status error-clear)** — it patches `_parse_error_codes`, which arrives with the base-status audit in #52 and isn't on master yet. Applying it standalone isn't possible; happy to send it right after #52 lands.
- **French translations** — all of them cover the entities being dropped above, and the diff also reverted the config-flow strings you just merged in #47. Upstream `fr.json` is currently complete against `en.json`, so there's nothing to contribute on its own. I'll resend French alongside whichever feature PRs land.

The asyncio fix is split out as #71.

Validated on a Freo X10 Pro (AX15). 168 tests pass on v1.0.1.
