### PR TITLE
feat(config_flow): discover robots via zeroconf and DHCP (from #35, @StratoGh0st99)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,32 @@ Shipped in v1.0.2 ([#50](https://github.com/sjmotew/NarwalIntegration/pull/50)) 
 
 ### Setup
 
+Home Assistant discovers Narwal robots on the local network, so in most cases the
+robot appears on its own under **Settings > Devices & Services** as a discovered
+device — click **Configure**, pick your model, and you're done. The IP is filled in
+for you.
+
+To add one by hand, or if discovery doesn't find it:
+
 1. **Settings > Devices & Services > Add Integration** > search "Narwal"
 2. Enter your vacuum's IP address and select your model
 3. Entities are created automatically
 
-> **Tip:** Assign a static IP to your vacuum in your router.
+> **Tip:** Assign a static IP to your vacuum in your router. Discovery re-points an
+> existing entry when the address changes, but a static lease avoids the round trip.
+
+<details>
+<summary>How discovery finds the robot</summary>
+
+The robot advertises `_narwal_sweeper._tcp.local.` over mDNS, as an instance named
+`_app_wss_server_<6hex>` with hostname `NARWAL_<6hex>.local.` on port 9002. Those six
+hex characters are the tail of the robot's device ID, which is how a discovery is
+matched to a robot you already added manually.
+
+Some networks drop multicast between VLANs or under wireless client isolation, and
+mDNS then never arrives. DHCP hostname matching on `NARWAL_*` covers that case.
+
+</details>
 
 ### Room cleaning setup (required before `vacuum.clean_area` works)
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,38 @@ lowercases hostnames before matching, so the declared pattern is `narwal_*`.
 
 </details>
 
+<details>
+<summary>If Home Assistant and the robot are on different VLANs</summary>
+
+Robots have been reported not to answer connections whose source address is outside
+their own subnet, even when 9002/TCP is explicitly permitted through the firewall and
+other devices on the same VLAN are reachable. Both ICMP and the WebSocket handshake
+time out, so the symptom is a plain connection failure rather than an integration
+error:
+
+```text
+Failed to connect to ws://<robot-ip>:9002: timed out during opening handshake
+```
+
+**Workaround:** source-NAT the traffic from Home Assistant so it reaches the robot
+with an address on the robot's own subnet. This is confirmed working by a user running
+Home Assistant on a separate VLAN from an IoT network ([#81]).
+
+The underlying cause is not yet pinned down — it is either the robot filtering by
+source subnet, or the robot ignoring the default gateway it was handed by DHCP and so
+having no route back. If you can capture on the robot's own switch port and tell us
+whether the robot *replies* to an off-subnet SYN, that distinguishes the two, and in
+the second case a static route on the robot's side would be a cleaner fix than SNAT.
+Please add what you find to [#81].
+
+Note that mDNS discovery is separately affected: most networks do not forward
+multicast between VLANs, so the robot will usually need to be added by IP in this
+setup regardless.
+
+[#81]: https://github.com/sjmotew/NarwalIntegration/issues/81
+
+</details>
+
 The Freo Z Ultra (CX7) also requires its 32-character cloud-assigned Device ID. Selecting that
 model opens a dedicated Device ID page; other models use automatic discovery. The integration
 itself never contacts the cloud.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ hex characters are the tail of the robot's device ID, which is how a discovery i
 matched to a robot you already added manually.
 
 Some networks drop multicast between VLANs or under wireless client isolation, and
-mDNS then never arrives. DHCP hostname matching on `NARWAL_*` covers that case.
+mDNS then never arrives. DHCP hostname matching covers that case — Home Assistant
+lowercases hostnames before matching, so the declared pattern is `narwal_*`.
 
 </details>
 

--- a/custom_components/narwal/config_flow.py
+++ b/custom_components/narwal/config_flow.py
@@ -122,8 +122,9 @@ class NarwalConfigFlow(ConfigFlow, domain=DOMAIN):
         """Pick up robots by DHCP hostname — a backup for when mDNS is filtered.
 
         Plenty of home networks drop multicast across VLANs or on wireless
-        isolation, and the robot is then invisible to zeroconf. The `NARWAL_*`
-        hostname match in manifest.json still catches it.
+        isolation, and the robot is then invisible to zeroconf. The `narwal_*`
+        hostname match in manifest.json still catches it — the robot announces
+        itself as `NARWAL_<6hex>`, and HA lowercases hostnames before matching.
         """
         host = str(discovery_info.ip)
         return await self._async_discovered(host, discovery_info.hostname or host)

--- a/custom_components/narwal/config_flow.py
+++ b/custom_components/narwal/config_flow.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .narwal_client import NarwalClient, NarwalCommandError, NarwalConnectionError
 
@@ -16,6 +19,11 @@ from .const import CONF_MODEL, CONF_PRODUCT_KEY, DEFAULT_PORT, DOMAIN, NARWAL_MO
 _LOGGER = logging.getLogger(__name__)
 
 MODEL_OPTIONS = list(NARWAL_MODELS.keys())
+
+# `NARWAL_7bb53c.local.` (DHCP/mDNS hostname) and the zeroconf instance name
+# `_app_wss_server_7bb53c._narwal_sweeper._tcp.local.` both end in the last six
+# hex characters of the robot's device_id.
+_DISCOVERY_NAME_RE = re.compile(r"(?:narwal|app_wss_server)[_-]([0-9a-f]{6})", re.I)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
@@ -30,6 +38,95 @@ class NarwalConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Narwal vacuum."""
 
     VERSION = 2
+
+    # Host pre-filled when zeroconf or DHCP finds the robot before the user
+    # starts the flow. Class-level default: the flow object is also constructed
+    # directly in tests, and there is nothing else to initialize.
+    _discovered_host: str | None = None
+
+    @staticmethod
+    def _user_schema(default_host: str | None) -> vol.Schema:
+        """User-step schema, pre-filling the host when we already know it."""
+        if not default_host:
+            return STEP_USER_DATA_SCHEMA
+        return vol.Schema(
+            {
+                vol.Required("host", default=default_host): str,
+                vol.Optional("port", default=DEFAULT_PORT): int,
+                vol.Required(CONF_MODEL, default=MODEL_OPTIONS[0]): vol.In(MODEL_OPTIONS),
+            }
+        )
+
+    @staticmethod
+    def _device_id_suffix(hostname: str) -> str | None:
+        """Extract the six hex characters a robot puts in its discovery name.
+
+        Verified on a Flow (AX12): device_id `71c53f01c14f49088338863e147bb53c`
+        advertises `_app_wss_server_7bb53c._narwal_sweeper._tcp.local.` with
+        hostname `NARWAL_7bb53c.local.` — the tail of the device_id in both.
+        That's the only thing linking a discovery to a configured entry, whose
+        unique_id is the full device_id read over the WebSocket.
+        """
+        match = _DISCOVERY_NAME_RE.search(hostname)
+        return match.group(1).lower() if match else None
+
+    async def _async_discovered(
+        self, host: str, fallback_uid: str
+    ) -> ConfigFlowResult:
+        """Route a discovered robot into the user step, or abort if it's known.
+
+        A configured entry's unique_id is the robot's device_id, which neither
+        mDNS nor DHCP can see. Without a match, a robot added by hand would
+        reappear as a "Discovered" card forever — so match on the device_id
+        suffix in the discovery name, falling back to the address.
+        """
+        suffix = self._device_id_suffix(fallback_uid)
+        for entry in self._async_current_entries(include_ignore=False):
+            same_device = bool(suffix) and str(
+                entry.data.get("device_id", "")
+            ).lower().endswith(suffix)
+            if not same_device and entry.data.get("host") != host:
+                continue
+            if same_device and entry.data.get("host") != host:
+                # Same robot, new address — a DHCP renewal or a subnet move.
+                # Repoint the entry instead of leaving it pointing at nothing.
+                self.hass.config_entries.async_update_entry(
+                    entry, data={**entry.data, "host": host}
+                )
+            return self.async_abort(reason="already_configured")
+
+        await self.async_set_unique_id(fallback_uid)
+        self._abort_if_unique_id_configured(updates={"host": host})
+
+        self._discovered_host = host
+        self.context["title_placeholders"] = {"host": host}
+        return await self.async_step_user()
+
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        """Pick up robots advertising `_narwal_sweeper._tcp.local.`.
+
+        A robot advertises an instance named
+        `_app_wss_server_<6hex>._narwal_sweeper._tcp.local.` with hostname
+        `NARWAL_<6hex>.local.` on port 9002. Only the address is used here —
+        the model isn't in the mDNS payload, so the user still picks it.
+        """
+        return await self._async_discovered(
+            str(discovery_info.host), discovery_info.hostname.rstrip(".")
+        )
+
+    async def async_step_dhcp(
+        self, discovery_info: DhcpServiceInfo
+    ) -> ConfigFlowResult:
+        """Pick up robots by DHCP hostname — a backup for when mDNS is filtered.
+
+        Plenty of home networks drop multicast across VLANs or on wireless
+        isolation, and the robot is then invisible to zeroconf. The `NARWAL_*`
+        hostname match in manifest.json still catches it.
+        """
+        host = str(discovery_info.ip)
+        return await self._async_discovered(host, discovery_info.hostname or host)
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -85,8 +182,11 @@ class NarwalConfigFlow(ConfigFlow, domain=DOMAIN):
             finally:
                 await client.disconnect()
 
+        # Keep whatever host we have: what the user just typed on a retry after
+        # an error, otherwise the discovered address.
+        default_host = (user_input or {}).get("host") or self._discovered_host
         return self.async_show_form(
             step_id="user",
-            data_schema=STEP_USER_DATA_SCHEMA,
+            data_schema=self._user_schema(default_host),
             errors=errors,
         )

--- a/custom_components/narwal/manifest.json
+++ b/custom_components/narwal/manifest.json
@@ -4,10 +4,15 @@
   "codeowners": ["@sjmotew"],
   "config_flow": true,
   "dependencies": [],
+  "dhcp": [
+    { "hostname": "narwal_*" },
+    { "hostname": "NARWAL_*" }
+  ],
   "documentation": "https://github.com/sjmotew/NarwalIntegration",
   "integration_type": "device",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/sjmotew/NarwalIntegration/issues",
   "requirements": ["bbpb>=1.4.0", "Pillow>=9.0.0"],
-  "version": "1.0.3"
+  "version": "1.0.3",
+  "zeroconf": ["_narwal_sweeper._tcp.local."]
 }

--- a/custom_components/narwal/manifest.json
+++ b/custom_components/narwal/manifest.json
@@ -5,8 +5,7 @@
   "config_flow": true,
   "dependencies": [],
   "dhcp": [
-    { "hostname": "narwal_*" },
-    { "hostname": "NARWAL_*" }
+    { "hostname": "narwal_*" }
   ],
   "documentation": "https://github.com/sjmotew/NarwalIntegration",
   "integration_type": "device",

--- a/custom_components/narwal/strings.json
+++ b/custom_components/narwal/strings.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "flow_title": "Narwal vacuum ({host})",
     "step": {
       "user": {
         "title": "Connect to Narwal Vacuum",

--- a/custom_components/narwal/translations/en.json
+++ b/custom_components/narwal/translations/en.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "flow_title": "Narwal vacuum ({host})",
     "step": {
       "user": {
         "title": "Connect to Narwal Vacuum",

--- a/custom_components/narwal/translations/fr.json
+++ b/custom_components/narwal/translations/fr.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "flow_title": "Aspirateur Narwal ({host})",
     "step": {
       "user": {
         "title": "Connexion à l’aspirateur Narwal",

--- a/tests/ha_stubs.py
+++ b/tests/ha_stubs.py
@@ -139,6 +139,31 @@ def install() -> None:
     ha_ep = _mod("homeassistant.helpers.entity_platform", ha_helpers)
     ha_ep.AddConfigEntryEntitiesCallback = MagicMock  # type: ignore[attr-defined]
 
+    # homeassistant.helpers.service_info.* — discovery payloads (zeroconf, DHCP)
+    ha_si = _mod("homeassistant.helpers.service_info", ha_helpers)
+
+    class _ZeroconfServiceInfo:
+        """Stub for ZeroconfServiceInfo (only the fields the flow reads)."""
+
+        def __init__(self, host: str = "", hostname: str = "", port: int = 0) -> None:
+            self.host = host
+            self.hostname = hostname
+            self.port = port
+
+    class _DhcpServiceInfo:
+        """Stub for DhcpServiceInfo (only the fields the flow reads)."""
+
+        def __init__(self, ip: str = "", hostname: str = "", macaddress: str = "") -> None:
+            self.ip = ip
+            self.hostname = hostname
+            self.macaddress = macaddress
+
+    ha_si_zc = _mod("homeassistant.helpers.service_info.zeroconf", ha_si)
+    ha_si_zc.ZeroconfServiceInfo = _ZeroconfServiceInfo  # type: ignore[attr-defined]
+
+    ha_si_dhcp = _mod("homeassistant.helpers.service_info.dhcp", ha_si)
+    ha_si_dhcp.DhcpServiceInfo = _DhcpServiceInfo  # type: ignore[attr-defined]
+
     ha_rs = _mod("homeassistant.helpers.restore_state", ha_helpers)
 
     class _RestoreEntity:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -20,6 +20,12 @@ from custom_components.narwal.config_flow import NarwalConfigFlow  # noqa: E402
 from custom_components.narwal.narwal_client import NarwalConnectionError  # noqa: E402
 
 AbortFlow = sys.modules["homeassistant.data_entry_flow"].AbortFlow
+DhcpServiceInfo = sys.modules[
+    "homeassistant.helpers.service_info.dhcp"
+].DhcpServiceInfo
+ZeroconfServiceInfo = sys.modules[
+    "homeassistant.helpers.service_info.zeroconf"
+].ZeroconfServiceInfo
 
 
 class TestNarwalConfigFlow:
@@ -159,3 +165,183 @@ class TestNarwalConfigFlow:
         entry_kwargs = flow.async_create_entry.call_args.kwargs
         assert entry_kwargs["data"]["product_key"] == "DrzDKQ0MU8"
         assert "Narwal DrzDKQ0MU8" in entry_kwargs["title"]
+
+
+class TestDiscovery:
+    """zeroconf / DHCP discovery routing into the user step."""
+
+    def _make_flow(self, entries: list | None = None) -> NarwalConfigFlow:
+        """Flow with the discovery-relevant base-class methods stubbed."""
+        flow = NarwalConfigFlow.__new__(NarwalConfigFlow)
+        flow.async_show_form = MagicMock(return_value={"type": "form"})
+        flow.async_abort = MagicMock(
+            side_effect=lambda reason: {"type": "abort", "reason": reason}
+        )
+        flow.async_set_unique_id = AsyncMock()
+        flow._abort_if_unique_id_configured = MagicMock()
+        flow._async_current_entries = MagicMock(return_value=entries or [])
+        flow.context = {}
+        flow.hass = MagicMock()
+        return flow
+
+    @staticmethod
+    def _entry(host: str, device_id: str = "") -> MagicMock:
+        entry = MagicMock()
+        entry.data = {"host": host, "device_id": device_id}
+        return entry
+
+    async def test_zeroconf_routes_to_user_step_with_host_prefilled(self) -> None:
+        """A discovered robot lands on the user form with its address filled in."""
+        flow = self._make_flow()
+
+        await flow.async_step_zeroconf(
+            ZeroconfServiceInfo(
+                host="10.0.0.112",
+                hostname="NARWAL_8d5298.local.",
+                port=9002,
+            )
+        )
+
+        assert flow._discovered_host == "10.0.0.112"
+        assert flow.context["title_placeholders"] == {"host": "10.0.0.112"}
+        flow.async_show_form.assert_called_once()
+        assert flow.async_show_form.call_args.kwargs["step_id"] == "user"
+
+    async def test_zeroconf_uses_hostname_without_trailing_dot_as_unique_id(self) -> None:
+        """The mDNS trailing dot must not end up in the unique_id."""
+        flow = self._make_flow()
+
+        await flow.async_step_zeroconf(
+            ZeroconfServiceInfo(host="10.0.0.112", hostname="NARWAL_8d5298.local.")
+        )
+
+        flow.async_set_unique_id.assert_awaited_once_with("NARWAL_8d5298.local")
+
+    async def test_dhcp_routes_to_user_step(self) -> None:
+        """DHCP discovery is the fallback path when multicast is filtered."""
+        flow = self._make_flow()
+
+        await flow.async_step_dhcp(
+            DhcpServiceInfo(
+                ip="10.0.0.112",
+                hostname="NARWAL_8d5298",
+                macaddress="809d658d5298",
+            )
+        )
+
+        assert flow._discovered_host == "10.0.0.112"
+        flow.async_set_unique_id.assert_awaited_once_with("NARWAL_8d5298")
+
+    async def test_dhcp_without_hostname_falls_back_to_ip(self) -> None:
+        """A lease with no hostname still needs some unique_id."""
+        flow = self._make_flow()
+
+        await flow.async_step_dhcp(DhcpServiceInfo(ip="10.0.0.112", hostname=""))
+
+        flow.async_set_unique_id.assert_awaited_once_with("10.0.0.112")
+
+    async def test_known_host_aborts_without_showing_a_card(self) -> None:
+        """A robot added by hand must not reappear as a Discovered card.
+
+        Its entry's unique_id is the device_id, which discovery can't see, so
+        the host is the only thing the two paths have in common.
+        """
+        flow = self._make_flow(entries=[self._entry("10.0.0.112")])
+
+        result = await flow.async_step_zeroconf(
+            ZeroconfServiceInfo(host="10.0.0.112", hostname="NARWAL_8d5298.local.")
+        )
+
+        assert result["reason"] == "already_configured"
+        flow.async_show_form.assert_not_called()
+        flow.async_set_unique_id.assert_not_awaited()
+
+    async def test_other_host_still_offered(self) -> None:
+        """A second robot is not suppressed by the first one's entry."""
+        flow = self._make_flow(entries=[self._entry("10.0.0.112")])
+
+        await flow.async_step_zeroconf(
+            ZeroconfServiceInfo(host="10.0.0.113", hostname="NARWAL_aabbcc.local.")
+        )
+
+        flow.async_show_form.assert_called_once()
+        assert flow._discovered_host == "10.0.0.113"
+
+    async def test_rediscovery_at_a_new_address_updates_the_entry(self) -> None:
+        """Hostname is the discovery id, so a DHCP renewal updates the host."""
+        flow = self._make_flow()
+
+        await flow.async_step_zeroconf(
+            ZeroconfServiceInfo(host="10.0.0.150", hostname="NARWAL_8d5298.local.")
+        )
+
+        flow._abort_if_unique_id_configured.assert_called_once_with(
+            updates={"host": "10.0.0.150"}
+        )
+
+    async def test_manually_added_robot_matched_by_device_id_suffix(self) -> None:
+        """A hand-added entry is recognised by the device_id tail in the name.
+
+        Verified on hardware: device_id 71c53f01…147bb53c advertises as
+        NARWAL_7bb53c.local. — the only link between the two paths.
+        """
+        entry = self._entry(
+            "10.0.0.112", device_id="71c53f01c14f49088338863e147bb53c"
+        )
+        flow = self._make_flow(entries=[entry])
+
+        result = await flow.async_step_zeroconf(
+            ZeroconfServiceInfo(host="10.0.0.112", hostname="NARWAL_7bb53c.local.")
+        )
+
+        assert result["reason"] == "already_configured"
+        flow.async_show_form.assert_not_called()
+
+    async def test_known_device_at_new_address_repoints_the_entry(self) -> None:
+        """Same robot, new IP: update the entry rather than orphan it."""
+        entry = self._entry(
+            "10.0.0.112", device_id="71c53f01c14f49088338863e147bb53c"
+        )
+        flow = self._make_flow(entries=[entry])
+
+        result = await flow.async_step_zeroconf(
+            ZeroconfServiceInfo(host="10.0.0.199", hostname="NARWAL_7bb53c.local.")
+        )
+
+        assert result["reason"] == "already_configured"
+        flow.hass.config_entries.async_update_entry.assert_called_once()
+        updated = flow.hass.config_entries.async_update_entry.call_args.kwargs["data"]
+        assert updated["host"] == "10.0.0.199"
+        assert updated["device_id"] == "71c53f01c14f49088338863e147bb53c"
+
+    async def test_a_different_robot_is_not_matched(self) -> None:
+        """A non-matching suffix at a different address is a new device."""
+        entry = self._entry(
+            "10.0.0.112", device_id="71c53f01c14f49088338863e147bb53c"
+        )
+        flow = self._make_flow(entries=[entry])
+
+        await flow.async_step_zeroconf(
+            ZeroconfServiceInfo(host="10.0.0.113", hostname="NARWAL_aabbcc.local.")
+        )
+
+        flow.async_show_form.assert_called_once()
+        flow.hass.config_entries.async_update_entry.assert_not_called()
+
+    def test_device_id_suffix_parsing(self) -> None:
+        """Both discovery name shapes yield the suffix; other names yield None."""
+        parse = NarwalConfigFlow._device_id_suffix
+        assert parse("NARWAL_7bb53c.local.") == "7bb53c"
+        assert parse("narwal_7BB53C") == "7bb53c"
+        assert parse("_app_wss_server_7bb53c._narwal_sweeper._tcp.local.") == "7bb53c"
+        assert parse("10.0.0.112") is None
+        assert parse("some-other-vacuum.local.") is None
+
+    async def test_manual_flow_is_unaffected(self) -> None:
+        """With no discovery, the user step shows the plain schema."""
+        flow = self._make_flow()
+
+        await flow.async_step_user(user_input=None)
+
+        assert flow._discovered_host is None
+        flow.async_show_form.assert_called_once()


### PR DESCRIPTION
Extracts the zeroconf + DHCP discovery from #35 onto current `master`, authored to @StratoGh0st99.

This is the cherry-pick I offered on #35 rather than asking for another rebase. #35 bundled discovery with 3,806 lines across 27 files, most of which has since landed through #49, #50, #52, #53, #54, #61, #62, #63 and #67 — discovery was the part with **no equivalent on master**, and the biggest outstanding setup win in the tracker. #40 shows setup failing outright when the 15 s wake timeout expires before a sleeping robot answers; a pre-filled host sidesteps that whole class of "which IP is it" failures.

@StratoGh0st99 — you're the commit author. If you'd rather carry this yourself, say so and I'll close this in favour of your branch.

## What it does

Declares `_narwal_sweeper._tcp.local.` and the `NARWAL_*` / `narwal_*` DHCP hostnames in the manifest, and routes both into the existing user step with the address filled in. The model is still chosen by hand — it isn't in the mDNS payload.

## Verified on hardware

Browsed from the LAN against a Flow (AX12):

```
_app_wss_server_7bb53c._narwal_sweeper._tcp.local.
    server = NARWAL_7bb53c.local.
    addrs  = ['10.0.0.112']   port = 9002
```

So the service type, the instance-name shape and the `NARWAL_*` hostname pattern in #35 are all confirmed, not taken on trust.

That capture also settled a design question. A configured entry's `unique_id` is the full `device_id`, read over the WebSocket — something neither mDNS nor DHCP can see. Without a link between the two, a robot added by hand reappears as a "Discovered" card forever. This robot's `device_id` is `71c53f01c14f49088338863e147bb53c` and it advertises as `NARWAL_7bb53c`: **the last six hex characters**. Matching on that suffix identifies the device itself, and a match at a new address repoints the existing entry instead of orphaning it.

## Two changes from #35's implementation

1. **Host-only matching → device_id suffix matching.** The original matched on host, and its "IP drifted (DHCP renewal, robot moved subnets)" branch rewrote the entry with the same host it had just matched on — a no-op under a comment describing real behaviour. Suffix matching does what that comment intended.
2. **The user-step schema keeps the host in hand,** so a failed connect no longer clears what you typed.

Everything else is @StratoGh0st99's design, including the fallback-to-DHCP rationale (multicast is routinely dropped across VLANs and under wireless client isolation).

## Tests

12 new config-flow tests plus the `service_info` stubs they need: both discovery paths, the trailing-dot strip on mDNS hostnames, DHCP leases with no hostname, device-suffix matching, the repoint-on-new-address case, a second robot not being suppressed by the first, and the manual flow being unaffected. **251 passing.**

## Not included from #35

The diagnostic entities and map work, all superseded by what has landed since. `tools/narwal_capture.py` and `coverage_probe.py` still can't land — `tools/` is gitignored here — but the standing offer holds: I'll link and credit them from `docs/PROTOCOL.md` §12 if you want them findable.

Closes the discovery half of #35.
