### PR TITLE
fix: log robot wake/sleep transitions at DEBUG

### DIFF
--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -484,7 +484,7 @@ class NarwalClient:
         self._last_broadcast_time = time.monotonic()
         if not self._robot_awake:
             self._robot_awake = True
-            _LOGGER.info("Robot is awake (received broadcast)")
+            _LOGGER.debug("Robot is awake (received broadcast)")
 
         if self.on_message:
             self.on_message(msg)
@@ -762,7 +762,7 @@ class NarwalClient:
                     and time.monotonic() - self._last_broadcast_time
                     > BROADCAST_STALE_TIMEOUT
                 ):
-                    _LOGGER.info(
+                    _LOGGER.debug(
                         "No broadcast for %.0fs — robot may have gone to sleep",
                         time.monotonic() - self._last_broadcast_time,
                     )

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -484,7 +484,7 @@ class NarwalClient:
         self._last_broadcast_time = time.monotonic()
         if not self._robot_awake:
             self._robot_awake = True
-            _LOGGER.info("Robot is awake (received broadcast)")
+            _LOGGER.debug("Robot is awake (received broadcast)")
 
         if self.on_message:
             self.on_message(msg)
@@ -762,7 +762,7 @@ class NarwalClient:
                     and time.monotonic() - self._last_broadcast_time
                     > BROADCAST_STALE_TIMEOUT
                 ):
-                    _LOGGER.info(
+                    _LOGGER.debug(
                         "No broadcast for %.0fs — robot may have gone to sleep",
                         time.monotonic() - self._last_broadcast_time,
                     )


### PR DESCRIPTION
## Problem

`_robot_awake` transitions are logged at INFO on both edges:

```python
# narwal_client/client.py:487
if not self._robot_awake:
    self._robot_awake = True
    _LOGGER.info("Robot is awake (received broadcast)")
```

```python
# narwal_client/client.py:765
if (self._robot_awake and self._last_broadcast_time > 0
        and time.monotonic() - self._last_broadcast_time > BROADCAST_STALE_TIMEOUT):
    _LOGGER.info("No broadcast for %.0fs — robot may have gone to sleep", ...)
```

Both are edge-triggered, so they look cheap. In practice a docked robot broadcasts only intermittently, and `BROADCAST_STALE_TIMEOUT` is 15s, so the flag flips continuously.

Over a 37-hour window on a live install (Narwal Flow, HA 2026.8.2), these two lines produced **5,767 of the 19,927 lines in the log** — about 29% of everything Home Assistant wrote:

| message | count |
| --- | --- |
| `Robot is awake (received broadcast)` | 2,901 |
| `No broadcast for 15s — robot may have gone to sleep` | 2,113 |
| `No broadcast for 16s — robot may have gone to sleep` | 676 |
| `No broadcast for 17s — robot may have gone to sleep` | 77 |

That is roughly 3,700 lines/day, a full wake/sleep cycle about every 46 seconds. On installs where the config directory sits on spinning disk this is a real amount of pointless write traffic, and it buries anything else in the log.

## Fix

Drop both to DEBUG.

Neither edge is something a user can act on — it is internal bookkeeping about whether the robot is currently broadcasting. The genuinely notable events around them stay at INFO (`Connected to Narwal vacuum at %s`, `Disconnected from Narwal vacuum`, `Attempting to wake robot`, `Robot woke up after %d attempt(s)`), so a normal log still shows connection lifecycle and explicit wake attempts. Anyone debugging broadcast behaviour can enable debug logging for `custom_components.narwal`.

## Notes

- Both copies of `narwal_client/client.py` are updated so the embedded copy stays in sync with the top-level one.
- `pytest tests/ -q` → 267 passed.
