### PR TITLE
feat: add Freo Z Ultra local control

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ This integration uses a **local WebSocket connection on port 9002**. Only models
 | **Freo Z10 Pro / Turbo** (AX26) | **Working** | Same product key and firmware (v01.02.00.15) reported under both names ([#40](https://github.com/sjmotew/NarwalIntegration/issues/40), [#70](https://github.com/sjmotew/NarwalIntegration/issues/70)). Room cleaning confirmed working with [#49](https://github.com/sjmotew/NarwalIntegration/pull/49). |
 | **Freo X10 Pro** (AX15) | **Working** | Community confirmed ([#12](https://github.com/sjmotew/NarwalIntegration/issues/12)) |
 | **Narwal JX** | **Unconfirmed** | Product key known, no working report yet — testers welcome ([#42](https://github.com/sjmotew/NarwalIntegration/issues/42)) |
-| **Freo Z Ultra** (CX7) | **Not Compatible** | Port 9002 open but no local broadcasts; cloud-only ([#5](https://github.com/sjmotew/NarwalIntegration/issues/5), confirmed by @Folg0re) |
+| **Freo Z Ultra** (hardware CX7, cloud identity J5) | **Working** | Requires the cloud-assigned Device ID during setup because this model does not broadcast. Base status, maps, consumables, and commands work locally; live cleaning position/progress is unavailable. |
 | **Freo X Ultra** (AX18/AX19) | **Not Compatible** | Uses ZeroMQ (port 6789) + Tuya cloud, not WebSocket ([#4](https://github.com/sjmotew/NarwalIntegration/issues/4)) |
 | **Freo X Plus** | **Not Compatible** | Cloud-only — no local API |
-| **Narwal J-series** (J1/J4/J5) | **Not Compatible** | J1: HTTP-only (port 8080); J4/J5: cloud-only (Tuya) |
+| **Narwal J-series** (J1/J4) | **Not Compatible** | J1: HTTP-only (port 8080); J4: cloud-only (Tuya). J5 is the cloud identity of the supported global CX7 listed above. |
 
 Models marked **Not Compatible** use a different protocol or are cloud-only. This is a hardware/firmware limitation.
 
@@ -113,6 +113,10 @@ Shipped in v1.0.2 ([#50](https://github.com/sjmotew/NarwalIntegration/pull/50)) 
 
 > **Tip:** Assign a static IP to your vacuum in your router.
 
+The Freo Z Ultra (CX7) also requires its 32-character cloud-assigned Device ID. Selecting that
+model opens a dedicated Device ID page; other models use automatic discovery. The integration
+itself never contacts the cloud.
+
 ### Room cleaning setup (required before `vacuum.clean_area` works)
 
 Home Assistant's room cleaning targets **HA areas**, not the robot's own rooms, so there is a one-time mapping step. Without it the service fails with *"Area mapping is not configured for vacuum.&lt;entity&gt;"*.
@@ -155,6 +159,7 @@ Room names come from the robot's map — rooms you named in the Narwal app keep 
 
 - **Wake from deep sleep is unreliable** — robot may not respond after long idle periods. Opening the Narwal app briefly can help.
 - **Single connection** — close the Narwal app before using HA to avoid conflicts.
+- **CX7 has no live stream** — it never broadcasts, so cleaning position and progress do not update live. Polled base status, battery, dock state, maps, consumables, and commands remain available.
 - **Fan speed is set-only** — robot doesn't broadcast its current level.
 - **All cleaning requires the dock** — `clean/start_clean` returns `NOT_READY` if the robot is not docked when the command is sent. This applies to whole-house `vacuum.start` as well as room cleans.
 - **Room cleaning needs a segment-to-area mapping** — `vacuum.clean_area` targets Home Assistant *areas*, not robot rooms, and the mapping editor is on the **entity**, not the integration or device page. See [Room cleaning setup](#room-cleaning-setup-required-before-vacuumclean_area-works). Without it the service fails with "Area mapping is not configured".

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Room names come from the robot's map — rooms you named in the Narwal app keep 
 
 - **Wake from deep sleep is unreliable** — robot may not respond after long idle periods. Opening the Narwal app briefly can help.
 - **Single connection** — close the Narwal app before using HA to avoid conflicts.
-- **CX7 has no live stream** — it never broadcasts, so cleaning position and progress do not update live. Polled base status, battery, dock state, maps, consumables, and commands remain available.
+- **CX7 has no live stream** — it never broadcasts, so cleaning position and progress do not update live. Polled base status, battery, dock state, maps, consumables, and commands remain available. State follows the 60-second poll, so the vacuum entity reaches `cleaning` up to a minute after the robot starts (31 s in a recorded run), and `cleaning_time`, `cleaning_area` and `current_room` stay `unknown` throughout a clean because they are only carried in broadcasts.
 - **Fan speed is set-only** — robot doesn't broadcast its current level.
 - **All cleaning requires the dock** — `clean/start_clean` returns `NOT_READY` if the robot is not docked when the command is sent. This applies to whole-house `vacuum.start` as well as room cleans.
 - **Room cleaning needs a segment-to-area mapping** — `vacuum.clean_area` targets Home Assistant *areas*, not robot rooms, and the mapping editor is on the **entity**, not the integration or device page. See [Room cleaning setup](#room-cleaning-setup-required-before-vacuumclean_area-works). Without it the service fails with "Area mapping is not configured".

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This integration uses a **local WebSocket connection on port 9002**. Only models
 | **Freo Z10 Pro / Turbo** (AX26) | **Working** | Same product key and firmware (v01.02.00.15) reported under both names ([#40](https://github.com/sjmotew/NarwalIntegration/issues/40), [#70](https://github.com/sjmotew/NarwalIntegration/issues/70)). Room cleaning confirmed working with [#49](https://github.com/sjmotew/NarwalIntegration/pull/49). |
 | **Freo X10 Pro** (AX15) | **Working** | Community confirmed ([#12](https://github.com/sjmotew/NarwalIntegration/issues/12)) |
 | **Narwal JX** | **Unconfirmed** | Product key known, no working report yet — testers welcome ([#42](https://github.com/sjmotew/NarwalIntegration/issues/42)) |
-| **Freo Z Ultra** (hardware CX7, cloud identity J5) | **Working** | Requires the cloud-assigned Device ID during setup because this model does not broadcast. Base status, maps, consumables, and commands work locally; live cleaning position/progress is unavailable. |
+| **Freo Z Ultra** (hardware CX7, cloud identity J5) | **Working on tested variant** | Confirmed with product key `hEA7OEshlx` on firmware `v01.13.11.02`. Requires the cloud-assigned Device ID because this model does not broadcast. Base status, maps, consumables, and commands work locally; live cleaning position/progress is unavailable. See the variant note below. |
 | **Freo X Ultra** (AX18/AX19) | **Not Compatible** | Uses ZeroMQ (port 6789) + Tuya cloud, not WebSocket ([#4](https://github.com/sjmotew/NarwalIntegration/issues/4)) |
 | **Freo X Plus** | **Not Compatible** | Cloud-only — no local API |
 | **Narwal J-series** (J1/J4) | **Not Compatible** | J1: HTTP-only (port 8080); J4: cloud-only (Tuya). J5 is the cloud identity of the supported global CX7 listed above. |
@@ -86,7 +86,7 @@ Shipped in v1.0.2 ([#50](https://github.com/sjmotew/NarwalIntegration/pull/50)) 
 - **Ambient light** — off, fireplace, nightlight, purple, on models with a dock light ([#61](https://github.com/sjmotew/NarwalIntegration/pull/61), v1.0.2)
 
 ### Connectivity
-- Real-time WebSocket push updates
+- Real-time WebSocket push updates on broadcasting models
 - Auto-reconnect with exponential backoff
 - Wake system for sleeping robots + keepalive heartbeat
 - 60-second polling fallback
@@ -116,6 +116,35 @@ Shipped in v1.0.2 ([#50](https://github.com/sjmotew/NarwalIntegration/pull/50)) 
 The Freo Z Ultra (CX7) also requires its 32-character cloud-assigned Device ID. Selecting that
 model opens a dedicated Device ID page; other models use automatic discovery. The integration
 itself never contacts the cloud.
+
+#### Finding the Device ID
+
+The Narwal app does not currently display this value. It is the 32-character hexadecimal
+identifier used as the second component of a Narwal MQTT topic:
+
+```text
+/<product_key>/<device_id>/status/working_status
+```
+
+You can obtain it from one of these sources:
+
+- The `deviceId` field returned by Narwal's authenticated account endpoint
+  `/user-device-platform-server/device-info/getDeviceInfoList`.
+- A Narwal MQTT capture, where it appears in the topic position shown above.
+- The stored device identifier or diagnostics from an existing Narwal cloud integration.
+
+Account and MQTT tooling is deliberately kept separate from this integration so Home Assistant
+never receives your Narwal credentials. Do not post the Device ID publicly; treat it as a device
+identifier even though it is not an account password or access token.
+
+#### CX7 variants
+
+Local control is currently verified on one global Freo Z Ultra whose cloud identity is J5,
+product key is `hEA7OEshlx`, and firmware is `v01.13.11.02`. Issue
+[#5](https://github.com/sjmotew/NarwalIntegration/issues/5) also contains reports of firmware
+`1.12.10.02` and a `BYWBPqSxeC` identity. That key remains in discovery coverage, but has not
+been proven to accept addressed local commands. Reports from additional regions and firmware
+versions are needed before support can be considered universal.
 
 ### Room cleaning setup (required before `vacuum.clean_area` works)
 

--- a/custom_components/narwal/__init__.py
+++ b/custom_components/narwal/__init__.py
@@ -8,8 +8,15 @@ from typing import TypeAlias
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 
-from .const import CONF_MODEL, CONF_PRODUCT_KEY, PLATFORMS
+from .const import (
+    CONF_MODEL,
+    CONF_PRODUCT_KEY,
+    DOMAIN,
+    PLATFORMS,
+    configured_model_name,
+)
 from .coordinator import NarwalCoordinator
 from .narwal_client import NarwalConnectionError
 
@@ -50,6 +57,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: NarwalConfigEntry) -> bo
     entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, entry.data["device_id"])}
+    )
+    if device is not None:
+        device_registry.async_update_device(
+            device.id,
+            model=configured_model_name(entry.data),
+            sw_version=coordinator.client.state.firmware_version or None,
+        )
 
     return True
 

--- a/custom_components/narwal/config_flow.py
+++ b/custom_components/narwal/config_flow.py
@@ -6,12 +6,18 @@ import logging
 from typing import Any
 
 import voluptuous as vol
-
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 
-from .narwal_client import NarwalClient, NarwalCommandError, NarwalConnectionError
-
-from .const import CONF_MODEL, CONF_PRODUCT_KEY, DEFAULT_PORT, DOMAIN, NARWAL_MODELS
+from .const import (
+    CONF_DEVICE_ID,
+    CONF_MODEL,
+    CONF_PRODUCT_KEY,
+    DEFAULT_PORT,
+    DOMAIN,
+    NARWAL_MODELS,
+    NO_BROADCAST_PRODUCT_KEYS,
+)
+from .narwal_client import NarwalClient
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,15 +31,15 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     }
 )
 
+STEP_DEVICE_ID_DATA_SCHEMA = vol.Schema({vol.Required(CONF_DEVICE_ID): str})
+
 
 class NarwalConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Narwal vacuum."""
 
     VERSION = 2
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle the initial step — user enters IP, port, and model."""
         errors: dict[str, str] = {}
 
@@ -42,46 +48,29 @@ class NarwalConfigFlow(ConfigFlow, domain=DOMAIN):
             port = user_input.get("port", DEFAULT_PORT)
             model_label = user_input[CONF_MODEL]
             product_key = NARWAL_MODELS[model_label]
+            self._pending_user_input = user_input
+            self._pending_product_key = product_key
 
-            # If user selected a specific model, set topic prefix directly
+            if product_key in NO_BROADCAST_PRODUCT_KEYS:
+                return await self.async_step_device_id()
+
             topic_prefix = None if product_key == "auto" else f"/{product_key}"
-
-            client = NarwalClient(
-                host=host, port=port, topic_prefix=topic_prefix,
-            )
+            client = NarwalClient(host=host, port=port, topic_prefix=topic_prefix)
             try:
                 await client.connect()
-                # Discover device_id from broadcast, then query info
-                await client.discover_device_id(timeout=15.0)
-                # Drain any stale field5 responses left in the WebSocket
-                # buffer from discover's wake probes before sending a
-                # real command
-                await client.drain_ws_buffer()
-                device_info = await client.get_device_info()
             except Exception as ex:
-                _LOGGER.warning(
-                    "Setup failed: %s: %s", type(ex).__name__, ex,
-                )
+                _LOGGER.warning("Setup connection failed: %s: %s", type(ex).__name__, ex)
                 errors["base"] = "cannot_connect"
             else:
-                device_id = device_info.device_id
-                await self.async_set_unique_id(device_id)
-                self._abort_if_unique_id_configured()
-
-                # Use the product key that actually worked (may have been
-                # auto-detected during discovery even if user picked "auto")
-                resolved_key = client.topic_prefix.lstrip("/")
-
-                return self.async_create_entry(
-                    title=model_label if product_key != "auto" else f"Narwal {resolved_key}",
-                    data={
-                        "host": host,
-                        "port": port,
-                        "device_id": device_id,
-                        CONF_PRODUCT_KEY: resolved_key,
-                        CONF_MODEL: model_label,
-                    },
-                )
+                try:
+                    await client.discover_device_id(timeout=15.0)
+                    await client.drain_ws_buffer()
+                    device_info = await client.get_device_info()
+                except Exception as ex:
+                    _LOGGER.info("Automatic Device ID discovery failed: %s", ex)
+                    return await self.async_step_device_id()
+                else:
+                    return await self._async_create_entry(client, device_info.device_id)
             finally:
                 await client.disconnect()
 
@@ -89,4 +78,69 @@ class NarwalConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors,
+        )
+
+    async def async_step_device_id(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Validate a manually supplied Device ID after discovery is unavailable."""
+        return await self._async_step_device_id(user_input, "device_id")
+
+    async def _async_step_device_id(
+        self,
+        user_input: dict[str, Any] | None,
+        step_id: str,
+    ) -> ConfigFlowResult:
+        """Validate a manually supplied Device ID."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            device_id = user_input[CONF_DEVICE_ID].strip()
+            setup = self._pending_user_input
+            product_key = self._pending_product_key
+            topic_prefix = None if product_key == "auto" else f"/{product_key}"
+            client = NarwalClient(
+                host=setup["host"],
+                port=setup.get("port", DEFAULT_PORT),
+                device_id=device_id,
+                topic_prefix=topic_prefix,
+            )
+            try:
+                await client.connect()
+                if product_key == "auto":
+                    await client.discover_device_id(timeout=15.0)
+                    await client.drain_ws_buffer()
+                device_info = await client.get_device_info()
+            except Exception as ex:
+                _LOGGER.warning("Device ID validation failed: %s: %s", type(ex).__name__, ex)
+                errors["base"] = "cannot_connect"
+            else:
+                return await self._async_create_entry(client, device_info.device_id)
+            finally:
+                await client.disconnect()
+
+        return self.async_show_form(
+            step_id=step_id,
+            data_schema=STEP_DEVICE_ID_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def _async_create_entry(self, client: NarwalClient, device_id: str) -> ConfigFlowResult:
+        """Create an entry from a locally validated robot identity."""
+        await self.async_set_unique_id(device_id)
+        self._abort_if_unique_id_configured()
+
+        setup = self._pending_user_input
+        product_key = self._pending_product_key
+        resolved_key = client.topic_prefix.lstrip("/")
+        model_label = setup[CONF_MODEL]
+        return self.async_create_entry(
+            title=model_label if product_key != "auto" else f"Narwal {resolved_key}",
+            data={
+                "host": setup["host"],
+                "port": setup.get("port", DEFAULT_PORT),
+                CONF_DEVICE_ID: device_id,
+                CONF_PRODUCT_KEY: resolved_key,
+                CONF_MODEL: model_label,
+            },
         )

--- a/custom_components/narwal/const.py
+++ b/custom_components/narwal/const.py
@@ -27,11 +27,26 @@ NARWAL_MODELS: dict[str, str] = {
     # "Z10 Turbo" (@romedtino, #40) and "Z10 Pro" (@shin906710, #70), same product_key.
     "Narwal Freo Z10 Pro / Turbo": "qV6BujoYLz",
     "Narwal Freo X10 Pro": "CNbforyZWI",
+    "Narwal Freo Z Ultra (CX7)": "hEA7OEshlx",
     "Other / Auto-detect": "auto",
 }
 
+CONF_DEVICE_ID = "device_id"
 CONF_MODEL = "model"
 CONF_PRODUCT_KEY = "product_key"
+
+NO_BROADCAST_PRODUCT_KEYS = {"hEA7OEshlx"}
+
+
+def configured_model_name(data: dict) -> str:
+    """Return device-registry model metadata for a config entry."""
+    model = data.get(CONF_MODEL)
+    if not model or model == "Narwal Flow":
+        return MODEL
+    if model == "Other / Auto-detect":
+        product_key = data.get(CONF_PRODUCT_KEY)
+        return f"Unknown ({product_key})" if product_key else "Unknown"
+    return model.removeprefix("Narwal ")
 
 PLATFORMS: list[Platform] = [
     Platform.VACUUM,

--- a/custom_components/narwal/coordinator.py
+++ b/custom_components/narwal/coordinator.py
@@ -23,7 +23,7 @@ from .narwal_client import (
 )
 from .narwal_client.const import ACTIVE_CLEANING_STATUSES, WorkingStatus
 
-from .const import DOMAIN
+from .const import DOMAIN, NO_BROADCAST_PRODUCT_KEYS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -82,11 +82,13 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         )
         product_key = entry.data.get("product_key")
         topic_prefix = f"/{product_key}" if product_key else None
+        supports_broadcasts = product_key not in NO_BROADCAST_PRODUCT_KEYS
         self.client = NarwalClient(
             host=entry.data["host"],
             port=entry.data["port"],
             device_id=entry.data.get("device_id", ""),
             topic_prefix=topic_prefix,
+            supports_broadcasts=supports_broadcasts,
         )
         self.clean_settings = CleanSettings()
         self._listen_task: asyncio.Task[None] | None = None
@@ -134,11 +136,12 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
 
         # Subscribe to broadcast topics (display_map, working_status, etc.)
         # Must be sent before listener starts so display_map flows during cleaning.
-        try:
-            await self.client.subscribe_to_topics()
-            self._last_topic_subscribe = time.monotonic()
-        except Exception:
-            _LOGGER.debug("Could not send topic subscription at startup")
+        if self.client.supports_broadcasts:
+            try:
+                await self.client.subscribe_to_topics()
+                self._last_topic_subscribe = time.monotonic()
+            except Exception:
+                _LOGGER.debug("Could not send topic subscription at startup")
 
         self.async_set_updated_data(self.client.state)
 
@@ -245,15 +248,18 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
             _LOGGER.debug("Map fetch failed — will retry on next broadcast")
             self._map_fetch_pending = False
             return
-        try:
-            await self.client.subscribe_to_topics()
-            self._last_topic_subscribe = time.monotonic()
-        except Exception:
-            _LOGGER.debug("Topic subscription failed after map load")
+        if self.client.supports_broadcasts:
+            try:
+                await self.client.subscribe_to_topics()
+                self._last_topic_subscribe = time.monotonic()
+            except Exception:
+                _LOGGER.debug("Topic subscription failed after map load")
         self.async_set_updated_data(self.client.state)
 
     async def _resub_topics(self) -> None:
         """Re-send topic subscription to recover display_map during cleaning."""
+        if not self.client.supports_broadcasts:
+            return
         try:
             await self.client.subscribe_to_topics()
             self._last_topic_subscribe = time.monotonic()
@@ -312,7 +318,10 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         # us we are cleaning, so gating renewal on that state deadlocks — the
         # subscription expires, the robot goes quiet, the entity stays "docked", and
         # nothing ever re-subscribes (#73).
-        if time.monotonic() - self._last_topic_subscribe > TOPIC_RESUBSCRIBE_AFTER:
+        if (
+            self.client.supports_broadcasts
+            and time.monotonic() - self._last_topic_subscribe > TOPIC_RESUBSCRIBE_AFTER
+        ):
             try:
                 await self.client.subscribe_to_topics()
                 self._last_topic_subscribe = time.monotonic()

--- a/custom_components/narwal/entity.py
+++ b/custom_components/narwal/entity.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, MANUFACTURER, MODEL
+from .const import DOMAIN, MANUFACTURER, configured_model_name
 from .coordinator import NarwalCoordinator
 
 
@@ -21,7 +21,7 @@ class NarwalEntity(CoordinatorEntity[NarwalCoordinator]):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device_id)},
             manufacturer=MANUFACTURER,
-            model=MODEL,
+            model=configured_model_name(coordinator.config_entry.data),
             sw_version=coordinator.client.state.firmware_version or None,
             name=coordinator.config_entry.title,
         )

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -149,12 +149,14 @@ class NarwalClient:
         port: int = DEFAULT_PORT,
         device_id: str = "",
         topic_prefix: str | None = None,
+        supports_broadcasts: bool = True,
     ) -> None:
         self.host = host
         self.port = port
         self.device_id = device_id
         self.url = f"ws://{host}:{port}"
         self.topic_prefix = topic_prefix or DEFAULT_TOPIC_PREFIX
+        self.supports_broadcasts = supports_broadcasts
         self.state = NarwalState()
         self.on_state_update: Callable[[NarwalState], None] | None = None
         self.on_message: Callable[[NarwalMessage], None] | None = None
@@ -166,8 +168,9 @@ class NarwalClient:
         self._connected = asyncio.Event()
         self._should_reconnect = True
         self._listener_active = False  # True when start_listening() is running recv loop
-        self._robot_awake = False  # True once we receive a broadcast
+        self._robot_awake = False  # True after a broadcast or addressed response
         self._last_broadcast_time: float = 0.0  # monotonic time of last broadcast
+        self._last_response_time: float = 0.0  # monotonic time of last addressed response
         self._last_display_map_time: float = 0.0  # monotonic time of last display_map
         # Queue for field5 command responses
         self._response_queue: asyncio.Queue[NarwalMessage] = asyncio.Queue()
@@ -185,8 +188,14 @@ class NarwalClient:
 
     @property
     def robot_awake(self) -> bool:
-        """Return True if the robot is actively broadcasting."""
+        """Return True if the robot has confirmed local reachability."""
         return self._robot_awake
+
+    def _mark_response_received(self) -> None:
+        """Record an addressed response as reachability for non-broadcast models."""
+        self._last_response_time = time.monotonic()
+        if not self.supports_broadcasts:
+            self._robot_awake = True
 
     @property
     def last_broadcast_age(self) -> float:
@@ -412,7 +421,8 @@ class NarwalClient:
                     # interrupt, but only if we send commands before it
                     # expires.  Don't wait for the keepalive loop's first
                     # tick (15s delay would be too late).
-                    await self._send_wake_burst()
+                    if self.supports_broadcasts:
+                        await self._send_wake_burst()
 
                 retry_delay = RECONNECT_INITIAL_DELAY  # reset on success
                 self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
@@ -465,6 +475,7 @@ class NarwalClient:
 
         # Field5 (0x2a) messages are command responses
         if msg.field_tag == PROTOBUF_FIELD5_TAG:
+            self._mark_response_received()
             _LOGGER.debug("Field5 response routed to queue: %s", msg.short_topic)
             await self._response_queue.put(msg)
             return
@@ -668,8 +679,10 @@ class NarwalClient:
                 been reset yet.
 
         Returns:
-            True if the robot is awake (received broadcasts), False otherwise.
+            True if the robot has confirmed local reachability, False otherwise.
         """
+        if not self.supports_broadcasts:
+            return self.connected
         if self._robot_awake and not force:
             return True
 
@@ -738,6 +751,9 @@ class NarwalClient:
                 await asyncio.sleep(KEEPALIVE_INTERVAL)
                 if not self.connected or not self._ws:
                     break
+
+                if not self.supports_broadcasts:
+                    continue
 
                 # Check if broadcasts have gone stale (robot fell back asleep)
                 if (
@@ -873,6 +889,8 @@ class NarwalClient:
             else:
                 # No listener — read directly from websocket
                 msg = await self._wait_for_field5_response(timeout)
+
+            self._mark_response_received()
 
         # Decode response
         try:

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -1374,6 +1374,7 @@ class NarwalClient:
             firmware_version=_clean_bytes(data.get("3", "")),
         )
         self.state.device_info = info
+        self.state.firmware_version = info.firmware_version
 
         # Update topic prefix to match this device's product key
         if info.product_key:

--- a/custom_components/narwal/narwal_client/const.py
+++ b/custom_components/narwal/narwal_client/const.py
@@ -29,8 +29,9 @@ KNOWN_PRODUCT_KEYS = [
     # AX26 — sold as both "Freo Z10 Turbo" (@romedtino, #40) and "Freo Z10 Pro"
     # (@shin906710, #70); same key, same FW v01.02.00.15, so one platform.
     "qV6BujoYLz",   # AX26 — Freo Z10 Pro / Turbo (confirmed local WebSocket)
-    # Confirmed cloud-only (port 9002 open but no local broadcasts)
-    "BYWBPqSxeC",   # CX7  — Freo Z Ultra (cloud-only, confirmed by @gabrielozcomidi)
+    # CX7 answers addressed local queries but emits no broadcasts.
+    "hEA7OEshlx",   # CX7/J5 — Freo Z Ultra (confirmed local WebSocket)
+    "BYWBPqSxeC",   # Previously attributed to CX7; retained for discovery coverage
     # Confirmed cloud-only (ZeroMQ port 6789, no WebSocket)
     "LnugwMG9ss",   # AX18 — Freo X Ultra (cloud-only, confirmed by @ManivannanBA)
     "5OMbqk58Sc",   # AX19 — Freo X Ultra
@@ -50,7 +51,6 @@ KNOWN_PRODUCT_KEYS = [
     "pcbfh2ldvx",   # X31
     "EHf6cRNRGT",   # J4 / J4Pure (APK, contributed by @northwestsupra)
     "6NjIDYxBXb",   # J4Lite (APK, contributed by @northwestsupra)
-    "hEA7OEshlx",   # J5  (APK, contributed by @northwestsupra)
     "CGjuB6dzq7",   # JX — Narwal JX (APK, contributed by @ciaoly, #42)
     "cUlfJN5JYP",   # Unknown model (APK, contributed by @northwestsupra)
 ]

--- a/custom_components/narwal/strings.json
+++ b/custom_components/narwal/strings.json
@@ -9,6 +9,13 @@
           "port": "Port",
           "model": "Model"
         }
+      },
+      "device_id": {
+        "title": "Enter Device ID",
+        "description": "Automatic discovery is unavailable. Enter the vacuum's 32-character cloud-assigned Device ID.",
+        "data": {
+          "device_id": "Device ID"
+        }
       }
     },
     "error": {

--- a/custom_components/narwal/strings.json
+++ b/custom_components/narwal/strings.json
@@ -12,7 +12,7 @@
       },
       "device_id": {
         "title": "Enter Device ID",
-        "description": "Automatic discovery is unavailable. Enter the vacuum's 32-character cloud-assigned Device ID.",
+        "description": "Automatic discovery is unavailable. Enter the vacuum's 32-character cloud-assigned Device ID. See the integration documentation for retrieval options.",
         "data": {
           "device_id": "Device ID"
         }

--- a/custom_components/narwal/translations/en.json
+++ b/custom_components/narwal/translations/en.json
@@ -9,6 +9,13 @@
           "port": "Port",
           "model": "Model"
         }
+      },
+      "device_id": {
+        "title": "Enter Device ID",
+        "description": "Automatic discovery is unavailable. Enter the vacuum's 32-character cloud-assigned Device ID.",
+        "data": {
+          "device_id": "Device ID"
+        }
       }
     },
     "error": {

--- a/custom_components/narwal/translations/en.json
+++ b/custom_components/narwal/translations/en.json
@@ -12,7 +12,7 @@
       },
       "device_id": {
         "title": "Enter Device ID",
-        "description": "Automatic discovery is unavailable. Enter the vacuum's 32-character cloud-assigned Device ID.",
+        "description": "Automatic discovery is unavailable. Enter the vacuum's 32-character cloud-assigned Device ID. See the integration documentation for retrieval options.",
         "data": {
           "device_id": "Device ID"
         }

--- a/custom_components/narwal/translations/fr.json
+++ b/custom_components/narwal/translations/fr.json
@@ -9,6 +9,13 @@
           "port": "Port",
           "model": "Modèle"
         }
+      },
+      "device_id": {
+        "title": "Saisir l’identifiant de l’appareil",
+        "description": "La découverte automatique n’est pas disponible. Saisissez l’identifiant de 32 caractères attribué à l’aspirateur dans le cloud.",
+        "data": {
+          "device_id": "Identifiant de l’appareil"
+        }
       }
     },
     "error": {

--- a/custom_components/narwal/translations/fr.json
+++ b/custom_components/narwal/translations/fr.json
@@ -12,7 +12,7 @@
       },
       "device_id": {
         "title": "Saisir l’identifiant de l’appareil",
-        "description": "La découverte automatique n’est pas disponible. Saisissez l’identifiant de 32 caractères attribué à l’aspirateur dans le cloud.",
+        "description": "La découverte automatique n’est pas disponible. Saisissez l’identifiant de 32 caractères attribué à l’aspirateur dans le cloud. Consultez la documentation de l’intégration pour savoir comment l’obtenir.",
         "data": {
           "device_id": "Identifiant de l’appareil"
         }

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -56,6 +56,10 @@ but the CX7 is an exception: it only responds to topics containing product key `
 and its real cloud-assigned device ID. See the README's compatibility table for the current
 per-model state.
 
+This identity is verified for one global CX7/J5 on firmware `v01.13.11.02`. Earlier reports in
+issue #5 associated CX7 with `BYWBPqSxeC` and firmware `1.12.10.02`; that key did not answer
+addressed probes on the verified robot, and remains an unresolved regional or platform variant.
+
 ---
 
 ## 2. Frame format
@@ -158,7 +162,9 @@ so treat a non-integer field 1 as a successful data response.
 Most robots sleep aggressively. While awake they broadcast status every ~1.5 s; while asleep
 they send nothing and ignore most commands — including map requests, which is the usual reason
 rooms fail to appear in a fresh install. The CX7 never broadcasts and instead relies on
-addressed polling, including `status/get_device_base_status`.
+addressed polling, including `status/get_device_base_status`. Clients must treat successful
+field5 responses as reachability for such models rather than waiting for a broadcast, renewing
+broadcast subscriptions, or reconnecting when broadcasts do not arrive.
 
 Working model:
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -48,13 +48,13 @@ the hardware, not a setting:
 
 | Transport | Port | Models observed | Local control? |
 |---|---|---|---|
-| WebSocket | 9002 | Flow (AX12), Flow 2, Freo Z10 Pro/Turbo (AX26), Freo X10 Pro (AX15), Freo Z10 Ultra (CX4) | Yes — this document |
+| WebSocket | 9002 | Flow (AX12), Flow 2, Freo Z10 Pro/Turbo (AX26), Freo X10 Pro (AX15), Freo Z10 Ultra (CX4), Freo Z Ultra (hardware CX7, cloud identity J5) | Yes — this document |
 | ZeroMQ (ZMTP 2.0) | 6789 | Freo X Ultra (AX18/AX19) | No — cloud-mediated |
-| Cloud only | 9002 open, no local broadcasts | Freo Z Ultra (CX7) | No |
 
-`nmap -p 9002 <robot_ip>` is the fastest triage. An open 9002 that never broadcasts is the
-cloud-only case, which looks identical to a working robot until you wait for data that never
-arrives. See the README's compatibility table for the current per-model state.
+`nmap -p 9002 <robot_ip>` is the fastest triage. Most supported models broadcast when awake,
+but the CX7 is an exception: it only responds to topics containing product key `hEA7OEshlx`
+and its real cloud-assigned device ID. See the README's compatibility table for the current
+per-model state.
 
 ---
 
@@ -132,7 +132,9 @@ The product key identifies the model (`QoEsI5qYXO` = AX12 Narwal Flow); the devi
 per-robot. Both are returned by `common/get_device_info`, but there's a bootstrap problem —
 you need the device ID to build a topic, and you need a topic to ask for the device ID. This
 integration resolves it by cycling known product-key prefixes during the wake burst and
-reading the device ID out of the first broadcast topic the robot emits.
+reading the device ID out of the first broadcast topic the robot emits. The CX7 never
+broadcasts and ignores incorrectly addressed requests, so its cloud-assigned device ID must
+be supplied before connecting.
 
 ### Result codes
 
@@ -153,9 +155,10 @@ so treat a non-integer field 1 as a successful data response.
 
 ## 4. Sleep, wake, and keepalive
 
-The robot sleeps aggressively. While awake it broadcasts status every ~1.5 s; while asleep it
-sends nothing and ignores most commands — including map requests, which is the usual reason
-rooms fail to appear in a fresh install.
+Most robots sleep aggressively. While awake they broadcast status every ~1.5 s; while asleep
+they send nothing and ignore most commands — including map requests, which is the usual reason
+rooms fail to appear in a fresh install. The CX7 never broadcasts and instead relies on
+addressed polling, including `status/get_device_base_status`.
 
 Working model:
 

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -149,12 +149,14 @@ class NarwalClient:
         port: int = DEFAULT_PORT,
         device_id: str = "",
         topic_prefix: str | None = None,
+        supports_broadcasts: bool = True,
     ) -> None:
         self.host = host
         self.port = port
         self.device_id = device_id
         self.url = f"ws://{host}:{port}"
         self.topic_prefix = topic_prefix or DEFAULT_TOPIC_PREFIX
+        self.supports_broadcasts = supports_broadcasts
         self.state = NarwalState()
         self.on_state_update: Callable[[NarwalState], None] | None = None
         self.on_message: Callable[[NarwalMessage], None] | None = None
@@ -166,8 +168,9 @@ class NarwalClient:
         self._connected = asyncio.Event()
         self._should_reconnect = True
         self._listener_active = False  # True when start_listening() is running recv loop
-        self._robot_awake = False  # True once we receive a broadcast
+        self._robot_awake = False  # True after a broadcast or addressed response
         self._last_broadcast_time: float = 0.0  # monotonic time of last broadcast
+        self._last_response_time: float = 0.0  # monotonic time of last addressed response
         self._last_display_map_time: float = 0.0  # monotonic time of last display_map
         # Queue for field5 command responses
         self._response_queue: asyncio.Queue[NarwalMessage] = asyncio.Queue()
@@ -185,8 +188,14 @@ class NarwalClient:
 
     @property
     def robot_awake(self) -> bool:
-        """Return True if the robot is actively broadcasting."""
+        """Return True if the robot has confirmed local reachability."""
         return self._robot_awake
+
+    def _mark_response_received(self) -> None:
+        """Record an addressed response as reachability for non-broadcast models."""
+        self._last_response_time = time.monotonic()
+        if not self.supports_broadcasts:
+            self._robot_awake = True
 
     @property
     def last_broadcast_age(self) -> float:
@@ -412,7 +421,8 @@ class NarwalClient:
                     # interrupt, but only if we send commands before it
                     # expires.  Don't wait for the keepalive loop's first
                     # tick (15s delay would be too late).
-                    await self._send_wake_burst()
+                    if self.supports_broadcasts:
+                        await self._send_wake_burst()
 
                 retry_delay = RECONNECT_INITIAL_DELAY  # reset on success
                 self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
@@ -465,6 +475,7 @@ class NarwalClient:
 
         # Field5 (0x2a) messages are command responses
         if msg.field_tag == PROTOBUF_FIELD5_TAG:
+            self._mark_response_received()
             _LOGGER.debug("Field5 response routed to queue: %s", msg.short_topic)
             await self._response_queue.put(msg)
             return
@@ -668,8 +679,10 @@ class NarwalClient:
                 been reset yet.
 
         Returns:
-            True if the robot is awake (received broadcasts), False otherwise.
+            True if the robot has confirmed local reachability, False otherwise.
         """
+        if not self.supports_broadcasts:
+            return self.connected
         if self._robot_awake and not force:
             return True
 
@@ -738,6 +751,9 @@ class NarwalClient:
                 await asyncio.sleep(KEEPALIVE_INTERVAL)
                 if not self.connected or not self._ws:
                     break
+
+                if not self.supports_broadcasts:
+                    continue
 
                 # Check if broadcasts have gone stale (robot fell back asleep)
                 if (
@@ -873,6 +889,8 @@ class NarwalClient:
             else:
                 # No listener — read directly from websocket
                 msg = await self._wait_for_field5_response(timeout)
+
+            self._mark_response_received()
 
         # Decode response
         try:

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -1374,6 +1374,7 @@ class NarwalClient:
             firmware_version=_clean_bytes(data.get("3", "")),
         )
         self.state.device_info = info
+        self.state.firmware_version = info.firmware_version
 
         # Update topic prefix to match this device's product key
         if info.product_key:

--- a/narwal_client/const.py
+++ b/narwal_client/const.py
@@ -29,8 +29,9 @@ KNOWN_PRODUCT_KEYS = [
     # AX26 — sold as both "Freo Z10 Turbo" (@romedtino, #40) and "Freo Z10 Pro"
     # (@shin906710, #70); same key, same FW v01.02.00.15, so one platform.
     "qV6BujoYLz",   # AX26 — Freo Z10 Pro / Turbo (confirmed local WebSocket)
-    # Confirmed cloud-only (port 9002 open but no local broadcasts)
-    "BYWBPqSxeC",   # CX7  — Freo Z Ultra (cloud-only, confirmed by @gabrielozcomidi)
+    # CX7 answers addressed local queries but emits no broadcasts.
+    "hEA7OEshlx",   # CX7/J5 — Freo Z Ultra (confirmed local WebSocket)
+    "BYWBPqSxeC",   # Previously attributed to CX7; retained for discovery coverage
     # Confirmed cloud-only (ZeroMQ port 6789, no WebSocket)
     "LnugwMG9ss",   # AX18 — Freo X Ultra (cloud-only, confirmed by @ManivannanBA)
     "5OMbqk58Sc",   # AX19 — Freo X Ultra
@@ -50,7 +51,6 @@ KNOWN_PRODUCT_KEYS = [
     "pcbfh2ldvx",   # X31
     "EHf6cRNRGT",   # J4 / J4Pure (APK, contributed by @northwestsupra)
     "6NjIDYxBXb",   # J4Lite (APK, contributed by @northwestsupra)
-    "hEA7OEshlx",   # J5  (APK, contributed by @northwestsupra)
     "CGjuB6dzq7",   # JX — Narwal JX (APK, contributed by @ciaoly, #42)
     "cUlfJN5JYP",   # Unknown model (APK, contributed by @northwestsupra)
 ]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -96,6 +96,25 @@ class TestNarwalClientInit:
             payload=b"\x08\x01",
         )
 
+    @pytest.mark.asyncio
+    async def test_device_info_updates_firmware_state(self) -> None:
+        """Device identity queries populate the firmware sensor state."""
+        client = NarwalClient("10.0.0.1")
+        response = CommandResponse(
+            data={
+                "1": b"hEA7OEshlx",
+                "2": b"0123456789abcdef0123456789abcdef",
+                "3": b"v01.13.11.02",
+            }
+        )
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = response
+            info = await client.get_device_info()
+
+        assert info.firmware_version == "v01.13.11.02"
+        assert client.state.firmware_version == "v01.13.11.02"
+
 
 class TestBuildCleanPayloadV2:
     """Tests for the v2 clean payload schema introduced for firmware

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -115,6 +115,28 @@ class TestNarwalClientInit:
         assert info.firmware_version == "v01.13.11.02"
         assert client.state.firmware_version == "v01.13.11.02"
 
+    def test_addressed_response_marks_non_broadcast_model_reachable(self) -> None:
+        """Non-broadcast models use command responses as reachability evidence."""
+        client = NarwalClient("10.0.0.1", supports_broadcasts=False)
+        assert not client.robot_awake
+
+        client._mark_response_received()
+
+        assert client.robot_awake
+        assert client._last_response_time > 0
+
+    @pytest.mark.asyncio
+    async def test_non_broadcast_wake_returns_without_waiting(self) -> None:
+        """A connected non-broadcast model does not wait for impossible broadcasts."""
+        client = NarwalClient("10.0.0.1", supports_broadcasts=False)
+        client._ws = AsyncMock()
+        client._connected.set()
+
+        with patch.object(client, "_send_wake_burst", new_callable=AsyncMock) as wake_burst:
+            assert await client.wake(timeout=10.0)
+
+        wake_burst.assert_not_awaited()
+
 
 class TestBuildCleanPayloadV2:
     """Tests for the v2 clean payload schema introduced for firmware

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -17,6 +17,10 @@ import tests.ha_stubs  # noqa: E402
 tests.ha_stubs.install()
 
 from custom_components.narwal.config_flow import NarwalConfigFlow  # noqa: E402
+from custom_components.narwal.const import (  # noqa: E402
+    NARWAL_MODELS,
+    NO_BROADCAST_PRODUCT_KEYS,
+)
 from custom_components.narwal.narwal_client import NarwalConnectionError  # noqa: E402
 
 AbortFlow = sys.modules["homeassistant.data_entry_flow"].AbortFlow
@@ -159,3 +163,91 @@ class TestNarwalConfigFlow:
         entry_kwargs = flow.async_create_entry.call_args.kwargs
         assert entry_kwargs["data"]["product_key"] == "DrzDKQ0MU8"
         assert "Narwal DrzDKQ0MU8" in entry_kwargs["title"]
+
+    async def test_non_broadcast_model_opens_device_id_step(self) -> None:
+        """A non-broadcast model requests its identity without connecting."""
+        flow = self._make_flow()
+        model = next(
+            label
+            for label, product_key in NARWAL_MODELS.items()
+            if product_key in NO_BROADCAST_PRODUCT_KEYS
+        )
+
+        with patch("custom_components.narwal.config_flow.NarwalClient") as client_class:
+            await flow.async_step_user(
+                user_input={
+                    "host": "10.0.0.70",
+                    "port": 9002,
+                    "model": model,
+                }
+            )
+
+        client_class.assert_not_called()
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["step_id"] == "device_id"
+        assert call_kwargs["errors"] == {}
+
+    async def test_non_broadcast_device_id_skips_discovery(self) -> None:
+        """A non-broadcast model validates an exactly addressed request."""
+        flow = self._make_flow()
+        device_id = "0123456789abcdef0123456789abcdef"
+        model, product_key = next(
+            (label, key)
+            for label, key in NARWAL_MODELS.items()
+            if key in NO_BROADCAST_PRODUCT_KEYS
+        )
+        mock_client = AsyncMock()
+        mock_client.topic_prefix = f"/{product_key}"
+        mock_device_info = MagicMock()
+        mock_device_info.device_id = device_id
+        mock_client.get_device_info.return_value = mock_device_info
+
+        with patch(
+            "custom_components.narwal.config_flow.NarwalClient",
+            return_value=mock_client,
+        ) as client_class:
+            await flow.async_step_user(
+                user_input={
+                    "host": "10.0.0.70",
+                    "port": 9002,
+                    "model": model,
+                }
+            )
+            await flow.async_step_device_id(user_input={"device_id": f" {device_id} "})
+
+        client_class.assert_called_once_with(
+            host="10.0.0.70",
+            port=9002,
+            device_id=device_id,
+            topic_prefix=f"/{product_key}",
+        )
+        mock_client.connect.assert_awaited_once()
+        mock_client.discover_device_id.assert_not_awaited()
+        mock_client.drain_ws_buffer.assert_not_awaited()
+        mock_client.get_device_info.assert_awaited_once()
+        entry_kwargs = flow.async_create_entry.call_args.kwargs
+        assert entry_kwargs["data"]["device_id"] == device_id
+        assert entry_kwargs["data"]["product_key"] == product_key
+        mock_client.disconnect.assert_awaited_once()
+
+    async def test_failed_auto_discovery_opens_device_id_step(self) -> None:
+        """Any model can fall back to an exactly addressed setup request."""
+        flow = self._make_flow()
+        mock_client = AsyncMock()
+        mock_client.discover_device_id.side_effect = TimeoutError
+
+        with patch(
+            "custom_components.narwal.config_flow.NarwalClient",
+            return_value=mock_client,
+        ):
+            await flow.async_step_user(
+                user_input={
+                    "host": "10.0.0.80",
+                    "port": 9002,
+                    "model": "Narwal Flow",
+                }
+            )
+
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["step_id"] == "device_id"
+        mock_client.disconnect.assert_awaited_once()

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -10,6 +10,9 @@ from custom_components.narwal.const import (  # noqa: E402
     CONF_DOCK_LIGHT_SUPPORTED,
     CONF_MODEL,
     CONF_PRODUCT_KEY,
+    NARWAL_MODELS,
+    NO_BROADCAST_PRODUCT_KEYS,
+    configured_model_name,
     is_dock_light_supported,
 )
 
@@ -44,3 +47,25 @@ def test_dock_light_option_override() -> None:
         {CONF_PRODUCT_KEY: "QxMSPG6VSO"},
         {CONF_DOCK_LIGHT_SUPPORTED: False},
     )
+
+
+def test_cx7_uses_j5_product_key_and_requires_addressed_setup() -> None:
+    """CX7 uses the live-tested J5 key and cannot use broadcast discovery."""
+    product_key = NARWAL_MODELS["Narwal Freo Z Ultra (CX7)"]
+    assert product_key == "hEA7OEshlx"
+    assert product_key in NO_BROADCAST_PRODUCT_KEYS
+
+
+def test_configured_model_name_uses_selected_cx7_model() -> None:
+    """Device metadata reflects the configured model instead of always showing Flow."""
+    assert configured_model_name(
+        {
+            CONF_MODEL: "Narwal Freo Z Ultra (CX7)",
+            CONF_PRODUCT_KEY: "hEA7OEshlx",
+        }
+    ) == "Freo Z Ultra (CX7)"
+
+
+def test_configured_model_name_preserves_legacy_flow_name() -> None:
+    """Existing Flow entries retain their hardware model identifier."""
+    assert configured_model_name({CONF_MODEL: "Narwal Flow"}) == "Flow (AX12)"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -17,6 +17,7 @@ import tests.ha_stubs  # noqa: E402
 
 tests.ha_stubs.install()
 
+from custom_components.narwal.const import NO_BROADCAST_PRODUCT_KEYS  # noqa: E402
 from custom_components.narwal.coordinator import (
     TOPIC_RESUBSCRIBE_AFTER,
     TOPIC_SUBSCRIPTION_TTL,
@@ -25,6 +26,29 @@ from custom_components.narwal.coordinator import (
 from custom_components.narwal.narwal_client import NarwalConnectionError, NarwalState  # noqa: E402
 
 UpdateFailed = sys.modules["homeassistant.helpers.update_coordinator"].UpdateFailed
+
+
+def test_non_broadcast_product_key_configures_polling_client() -> None:
+    """Coordinator propagates the product capability to the client."""
+    product_key = next(iter(NO_BROADCAST_PRODUCT_KEYS))
+    entry = MagicMock()
+    entry.data = {
+        "host": "10.0.0.70",
+        "port": 9002,
+        "device_id": "device-id",
+        "product_key": product_key,
+    }
+
+    with patch("custom_components.narwal.coordinator.NarwalClient") as client_class:
+        NarwalCoordinator(MagicMock(), entry)
+
+    client_class.assert_called_once_with(
+        host="10.0.0.70",
+        port=9002,
+        device_id="device-id",
+        topic_prefix=f"/{product_key}",
+        supports_broadcasts=False,
+    )
 
 
 class TestCoordinatorResilience:
@@ -195,6 +219,7 @@ class TestTopicSubscriptionRenewal:
         c.client.get_map = AsyncMock()
         c.client.get_consumable_info = AsyncMock()
         c.client.subscribe_to_topics = AsyncMock()
+        c.client.supports_broadcasts = True
         c.client.state.map_data = MagicMock()  # skip the map-retry branch
         c._consecutive_failures = 0
         c._max_failures = 5
@@ -220,6 +245,16 @@ class TestTopicSubscriptionRenewal:
         """A fresh subscription is not re-sent on every poll."""
         c = self._coordinator(time.monotonic())
         await c._async_update_data()
+        c.client.subscribe_to_topics.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_broadcast_model_does_not_subscribe(self) -> None:
+        """Polling-only models never renew an unsupported broadcast subscription."""
+        c = self._coordinator(time.monotonic() - (TOPIC_RESUBSCRIBE_AFTER + 30))
+        c.client.supports_broadcasts = False
+
+        await c._async_update_data()
+
         c.client.subscribe_to_topics.assert_not_awaited()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add Freo Z Ultra hardware CX7 support using the locally verified J5 product key (`hEA7OEshlx`)
- request a cloud-assigned Device ID through the generic non-broadcast setup step while keeping the integration fully local
- make non-broadcast capability generic: addressed responses establish reachability, wake waits and broadcast subscriptions are skipped, and missing broadcasts no longer force reconnects
- correct device model and firmware metadata and document Device ID retrieval options, polling limitations, and unresolved variants
- retain `BYWBPqSxeC` as an unresolved discovery key rather than treating it as the verified CX7 key

## Hardware verification

Verified on one global Freo Z Ultra (hardware CX7, cloud identity J5) running firmware `v01.13.11.02`. Addressed local WebSocket queries return base status, maps, consumables, and device information. The Home Assistant integration created 28 entities and rendered the static map.

The CX7 does not emit broadcasts, so live cleaning position and progress are unavailable; regular status polling and commands continue to work locally. The polling-only runtime was observed beyond the previous reconnect threshold without wake-burst or forced-reconnect warnings.

## Variant scope

Issue #5 also reports firmware `1.12.10.02` and a `BYWBPqSxeC` identity. Those variants are not yet locally verified with this implementation. Additional owner testing is requested before claiming universal CX7 support.

## Testing

- `pytest` (241 passed)
- deployed to Home Assistant 2026.8.1 and validated against live hardware

Related to #5