### PR TITLE
fix(tests): resolve asyncio get_event_loop deprecation in Python 3.12

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -31,17 +31,17 @@ class TestNarwalClientInit:
         assert not client.connected
         assert client.state.battery_level == 0
 
-    def test_commands_require_connection(self) -> None:
+    @pytest.mark.asyncio
+    async def test_commands_require_connection(self) -> None:
         client = NarwalClient("10.0.0.1")
         with pytest.raises(NarwalConnectionError):
-            asyncio.get_event_loop().run_until_complete(client.start())
+            await client.start()
 
-    def test_send_raw_without_connection_raises(self) -> None:
+    @pytest.mark.asyncio
+    async def test_send_raw_without_connection_raises(self) -> None:
         client = NarwalClient("10.0.0.1")
         with pytest.raises(NarwalConnectionError):
-            asyncio.get_event_loop().run_until_complete(
-                client.send_raw("test/topic", b"\x08\x01")
-            )
+            await client.send_raw("test/topic", b"\x08\x01")
 
 
 class TestBuildCleanPayloadV2:
@@ -123,7 +123,8 @@ class TestStartLegacyAndV2Fallback:
         client._connected = True
         return client
 
-    def test_start_returns_legacy_response_on_success(self) -> None:
+    @pytest.mark.asyncio
+    async def test_start_returns_legacy_response_on_success(self) -> None:
         """If legacy payload succeeds (code=1), no v2 retry happens."""
         client = self._connected_client()
         success = CommandResponse(result_code=CommandResult.SUCCESS)
@@ -132,12 +133,13 @@ class TestStartLegacyAndV2Fallback:
             client, "send_command", new_callable=AsyncMock
         ) as mock_send:
             mock_send.return_value = success
-            result = asyncio.get_event_loop().run_until_complete(client.start())
+            result = await client.start()
 
         assert result is success
         mock_send.assert_awaited_once()  # no fallback fired
 
-    def test_start_falls_back_to_v2_on_not_applicable(self) -> None:
+    @pytest.mark.asyncio
+    async def test_start_falls_back_to_v2_on_not_applicable(self) -> None:
         """NOT_APPLICABLE from legacy triggers v2 retry with cached rooms."""
         client = self._connected_client()
         client.state.map_data = MapData(rooms=[
@@ -152,7 +154,7 @@ class TestStartLegacyAndV2Fallback:
             client, "send_command", new_callable=AsyncMock
         ) as mock_send:
             mock_send.side_effect = [not_applicable, success]
-            result = asyncio.get_event_loop().run_until_complete(client.start())
+            result = await client.start()
 
         assert mock_send.await_count == 2
         # Second call's payload must be v2 (different bytes from legacy)
@@ -161,7 +163,8 @@ class TestStartLegacyAndV2Fallback:
         assert second_payload != client._DEFAULT_CLEAN_PAYLOAD
         assert result is success
 
-    def test_start_returns_not_applicable_when_no_map_cached(self) -> None:
+    @pytest.mark.asyncio
+    async def test_start_returns_not_applicable_when_no_map_cached(self) -> None:
         """NOT_APPLICABLE without a cached map surfaces the error
         instead of crashing — user just needs to load the map first."""
         client = self._connected_client()
@@ -173,12 +176,13 @@ class TestStartLegacyAndV2Fallback:
             client, "send_command", new_callable=AsyncMock
         ) as mock_send:
             mock_send.return_value = not_applicable
-            result = asyncio.get_event_loop().run_until_complete(client.start())
+            result = await client.start()
 
         mock_send.assert_awaited_once()  # no v2 retry without rooms
         assert result.result_code == CommandResult.NOT_APPLICABLE
 
-    def test_start_skips_v2_when_map_has_no_room_ids(self) -> None:
+    @pytest.mark.asyncio
+    async def test_start_skips_v2_when_map_has_no_room_ids(self) -> None:
         """Map present but every room_id is 0 — don't send junk."""
         client = self._connected_client()
         client.state.map_data = MapData(rooms=[RoomInfo(room_id=0)])
@@ -189,7 +193,7 @@ class TestStartLegacyAndV2Fallback:
             client, "send_command", new_callable=AsyncMock
         ) as mock_send:
             mock_send.return_value = not_applicable
-            result = asyncio.get_event_loop().run_until_complete(client.start())
+            result = await client.start()
 
         mock_send.assert_awaited_once()
         assert result.result_code == CommandResult.NOT_APPLICABLE

--- a/tests/test_client_rooms.py
+++ b/tests/test_client_rooms.py
@@ -80,7 +80,8 @@ class TestBuildRoomCleanPayload:
 class TestStartRooms:
     """Tests for start_rooms async method."""
 
-    def test_empty_rooms_calls_start(self) -> None:
+    @pytest.mark.asyncio
+    async def test_empty_rooms_calls_start(self) -> None:
         """start_rooms([]) falls back to whole-house start()."""
         client = NarwalClient("127.0.0.1")
         client._ws = AsyncMock()  # fake connected state
