### PR TITLE
fix(logging): warn once per unmapped working_status value (#46)

### DIFF
--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -9,6 +9,11 @@ from typing import Any, ClassVar
 
 _LOGGER = logging.getLogger(__name__)
 
+# Raw working_status values already reported. The robot rebroadcasts its status
+# every ~1.5s, so warning on each broadcast floods the log with thousands of
+# identical lines (#46). Warn once per distinct value instead.
+_WARNED_WORKING_STATUS: set[Any] = set()
+
 from .const import CommandResult, FanLevel, MopHumidity, WorkingStatus
 
 
@@ -694,11 +699,14 @@ class NarwalState:
                     self.working_status = WorkingStatus(int(field3["1"]))
                 except (ValueError, TypeError):
                     raw_val = field3["1"]
-                    _LOGGER.warning(
-                        "Unknown working_status value: %s — treating as UNKNOWN. "
-                        "Please report this value at the GitHub repo.",
-                        raw_val,
-                    )
+                    if raw_val not in _WARNED_WORKING_STATUS:
+                        _WARNED_WORKING_STATUS.add(raw_val)
+                        _LOGGER.warning(
+                            "Unknown working_status value: %s — treating as UNKNOWN. "
+                            "Please report this value at the GitHub repo. "
+                            "(further occurrences of this value are suppressed)",
+                            raw_val,
+                        )
                     self.working_status = WorkingStatus.UNKNOWN
             # Sub-field 2: paused overlay (0 or absent = not paused, 1 = paused)
             self.is_paused = bool(field3.get("2"))

--- a/custom_components/narwal/vacuum.py
+++ b/custom_components/narwal/vacuum.py
@@ -28,6 +28,11 @@ from .entity import NarwalEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+# working_status values already reported as unmapped. Activity is recomputed on
+# every state broadcast (~1.5s), so an unmapped value otherwise floods the log
+# with thousands of identical lines (#46). Warn once per distinct value.
+_WARNED_UNMAPPED_ACTIVITY: set[int] = set()
+
 WORKING_STATUS_TO_ACTIVITY: dict[WorkingStatus, VacuumActivity] = {
     WorkingStatus.DOCKED: VacuumActivity.DOCKED,
     WorkingStatus.CHARGED: VacuumActivity.DOCKED,
@@ -100,10 +105,13 @@ class NarwalVacuum(NarwalEntity, StateVacuumEntity):
         # don't report IDLE while the robot is clearly active off-dock.
         # New firmware versions may introduce values we haven't mapped yet.
         if not state.is_docked:
-            _LOGGER.warning(
-                "Unmapped working_status %s (%d) while off-dock — reporting CLEANING",
-                state.working_status.name, state.working_status.value,
-            )
+            if state.working_status.value not in _WARNED_UNMAPPED_ACTIVITY:
+                _WARNED_UNMAPPED_ACTIVITY.add(state.working_status.value)
+                _LOGGER.warning(
+                    "Unmapped working_status %s (%d) while off-dock — reporting "
+                    "CLEANING (further occurrences of this value are suppressed)",
+                    state.working_status.name, state.working_status.value,
+                )
             return VacuumActivity.CLEANING
         return VacuumActivity.IDLE
 

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -9,6 +9,11 @@ from typing import Any, ClassVar
 
 _LOGGER = logging.getLogger(__name__)
 
+# Raw working_status values already reported. The robot rebroadcasts its status
+# every ~1.5s, so warning on each broadcast floods the log with thousands of
+# identical lines (#46). Warn once per distinct value instead.
+_WARNED_WORKING_STATUS: set[Any] = set()
+
 from .const import CommandResult, FanLevel, MopHumidity, WorkingStatus
 
 
@@ -694,11 +699,14 @@ class NarwalState:
                     self.working_status = WorkingStatus(int(field3["1"]))
                 except (ValueError, TypeError):
                     raw_val = field3["1"]
-                    _LOGGER.warning(
-                        "Unknown working_status value: %s — treating as UNKNOWN. "
-                        "Please report this value at the GitHub repo.",
-                        raw_val,
-                    )
+                    if raw_val not in _WARNED_WORKING_STATUS:
+                        _WARNED_WORKING_STATUS.add(raw_val)
+                        _LOGGER.warning(
+                            "Unknown working_status value: %s — treating as UNKNOWN. "
+                            "Please report this value at the GitHub repo. "
+                            "(further occurrences of this value are suppressed)",
+                            raw_val,
+                        )
                     self.working_status = WorkingStatus.UNKNOWN
             # Sub-field 2: paused overlay (0 or absent = not paused, 1 = paused)
             self.is_paused = bool(field3.get("2"))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import struct
 
 from narwal_client.const import WorkingStatus
@@ -191,6 +192,24 @@ class TestNarwalState:
         """Unmapped working_status value falls back to UNKNOWN."""
         state = NarwalState()
         state.update_from_base_status({"3": {"1": 99}})
+        assert state.working_status == WorkingStatus.UNKNOWN
+
+    def test_unknown_working_status_warns_once(self, caplog) -> None:
+        """Repeated unknown values warn once, not once per broadcast (#46).
+
+        The robot rebroadcasts status every ~1.5s; warning each time floods
+        the log with thousands of identical lines.
+        """
+        from narwal_client import models as models_mod
+
+        models_mod._WARNED_WORKING_STATUS.discard(17)
+        state = NarwalState()
+        with caplog.at_level(logging.WARNING, logger=models_mod.__name__):
+            for _ in range(50):
+                state.update_from_base_status({"3": {"1": 17}})
+
+        warnings = [r for r in caplog.records if "Unknown working_status" in r.message]
+        assert len(warnings) == 1
         assert state.working_status == WorkingStatus.UNKNOWN
 
     def test_update_from_base_status(self) -> None:


### PR DESCRIPTION
Fixes the log flooding in #46.

`base_status` is rebroadcast roughly every 1.5s and activity is recomputed on each one, so a single unmapped `working_status` warns on every broadcast from two separate paths — reported as 288 and 2071 occurrences in about 40 minutes.

Both paths now warn once per distinct value. Behaviour is otherwise unchanged: an unknown value off-dock still reports CLEANING, and the value is still surfaced once so it can be reported.

Value `17` itself is left unmapped. I can't reproduce it on a Freo X10 Pro (AX15), and the enum is explicitly model-dependent — mapping it from a Flow 2 report would risk showing the wrong state on other models. The reporter would need to say what the robot was physically doing for that half to be closed.

Sent standalone since it's independent of #67. 169 tests pass on v1.0.1, including a regression test that asserts 50 broadcasts produce one warning.
