### PR TITLE
fix(models): decode packed consumable alert lists (#79)

### DIFF
--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -183,9 +183,39 @@ def _to_float32(val: Any) -> float | None:
     return None
 
 
+def _packed_varints(raw: bytes) -> list[int]:
+    """Decode a protobuf packed repeated varint field."""
+    out: list[int] = []
+    acc = shift = 0
+    for byte in raw:
+        acc |= (byte & 0x7F) << shift
+        if byte & 0x80:
+            shift += 7
+        else:
+            out.append(acc)
+            acc = shift = 0
+    return out  # a trailing unterminated varint is incomplete data; drop it
+
+
 def _enum_int_list(val: Any) -> list[int]:
-    """Coerce a bbp repeated field (int, list, or absent) to a list of non-zero ints."""
-    items = val if isinstance(val, list) else [val] if val is not None else []
+    """Coerce a bbp repeated field to a list of non-zero ints.
+
+    protobuf packs repeated scalars, and blackboxprotobuf surfaces a packed field as
+    str/bytes rather than a list — the code points are the encoded bytes. Feeding that
+    to int() raises, and an alert list that fails to parse is indistinguishable from a
+    robot reporting nothing wrong, so this silently reported healthy consumables on a
+    robot asking for six parts (#79).
+    """
+    if isinstance(val, (bytes, bytearray)):
+        items: Any = _packed_varints(bytes(val))
+    elif isinstance(val, str):
+        # bbp decodes the blob as latin-1, so each code point is one byte.
+        items = _packed_varints(val.encode("latin-1", "ignore"))
+    elif isinstance(val, list):
+        items = val
+    else:
+        items = [val] if val is not None else []
+
     out: list[int] = []
     for item in items:
         try:

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -183,9 +183,39 @@ def _to_float32(val: Any) -> float | None:
     return None
 
 
+def _packed_varints(raw: bytes) -> list[int]:
+    """Decode a protobuf packed repeated varint field."""
+    out: list[int] = []
+    acc = shift = 0
+    for byte in raw:
+        acc |= (byte & 0x7F) << shift
+        if byte & 0x80:
+            shift += 7
+        else:
+            out.append(acc)
+            acc = shift = 0
+    return out  # a trailing unterminated varint is incomplete data; drop it
+
+
 def _enum_int_list(val: Any) -> list[int]:
-    """Coerce a bbp repeated field (int, list, or absent) to a list of non-zero ints."""
-    items = val if isinstance(val, list) else [val] if val is not None else []
+    """Coerce a bbp repeated field to a list of non-zero ints.
+
+    protobuf packs repeated scalars, and blackboxprotobuf surfaces a packed field as
+    str/bytes rather than a list — the code points are the encoded bytes. Feeding that
+    to int() raises, and an alert list that fails to parse is indistinguishable from a
+    robot reporting nothing wrong, so this silently reported healthy consumables on a
+    robot asking for six parts (#79).
+    """
+    if isinstance(val, (bytes, bytearray)):
+        items: Any = _packed_varints(bytes(val))
+    elif isinstance(val, str):
+        # bbp decodes the blob as latin-1, so each code point is one byte.
+        items = _packed_varints(val.encode("latin-1", "ignore"))
+    elif isinstance(val, list):
+        items = val
+    else:
+        items = [val] if val is not None else []
+
     out: list[int] = []
     for item in items:
         try:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -337,6 +337,48 @@ class TestNarwalState:
         assert state.maintain_items == []
         assert state.replace_items == []
 
+    def test_consumable_info_packed_varints(self) -> None:
+        """The wire shape: protobuf packs repeated scalars, bbp yields str (#79).
+
+        Verbatim capture from a Flow (AX12, v01.08.03.07). The list-and-int shapes
+        above are what a hand-written payload looks like, not what a robot sends —
+        which is how this went unnoticed while every alert was dropped.
+        """
+        state = NarwalState()
+        state.update_from_consumable_info({"1": {"1": "\x04\x06\x08\n", "2": "\x03\x14"}})
+        # wash ribs, universal wheel, side distance sensor, anti-winding brush
+        assert state.maintain_items == [4, 6, 8, 10]
+        assert state.replace_items == [3, 20]  # side brush, station bag
+
+    def test_consumable_info_single_packed_item(self) -> None:
+        """A one-item packed list is where an off-by-one decoder still looks right."""
+        state = NarwalState()
+        state.update_from_consumable_info({"1": {"1": "\x02", "2": "\x08"}})
+        assert state.maintain_items == [2]  # dust filter
+        assert state.replace_items == [8]  # dust bag
+
+    def test_consumable_info_accepts_bytes(self) -> None:
+        """Same blob as bytes rather than str — decoder version shouldn't matter."""
+        state = NarwalState()
+        state.update_from_consumable_info({"1": {"1": b"\x04\x06", "2": b"\x14"}})
+        assert state.maintain_items == [4, 6]
+        assert state.replace_items == [20]
+
+    def test_consumable_info_multibyte_varint(self) -> None:
+        """Values above 127 span bytes; a byte-per-value shortcut would misread them."""
+        state = NarwalState()
+        state.update_from_consumable_info({"1": {"1": "\xac\x02", "2": "\x01"}})
+        assert state.maintain_items == [300]
+        assert state.replace_items == [1]
+
+    def test_consumable_info_empty_blob_is_healthy(self) -> None:
+        """An empty packed field still means nothing needs attention."""
+        state = NarwalState()
+        state.update_from_consumable_info({"1": {"1": [4], "2": [20]}})
+        state.update_from_consumable_info({"1": {"1": "", "2": ""}})
+        assert state.maintain_items == []
+        assert state.replace_items == []
+
     def test_base_status_dock_light_mode(self) -> None:
         """Field 50 exposes the base station ambient light mode."""
         state = NarwalState()


### PR DESCRIPTION
Fixes the confirmed bug in #79: **every consumable maintain/replace alert has been silently discarded since the feature shipped.**

## The bug

`consumable/get_consumable_info` returns its two lists as **packed repeated varints**, and blackboxprotobuf surfaces a packed field as a `str` whose code points are the encoded bytes. `_enum_int_list()` accepted "an int, or a list of ints", so `int('\x04\x06\x08\n')` raised, the per-item `except: continue` swallowed it, and both lists came back empty.

Empty means *nothing needs attention*. That's what made this invisible — it failed as good news. Live capture from my Flow (AX12, `v01.08.03.07`), a robot that has been running for months:

```
{'1': {'1': '\x04\x06\x08\n', '2': '\x03\x14'}}

  maintainItems = [4, 6, 8, 10]  wash ribs, universal wheel,
                                 side distance sensor, anti-winding brush
  replaceItems  = [3, 20]        side brush, station bag
```

`binary_sensor.maintenance_required` and `binary_sensor.replacement_required` reported `off` throughout, on a robot asking for six parts.

## The fix

Decode `str`/`bytes` as packed varints before the int conversion. Properly, not one byte per value — enum ids are all small today, but a byte-per-value shortcut would misread anything above 127 and hide the next surprise.

Both callers of `_enum_int_list` are consumable lists, so there is no genuine text field that could be mangled by treating a `str` as a blob.

## Why a green suite missed it

The existing test fed `{"1": [1, 9], "2": 8}` — the shapes a **hand-written** payload takes, not the shape a robot sends. The test and the code shared an assumption, so they agreed with each other and not with the device.

New tests use the verbatim capture, plus the cases that would let a subtly wrong decoder pass:

- the real four-item / two-item capture
- a **single-item** list, where an off-by-one decoder still looks correct
- a `bytes` blob rather than `str`, so a bbp version change doesn't reintroduce it
- a **multi-byte varint** (300), which a byte-per-value shortcut gets wrong
- an empty blob, which must still mean healthy

`255 passed`, and both `narwal_client` copies verified identical.

## Verification

Re-ran the probe against the live robot with the patched code — the same payload that previously parsed to nothing now yields `maintain_items = [4, 6, 8, 10]` and `replace_items = [3, 20]`.

## Scope

This closes the first checkbox in #79 only. The disputed field 38, the unverified field 41 → detergent mapping, the absent fields 21/35, and the tank-state thresholds behind #77 all still need captures from other people's hardware — the asks are listed in that issue.