@@ -88,10 +89,11 @@ class TestStartRooms:
 
         with patch.object(client, "start", new_callable=AsyncMock) as mock_start:
             mock_start.return_value = AsyncMock()
-            asyncio.get_event_loop().run_until_complete(client.start_rooms([]))
+            await client.start_rooms([])
             mock_start.assert_awaited_once()
 
-    def test_room_ids_sends_room_payload(self) -> None:
+    @pytest.mark.asyncio
+    async def test_room_ids_sends_room_payload(self) -> None:
         """start_rooms with IDs sends room-specific payload via send_command."""
         client = NarwalClient("127.0.0.1")
         client._ws = AsyncMock()
@@ -102,7 +104,7 @@ class TestStartRooms:
             client, "send_command", new_callable=AsyncMock
         ) as mock_send:
             mock_send.return_value = success
-            asyncio.get_event_loop().run_until_complete(client.start_rooms([11, 9]))
+            await client.start_rooms([11, 9])
             mock_send.assert_awaited_once()
             payload_arg = mock_send.await_args.kwargs.get("payload")
             assert payload_arg is not None
@@ -122,7 +124,8 @@ class TestStartRoomsV2First:
         client._connected = True
         return client
 
-    def test_success_on_v2_does_not_retry(self) -> None:
+    @pytest.mark.asyncio
+    async def test_success_on_v2_does_not_retry(self) -> None:
         """If the v2 room payload is accepted, no legacy retry happens."""
         client = self._connected_client()
         success = CommandResponse(result_code=CommandResult.SUCCESS)
@@ -131,14 +134,13 @@ class TestStartRoomsV2First:
             client, "send_command", new_callable=AsyncMock
         ) as mock_send:
             mock_send.return_value = success
-            result = asyncio.get_event_loop().run_until_complete(
-                client.start_rooms([5])
-            )
+            result = await client.start_rooms([5])
 
         assert result is success
         mock_send.assert_awaited_once()
 
-    def test_v2_sends_correct_room_ids(self) -> None:
+    @pytest.mark.asyncio
+    async def test_v2_sends_correct_room_ids(self) -> None:
         """v2 payload encodes exactly the requested rooms."""
         client = self._connected_client()
         success = CommandResponse(result_code=CommandResult.SUCCESS)
@@ -147,9 +149,7 @@ class TestStartRoomsV2First:
             client, "send_command", new_callable=AsyncMock
         ) as mock_send:
             mock_send.return_value = success
-            asyncio.get_event_loop().run_until_complete(
-                client.start_rooms([5, 7])
-            )
+            await client.start_rooms([5, 7])
 
         import blackboxprotobuf
         payload = mock_send.await_args.kwargs.get("payload")
@@ -158,7 +158,8 @@ class TestStartRoomsV2First:
         ids = [e["1"]["2"] for e in entries]
         assert ids == [5, 7]
 
-    def test_not_applicable_triggers_legacy_retry(self) -> None:
+    @pytest.mark.asyncio
+    async def test_not_applicable_triggers_legacy_retry(self) -> None:
         """NOT_APPLICABLE on v2 triggers a legacy flat-room retry."""
         client = self._connected_client()
         not_applicable = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
@@ -168,9 +169,7 @@ class TestStartRoomsV2First:
             client, "send_command", new_callable=AsyncMock
         ) as mock_send:
             mock_send.side_effect = [not_applicable, success]
-            result = asyncio.get_event_loop().run_until_complete(
-                client.start_rooms([5, 7])
-            )
+            result = await client.start_rooms([5, 7])
 
         assert mock_send.await_count == 2
         v2_payload = mock_send.await_args_list[0].kwargs.get("payload")
@@ -178,7 +177,8 @@ class TestStartRoomsV2First:
         assert v2_payload != legacy_payload
         assert result is success
 
-    def test_conflict_does_not_trigger_retry(self) -> None:
+    @pytest.mark.asyncio
+    async def test_conflict_does_not_trigger_retry(self) -> None:
         """A CONFLICT response (robot busy) surfaces as-is — no retry."""
         client = self._connected_client()
         conflict = CommandResponse(result_code=CommandResult.CONFLICT)
@@ -187,9 +187,7 @@ class TestStartRoomsV2First:
             client, "send_command", new_callable=AsyncMock
         ) as mock_send:
             mock_send.return_value = conflict
-            result = asyncio.get_event_loop().run_until_complete(
-                client.start_rooms([5])
-            )
+            result = await client.start_rooms([5])
 
         mock_send.assert_awaited_once()
         assert result.result_code == CommandResult.CONFLICT


### PR DESCRIPTION
Split out of #67 as requested.

Replaces `asyncio.get_event_loop().run_until_complete(...)` in the tests with
`@pytest.mark.asyncio` coroutine tests. `get_event_loop()` raises a
DeprecationWarning on Python 3.12+ when there is no running loop, and is slated
to become an error.

Tests only — no changes to integration code.

168 tests pass on `master` (v1.0.1).
