### PR TITLE
fix(client): preserve discovered product prefix

### DIFF
--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -16,6 +16,7 @@ from .const import (
     BROADCAST_STALE_TIMEOUT,
     COMMAND_RESPONSE_TIMEOUT,
     DEFAULT_PORT,
+    DEFAULT_TOPIC_PREFIX,
     HEARTBEAT_INTERVAL,
     KEEPALIVE_INTERVAL,
     KNOWN_PRODUCT_KEYS,
@@ -23,9 +24,10 @@ from .const import (
     RECONNECT_INITIAL_DELAY,
     RECONNECT_MAX_DELAY,
     TOPIC_CMD_ACTIVE_ROBOT,
-    TOPIC_CMD_APP_HEARTBEAT,
     TOPIC_CMD_AMBIENT_LIGHT_CTRL,
+    TOPIC_CMD_APP_HEARTBEAT,
     TOPIC_CMD_CANCEL,
+    TOPIC_CMD_CLEAN_TASK,
     TOPIC_CMD_DRY_MOP,
     TOPIC_CMD_DUST_GATHERING,
     TOPIC_CMD_EASY_CLEAN,
@@ -34,32 +36,29 @@ from .const import (
     TOPIC_CMD_GET_BASE_STATUS,
     TOPIC_CMD_GET_CONSUMABLE_INFO,
     TOPIC_CMD_GET_CURRENT_TASK,
+    TOPIC_CMD_GET_DEBUG_IMAGE,
     TOPIC_CMD_GET_DEVICE_INFO,
     TOPIC_CMD_GET_FEATURE_LIST,
     TOPIC_CMD_GET_MAP,
     TOPIC_CMD_NOTIFY_APP_EVENT,
     TOPIC_CMD_PAUSE,
-    TOPIC_CMD_PING,
+    TOPIC_CMD_PLAN_START,
     TOPIC_CMD_RECALL,
     TOPIC_CMD_RESUME,
     TOPIC_CMD_SET_FAN_LEVEL,
-    TOPIC_CMD_SET_MOP_HUMIDITY,
-    TOPIC_CMD_PLAN_START,
-    TOPIC_CMD_CLEAN_TASK,
-    TOPIC_CMD_TAKE_PICTURE,
-    TOPIC_CMD_GET_DEBUG_IMAGE,
     TOPIC_CMD_SET_LED,
+    TOPIC_CMD_SET_MOP_HUMIDITY,
+    TOPIC_CMD_TAKE_PICTURE,
     TOPIC_CMD_WASH_MOP,
     TOPIC_CMD_YELL,
-    DEFAULT_TOPIC_PREFIX,
     WAKE_TIMEOUT,
     AmbientLightCtrlType,
     CommandResult,
     FanLevel,
     MopHumidity,
     MopStrengthLevel,
-    WorkMode,
     WorkingStatus,
+    WorkMode,
 )
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState
 from .protocol import (
@@ -180,6 +179,13 @@ class NarwalClient:
     def _full_topic(self, short_topic: str) -> str:
         """Build the full topic path."""
         return f"{self.topic_prefix}/{self.device_id}/{short_topic}"
+
+    def _update_topic_prefix_from_topic(self, topic: str, source: str) -> None:
+        """Preserve the product-key prefix from a robot response topic."""
+        parts = topic.split("/")
+        if len(parts) >= 2 and parts[0] == "" and parts[1]:
+            self.topic_prefix = f"/{parts[1]}"
+            _LOGGER.info("Topic prefix from %s: %s", source, self.topic_prefix)
 
     @property
     def connected(self) -> bool:
@@ -332,12 +338,29 @@ class NarwalClient:
             if msg.field_tag == PROTOBUF_FIELD5_TAG and msg.payload:
                 try:
                     decoded = self._decode_protobuf(msg.payload)
+                    raw_product_key = decoded.get("1", b"")
+                    if isinstance(raw_product_key, bytes):
+                        product_key = raw_product_key.decode(
+                            "utf-8", errors="replace"
+                        ).strip()
+                    elif isinstance(raw_product_key, str):
+                        product_key = raw_product_key.strip()
+                    else:
+                        product_key = ""
                     raw_id = decoded.get("2", b"")
                     if isinstance(raw_id, bytes):
                         raw_id = raw_id.decode("utf-8", errors="replace").strip()
                     else:
                         raw_id = str(raw_id).strip()
                     if raw_id:
+                        if product_key:
+                            self.topic_prefix = f"/{product_key}"
+                            _LOGGER.info(
+                                "Topic prefix from response payload: %s",
+                                self.topic_prefix,
+                            )
+                        else:
+                            self._update_topic_prefix_from_topic(msg.topic, "response")
                         self.device_id = raw_id
                         _LOGGER.info("Discovered device_id from response: %s", self.device_id)
                         return self.device_id
@@ -350,9 +373,7 @@ class NarwalClient:
                 # Topic format: /{product_key}/{device_id}/{category}/{type}
                 if len(parts) >= 4 and parts[2]:
                     # Extract product_key from topic to set correct prefix
-                    if parts[1]:
-                        self.topic_prefix = f"/{parts[1]}"
-                        _LOGGER.info("Topic prefix from broadcast: %s", self.topic_prefix)
+                    self._update_topic_prefix_from_topic(msg.topic, "broadcast")
                     self.device_id = parts[2]
                     _LOGGER.info("Discovered device_id from broadcast: %s", self.device_id)
                     return self.device_id
@@ -374,7 +395,7 @@ class NarwalClient:
         drained = 0
         while True:
             try:
-                data = await asyncio.wait_for(self._ws.recv(), timeout=0.05)
+                await asyncio.wait_for(self._ws.recv(), timeout=0.05)
                 drained += 1
             except asyncio.TimeoutError:
                 break

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -16,6 +16,7 @@ from .const import (
     BROADCAST_STALE_TIMEOUT,
     COMMAND_RESPONSE_TIMEOUT,
     DEFAULT_PORT,
+    DEFAULT_TOPIC_PREFIX,
     HEARTBEAT_INTERVAL,
     KEEPALIVE_INTERVAL,
     KNOWN_PRODUCT_KEYS,
@@ -23,9 +24,10 @@ from .const import (
     RECONNECT_INITIAL_DELAY,
     RECONNECT_MAX_DELAY,
     TOPIC_CMD_ACTIVE_ROBOT,
-    TOPIC_CMD_APP_HEARTBEAT,
     TOPIC_CMD_AMBIENT_LIGHT_CTRL,
+    TOPIC_CMD_APP_HEARTBEAT,
     TOPIC_CMD_CANCEL,
+    TOPIC_CMD_CLEAN_TASK,
     TOPIC_CMD_DRY_MOP,
     TOPIC_CMD_DUST_GATHERING,
     TOPIC_CMD_EASY_CLEAN,
@@ -34,32 +36,29 @@ from .const import (
     TOPIC_CMD_GET_BASE_STATUS,
     TOPIC_CMD_GET_CONSUMABLE_INFO,
     TOPIC_CMD_GET_CURRENT_TASK,
+    TOPIC_CMD_GET_DEBUG_IMAGE,
     TOPIC_CMD_GET_DEVICE_INFO,
     TOPIC_CMD_GET_FEATURE_LIST,
     TOPIC_CMD_GET_MAP,
     TOPIC_CMD_NOTIFY_APP_EVENT,
     TOPIC_CMD_PAUSE,
-    TOPIC_CMD_PING,
+    TOPIC_CMD_PLAN_START,
     TOPIC_CMD_RECALL,
     TOPIC_CMD_RESUME,
     TOPIC_CMD_SET_FAN_LEVEL,
-    TOPIC_CMD_SET_MOP_HUMIDITY,
-    TOPIC_CMD_PLAN_START,
-    TOPIC_CMD_CLEAN_TASK,
-    TOPIC_CMD_TAKE_PICTURE,
-    TOPIC_CMD_GET_DEBUG_IMAGE,
     TOPIC_CMD_SET_LED,
+    TOPIC_CMD_SET_MOP_HUMIDITY,
+    TOPIC_CMD_TAKE_PICTURE,
     TOPIC_CMD_WASH_MOP,
     TOPIC_CMD_YELL,
-    DEFAULT_TOPIC_PREFIX,
     WAKE_TIMEOUT,
     AmbientLightCtrlType,
     CommandResult,
     FanLevel,
     MopHumidity,
     MopStrengthLevel,
-    WorkMode,
     WorkingStatus,
+    WorkMode,
 )
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState
 from .protocol import (
@@ -180,6 +179,13 @@ class NarwalClient:
     def _full_topic(self, short_topic: str) -> str:
         """Build the full topic path."""
         return f"{self.topic_prefix}/{self.device_id}/{short_topic}"
+
+    def _update_topic_prefix_from_topic(self, topic: str, source: str) -> None:
+        """Preserve the product-key prefix from a robot response topic."""
+        parts = topic.split("/")
+        if len(parts) >= 2 and parts[0] == "" and parts[1]:
+            self.topic_prefix = f"/{parts[1]}"
+            _LOGGER.info("Topic prefix from %s: %s", source, self.topic_prefix)
 
     @property
     def connected(self) -> bool:
@@ -332,12 +338,29 @@ class NarwalClient:
             if msg.field_tag == PROTOBUF_FIELD5_TAG and msg.payload:
                 try:
                     decoded = self._decode_protobuf(msg.payload)
+                    raw_product_key = decoded.get("1", b"")
+                    if isinstance(raw_product_key, bytes):
+                        product_key = raw_product_key.decode(
+                            "utf-8", errors="replace"
+                        ).strip()
+                    elif isinstance(raw_product_key, str):
+                        product_key = raw_product_key.strip()
+                    else:
+                        product_key = ""
                     raw_id = decoded.get("2", b"")
                     if isinstance(raw_id, bytes):
                         raw_id = raw_id.decode("utf-8", errors="replace").strip()
                     else:
                         raw_id = str(raw_id).strip()
                     if raw_id:
+                        if product_key:
+                            self.topic_prefix = f"/{product_key}"
+                            _LOGGER.info(
+                                "Topic prefix from response payload: %s",
+                                self.topic_prefix,
+                            )
+                        else:
+                            self._update_topic_prefix_from_topic(msg.topic, "response")
                         self.device_id = raw_id
                         _LOGGER.info("Discovered device_id from response: %s", self.device_id)
                         return self.device_id
@@ -350,9 +373,7 @@ class NarwalClient:
                 # Topic format: /{product_key}/{device_id}/{category}/{type}
                 if len(parts) >= 4 and parts[2]:
                     # Extract product_key from topic to set correct prefix
-                    if parts[1]:
-                        self.topic_prefix = f"/{parts[1]}"
-                        _LOGGER.info("Topic prefix from broadcast: %s", self.topic_prefix)
+                    self._update_topic_prefix_from_topic(msg.topic, "broadcast")
                     self.device_id = parts[2]
                     _LOGGER.info("Discovered device_id from broadcast: %s", self.device_id)
                     return self.device_id
@@ -374,7 +395,7 @@ class NarwalClient:
         drained = 0
         while True:
             try:
-                data = await asyncio.wait_for(self._ws.recv(), timeout=0.05)
+                await asyncio.wait_for(self._ws.recv(), timeout=0.05)
                 drained += 1
             except asyncio.TimeoutError:
                 break

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,7 +19,7 @@ from narwal_client.const import (
     WorkingStatus,
 )
 from narwal_client.models import CommandResponse, MapData, RoomInfo
-from narwal_client.protocol import build_frame
+from narwal_client.protocol import PROTOBUF_FIELD5_TAG, build_frame
 
 
 class TestNarwalClientInit:
@@ -139,6 +139,30 @@ class TestNarwalClientInit:
             assert await client.wake(timeout=10.0)
 
         wake_burst.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_discover_device_id_preserves_field5_product_key(self) -> None:
+        """Auto-discovery must keep the product key that answered the wake probe."""
+        client = NarwalClient("10.0.0.1")
+        client._ws = AsyncMock()
+        client._connected.set()
+        client._ws.recv.return_value = bytes(
+            [0x01, 0x02, PROTOBUF_FIELD5_TAG, 0x00, 0x08, 0x01]
+        )
+
+        with patch.object(
+            client,
+            "_decode_protobuf",
+            return_value={
+                "1": b"DrzDKQ0MU8",
+                "2": b"auto_device_456",
+            },
+        ):
+            device_id = await client.discover_device_id(timeout=1.0)
+
+        assert device_id == "auto_device_456"
+        assert client.device_id == "auto_device_456"
+        assert client.topic_prefix == "/DrzDKQ0MU8"
 
 
 class TestBuildCleanPayloadV2:


### PR DESCRIPTION
## Summary
- preserve the product-key topic prefix when field-5 device-info responses identify a robot
- decode the product key and device id from the same response
- retain broadcast-topic discovery as a fallback
- cover non-default product-key discovery with a regression test

## Why
Some Narwal models use product-specific topic prefixes. Field-5 command responses have an empty topic, but `get_device_info` returns the product key in payload field 1 alongside the device id in field 2.

Preserving both values from that response makes later local commands use the robot's actual topic namespace. Models that broadcast their identity remain supported through the existing topic-based fallback.