### PR TITLE
feat(dock): add dock task switches

### DIFF
--- a/custom_components/narwal/binary_sensor.py
+++ b/custom_components/narwal/binary_sensor.py
@@ -15,8 +15,6 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .narwal_client import NarwalState
-
 from . import NarwalConfigEntry
 from .const import (
     CONSUMABLE_MAINTAIN_ITEMS,
@@ -24,7 +22,8 @@ from .const import (
     ERROR_HELP_URL_TEMPLATE,
 )
 from .coordinator import NarwalCoordinator
-from .entity import NarwalEntity
+from .entity import NarwalDockEntity, NarwalEntity
+from .narwal_client import NarwalState
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -33,6 +32,7 @@ class NarwalBinarySensorEntityDescription(BinarySensorEntityDescription):
 
     value_fn: Callable[[NarwalState], bool | None]
     attrs_fn: Callable[[NarwalState], dict[str, Any] | None] | None = None
+    dock_device: bool = False
 
 
 def _tank_problem(attr: str, bad: frozenset[int]) -> Callable[[NarwalState], bool | None]:
@@ -96,6 +96,7 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[NarwalBinarySensorEntityDescription, ...] = (
         translation_key="clean_water_tank",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
+        dock_device=True,
         value_fn=_tank_problem("clean_water_tank_state", frozenset({2, 3, 4})),
     ),
     NarwalBinarySensorEntityDescription(
@@ -103,6 +104,7 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[NarwalBinarySensorEntityDescription, ...] = (
         translation_key="sewage_tank",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
+        dock_device=True,
         value_fn=_tank_problem("sewage_tank_state", frozenset({2, 3})),
     ),
     NarwalBinarySensorEntityDescription(
@@ -110,6 +112,7 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[NarwalBinarySensorEntityDescription, ...] = (
         translation_key="dust_box",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
+        dock_device=True,
         value_fn=_tank_problem("dust_box_state", frozenset({2, 3, 4})),
     ),
     NarwalBinarySensorEntityDescription(
@@ -117,6 +120,7 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[NarwalBinarySensorEntityDescription, ...] = (
         translation_key="dust_bag",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
+        dock_device=True,
         value_fn=_tank_problem("dust_bag_state", frozenset({2, 3, 4})),
     ),
     NarwalBinarySensorEntityDescription(
@@ -124,6 +128,7 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[NarwalBinarySensorEntityDescription, ...] = (
         translation_key="station_bag",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
+        dock_device=True,
         value_fn=_tank_problem("station_bag_state", frozenset({2, 3, 4})),
     ),
 )
@@ -138,7 +143,11 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
     entities: list[BinarySensorEntity] = [NarwalDockedSensor(coordinator)]
     entities += [
-        NarwalBinarySensor(coordinator, description)
+        (
+            NarwalDockBinarySensor(coordinator, description)
+            if description.dock_device
+            else NarwalBinarySensor(coordinator, description)
+        )
         for description in BINARY_SENSOR_DESCRIPTIONS
     ]
     async_add_entities(entities)
@@ -191,6 +200,39 @@ class NarwalBinarySensor(NarwalEntity, BinarySensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Optional per-sensor attributes (e.g. fault code detail)."""
+        state = self.coordinator.data
+        if state is None or self.entity_description.attrs_fn is None:
+            return None
+        return self.entity_description.attrs_fn(state)
+
+
+class NarwalDockBinarySensor(NarwalDockEntity, BinarySensorEntity):
+    """A description-driven Narwal binary sensor assigned to the dock device."""
+
+    entity_description: NarwalBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: NarwalCoordinator,
+        description: NarwalBinarySensorEntityDescription,
+    ) -> None:
+        """Initialize the dock binary sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        device_id = coordinator.config_entry.data["device_id"]
+        self._attr_unique_id = f"{device_id}_{description.key}"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the sensor value (None = unavailable)."""
+        state = self.coordinator.data
+        if state is None:
+            return None
+        return self.entity_description.value_fn(state)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Optional per-sensor attributes."""
         state = self.coordinator.data
         if state is None or self.entity_description.attrs_fn is None:
             return None

--- a/custom_components/narwal/coordinator.py
+++ b/custom_components/narwal/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import time
 from dataclasses import dataclass
@@ -12,18 +13,18 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from .const import DOMAIN, NO_BROADCAST_PRODUCT_KEYS
 from .narwal_client import (
-    WorkMode,
+    CommandResponse,
     FanLevel,
     MopHumidity,
     MopStrengthLevel,
     NarwalClient,
     NarwalConnectionError,
     NarwalState,
+    WorkMode,
 )
 from .narwal_client.const import ACTIVE_CLEANING_STATUSES, WorkingStatus
-
-from .const import DOMAIN, NO_BROADCAST_PRODUCT_KEYS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,11 +46,36 @@ TOPIC_SUBSCRIPTION_TTL = 600.0
 TOPIC_RESUBSCRIBE_AFTER = 240.0
 
 
+def _status_payload(response: CommandResponse) -> dict[str, object] | None:
+    """Return the decoded robot_base_status payload from a response."""
+    if not response.accepted or not isinstance(response.data, dict):
+        return None
+    status_data = response.data.get("2")
+    if isinstance(status_data, dict) and status_data:
+        return status_data
+    return None
+
+
+def _has_dock_status_payload(response: CommandResponse) -> bool:
+    """Return True when a response carries the dock status submessage."""
+    status_data = _status_payload(response)
+    if status_data is None:
+        return False
+    field3 = status_data.get("3")
+    if isinstance(field3, list):
+        field3 = field3[0] if field3 else None
+    if not isinstance(field3, dict):
+        return False
+    return bool({"1", "2", "3", "7", "10", "12", "18"}.intersection(field3))
+
+
 @dataclass
 class CleanSettings:
     """User-selected clean parameters, applied at the next room clean start.
 
-    Single source of truth the select/number entities mutate and the clean-start path reads; each entity persists its value via RestoreEntity, so they survive restarts. Only fan and water also have live setters — work_mode/mop_strength/passes take effect at the next start.
+    Single source of truth the select/number entities mutate and the
+    clean-start path reads; each entity persists its value via RestoreEntity.
+    Only fan and water also have live setters.
     """
 
     work_mode: WorkMode = WorkMode.VACUUM_AND_MOP
@@ -99,7 +125,22 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         self._last_topic_subscribe: float = 0.0
         self._consecutive_failures = 0
         self._max_failures = 5  # 5 * 60s = 5 minutes before entities go unavailable
-        self._consumable_poll_countdown = 0  # 0 = fetch on next poll, then every CONSUMABLE_POLL_EVERY
+        self._dock_status_refresh_failed = True
+        self._consumable_poll_countdown = 0
+        self.dock_action_lock = asyncio.Lock()
+
+    @property
+    def has_fresh_state(self) -> bool:
+        """Return true when the coordinator has not returned stale poll data."""
+        return self.last_update_success and not self._dock_status_refresh_failed
+
+    def _mark_dock_status_refresh_failed(self) -> None:
+        """Record that dock-control state may be stale."""
+        self._dock_status_refresh_failed = True
+
+    def _mark_dock_status_refresh_succeeded(self) -> None:
+        """Record that dock-control state came from a current base-status payload."""
+        self._dock_status_refresh_failed = False
 
     async def async_setup(self) -> None:
         """Connect to the vacuum and start the WebSocket listener.
@@ -118,10 +159,20 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
             _LOGGER.debug("Could not fetch device info at startup")
 
         try:
-            await self.client.get_status(
+            response = await self.client.get_status(
                 full_update=not self.client.state.has_recent_active_working_status
             )
+            if not getattr(response, "accepted", True):
+                raise NarwalConnectionError(
+                    f"Status refresh failed with code {response.result_code}"
+                )
+            if not _has_dock_status_payload(response):
+                raise NarwalConnectionError(
+                    "Status refresh returned no dock-status payload"
+                )
+            self._mark_dock_status_refresh_succeeded()
         except Exception:
+            self._mark_dock_status_refresh_failed()
             _LOGGER.debug("Could not fetch initial status")
 
         try:
@@ -269,12 +320,51 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
     async def _refresh_dock_status(self) -> None:
         """Immediate get_status() after return-to-dock to refresh dock fields."""
         try:
-            await self.client.get_status(
+            response = await self.client.get_status(
                 full_update=not self.client.state.has_recent_active_working_status
             )
+            if not getattr(response, "accepted", True):
+                raise NarwalConnectionError(
+                    f"Status refresh failed with code {response.result_code}"
+                )
+            if not _has_dock_status_payload(response):
+                raise NarwalConnectionError(
+                    "Status refresh returned no dock-status payload"
+                )
+            self._mark_dock_status_refresh_succeeded()
             self.async_set_updated_data(self.client.state)
         except Exception:
+            self._mark_dock_status_refresh_failed()
             _LOGGER.debug("Failed to refresh dock status after transition")
+            self.async_set_updated_data(self.client.state)
+
+    async def async_refresh_dock_status(self) -> bool:
+        """Refresh full dock/base-station status for action gating."""
+        full_update = not self.client.state.has_recent_active_working_status
+        try:
+            response = await self.client.get_status(full_update=full_update)
+        except Exception:
+            self._mark_dock_status_refresh_failed()
+            _LOGGER.debug("Failed to refresh dock status")
+            self.async_set_updated_data(self.client.state)
+            return False
+        if not response.accepted:
+            self._mark_dock_status_refresh_failed()
+            _LOGGER.debug(
+                "Dock status refresh was rejected with code %s",
+                response.result_code,
+            )
+            self.async_set_updated_data(self.client.state)
+            return False
+        if full_update and not _has_dock_status_payload(response):
+            self._mark_dock_status_refresh_failed()
+            _LOGGER.debug("Dock status refresh returned no dock-status payload")
+            self.async_set_updated_data(self.client.state)
+            return False
+        if full_update:
+            self._mark_dock_status_refresh_succeeded()
+        self.async_set_updated_data(self.client.state)
+        return True
 
     async def _async_update_data(self) -> NarwalState:
         """Polling fallback — fetch status if no push updates arrived.
@@ -289,11 +379,20 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         try:
             if not self.client.connected:
                 raise NarwalConnectionError("Not connected")
-            await self.client.get_status(
-                full_update=not self.client.state.has_recent_active_working_status
-            )
+            full_update = not self.client.state.has_recent_active_working_status
+            response = await self.client.get_status(full_update=full_update)
+            if not getattr(response, "accepted", True):
+                raise NarwalConnectionError(
+                    f"Status refresh failed with code {response.result_code}"
+                )
+            if full_update and not _has_dock_status_payload(response):
+                # An accepted partial response still proves the connection is
+                # healthy. Keep dock actions stale without taking unrelated
+                # entities unavailable after repeated battery-only polls.
+                self._mark_dock_status_refresh_failed()
         except Exception as err:
             self._consecutive_failures += 1
+            self._mark_dock_status_refresh_failed()
             if self._consecutive_failures >= self._max_failures:
                 raise UpdateFailed(
                     f"Vacuum unreachable for {self._consecutive_failures} consecutive polls"
@@ -305,13 +404,13 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
             return self.client.state  # stale data keeps entities available
         else:
             self._consecutive_failures = 0
+            if full_update and _has_dock_status_payload(response):
+                self._mark_dock_status_refresh_succeeded()
 
         # Retry map fetch if it failed during setup
         if self.client.state.map_data is None:
-            try:
+            with contextlib.suppress(Exception):
                 await self.client.get_map()
-            except Exception:
-                pass
 
         # Renew the broadcast subscription before it lapses. This is deliberately
         # NOT conditional on believing we are cleaning: working_status is what tells

--- a/custom_components/narwal/dock_tasks.py
+++ b/custom_components/narwal/dock_tasks.py
@@ -101,6 +101,17 @@ def is_robot_work_context(state: NarwalState | None) -> bool:
     )
 
 
+def has_active_dock_work(state: NarwalState | None) -> bool:
+    """Return True when station work makes robot commands ambiguous."""
+    if state is None:
+        return False
+    return (
+        state.is_station_active
+        or state.has_unmapped_active_dock_task
+        or bool(state.active_dock_task_keys)
+    )
+
+
 def can_start_dock_task(state: NarwalState | None, task_key: str | None = None) -> bool:
     """Return True when a dock task can be started safely."""
     if has_blocking_error(state):

--- a/custom_components/narwal/dock_tasks.py
+++ b/custom_components/narwal/dock_tasks.py
@@ -1,0 +1,167 @@
+"""Narwal dock task definitions and command gates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .narwal_client.const import ACTIVE_CLEANING_STATUSES, WorkingStatus
+from .narwal_client.models import (
+    DOCK_TASK_DRY_DOCK_BAG,
+    DOCK_TASK_DRY_DUST_BIN,
+    DOCK_TASK_DRY_MOP,
+    DOCK_TASK_EMPTY_DUSTBIN,
+    DOCK_TASK_WASH_MOP,
+    NarwalState,
+)
+
+
+@dataclass(frozen=True)
+class DockTaskDefinition:
+    """Description of one supported dock task."""
+
+    key: str
+    translation_key: str
+    action: str
+    icon: str
+
+
+DOCK_TASKS: tuple[DockTaskDefinition, ...] = (
+    DockTaskDefinition(
+        key=DOCK_TASK_EMPTY_DUSTBIN,
+        translation_key=DOCK_TASK_EMPTY_DUSTBIN,
+        action="empty_dustbin",
+        icon="mdi:delete-empty",
+    ),
+    DockTaskDefinition(
+        key=DOCK_TASK_WASH_MOP,
+        translation_key=DOCK_TASK_WASH_MOP,
+        action="wash_mop_by_robot_status",
+        icon="mdi:waves-arrow-up",
+    ),
+    DockTaskDefinition(
+        key=DOCK_TASK_DRY_MOP,
+        translation_key=DOCK_TASK_DRY_MOP,
+        action="dry_mop",
+        icon="mdi:fan",
+    ),
+    DockTaskDefinition(
+        key=DOCK_TASK_DRY_DUST_BIN,
+        translation_key=DOCK_TASK_DRY_DUST_BIN,
+        action="dry_dust_bag",
+        icon="mdi:air-filter",
+    ),
+    DockTaskDefinition(
+        key=DOCK_TASK_DRY_DOCK_BAG,
+        translation_key=DOCK_TASK_DRY_DOCK_BAG,
+        action="dry_station_bag",
+        icon="mdi:shield-sun-outline",
+    ),
+)
+
+GENERIC_STOP_DOCK_TASKS = frozenset(
+    {
+        DOCK_TASK_EMPTY_DUSTBIN,
+        DOCK_TASK_WASH_MOP,
+        DOCK_TASK_DRY_MOP,
+    }
+)
+SCOPED_STOP_DOCK_TASKS = frozenset({DOCK_TASK_DRY_DOCK_BAG, DOCK_TASK_DRY_DUST_BIN})
+STOPPABLE_DOCK_TASKS = GENERIC_STOP_DOCK_TASKS | SCOPED_STOP_DOCK_TASKS
+
+
+def has_blocking_error(state: NarwalState | None) -> bool:
+    """Return True when the robot reports a fault that should block commands."""
+    return state is None or state.working_status == WorkingStatus.ERROR or state.has_error
+
+
+def is_clean_session_context(state: NarwalState | None) -> bool:
+    """Return True while robot-side clean task context is still current."""
+    if state is None:
+        return False
+    return (
+        state.is_cleaning
+        or state.has_assumed_robot_clean
+        or state.working_status in ACTIVE_CLEANING_STATUSES
+        or state.working_status == WorkingStatus.TASK_COMPLETED
+        or state.has_recent_active_working_status
+        or state.is_returning
+    )
+
+
+def is_robot_work_context(state: NarwalState | None) -> bool:
+    """Return True when generic force-end could affect robot-side work."""
+    if state is None:
+        return False
+    return (
+        state.is_cleaning
+        or state.has_assumed_robot_clean
+        or state.working_status in ACTIVE_CLEANING_STATUSES
+        or state.has_recent_active_working_status
+        or state.is_returning
+    )
+
+
+def can_start_dock_task(state: NarwalState | None, task_key: str | None = None) -> bool:
+    """Return True when a dock task can be started safely."""
+    if has_blocking_error(state):
+        return False
+    if state.working_status == WorkingStatus.UNKNOWN:
+        return False
+    if not state.is_docked or is_clean_session_context(state):
+        return False
+    if state.has_unmapped_active_dock_task:
+        return False
+    if state.assumed_active_dock_task is not None:
+        return False
+    if task_key is None:
+        return not state.active_dock_task_keys
+    active_keys = set(state.active_dock_task_keys)
+    if task_key in active_keys:
+        return False
+    # Default conservative policy: do not expose parallel starts until hardware
+    # testing verifies an exact task combination.
+    return not active_keys
+
+
+def can_start_robot_clean(state: NarwalState | None) -> bool:
+    """Return True when reported state permits sending a new robot clean."""
+    if has_blocking_error(state):
+        return False
+    if state.working_status == WorkingStatus.UNKNOWN:
+        return False
+    if state.has_assumed_robot_clean:
+        return False
+    return not state.blocks_robot_start_for_dock_task
+
+
+def can_stop_dock_task(state: NarwalState | None, task_key: str | None = None) -> bool:
+    """Return True when a dock task can be stopped without ambiguity."""
+    if has_blocking_error(state):
+        return False
+    if state.working_status == WorkingStatus.UNKNOWN:
+        return False
+    active_keys = state.active_dock_task_keys
+    if not active_keys:
+        return False
+    if state.has_unmapped_active_dock_task:
+        return task_key in SCOPED_STOP_DOCK_TASKS and task_key in active_keys
+    if is_robot_work_context(state):
+        return task_key in SCOPED_STOP_DOCK_TASKS and task_key in active_keys
+    active_key_set = set(active_keys)
+    telemetry_key_set = set(state.telemetry_dock_task_keys)
+    if task_key is None:
+        if len(active_key_set) != 1:
+            return False
+        active_key = next(iter(active_key_set))
+        if active_key not in STOPPABLE_DOCK_TASKS:
+            return False
+        if active_key in SCOPED_STOP_DOCK_TASKS:
+            return active_key in telemetry_key_set
+        return state.is_docked and state.has_dock_presence_signal
+    if task_key not in active_key_set or task_key not in STOPPABLE_DOCK_TASKS:
+        return False
+    if task_key in SCOPED_STOP_DOCK_TASKS:
+        return task_key in telemetry_key_set
+    if not (state.is_docked and state.has_dock_presence_signal):
+        return False
+    return active_key_set == {task_key}

--- a/custom_components/narwal/entity.py
+++ b/custom_components/narwal/entity.py
@@ -9,6 +9,31 @@ from .const import DOMAIN, MANUFACTURER, configured_model_name
 from .coordinator import NarwalCoordinator
 
 
+def narwal_robot_device_info(coordinator: NarwalCoordinator) -> DeviceInfo:
+    """Return device info for the robot vacuum."""
+    device_id = coordinator.config_entry.data["device_id"]
+    return DeviceInfo(
+        identifiers={(DOMAIN, device_id)},
+        manufacturer=MANUFACTURER,
+        model=configured_model_name(coordinator.config_entry.data),
+        sw_version=coordinator.client.state.firmware_version or None,
+        name=coordinator.config_entry.title,
+    )
+
+
+def narwal_dock_device_info(coordinator: NarwalCoordinator) -> DeviceInfo:
+    """Return device info for the robot dock/base station."""
+    device_id = coordinator.config_entry.data["device_id"]
+    return DeviceInfo(
+        identifiers={(DOMAIN, f"{device_id}_dock")},
+        manufacturer=MANUFACTURER,
+        model=f"{configured_model_name(coordinator.config_entry.data)} Dock",
+        sw_version=coordinator.client.state.firmware_version or None,
+        name=f"{coordinator.config_entry.title} Dock",
+        via_device=(DOMAIN, device_id),
+    )
+
+
 class NarwalEntity(CoordinatorEntity[NarwalCoordinator]):
     """Base class for Narwal entities."""
 
@@ -17,16 +42,18 @@ class NarwalEntity(CoordinatorEntity[NarwalCoordinator]):
     def __init__(self, coordinator: NarwalCoordinator) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
-        device_id = coordinator.config_entry.data["device_id"]
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, device_id)},
-            manufacturer=MANUFACTURER,
-            model=configured_model_name(coordinator.config_entry.data),
-            sw_version=coordinator.client.state.firmware_version or None,
-            name=coordinator.config_entry.title,
-        )
+        self._attr_device_info = narwal_robot_device_info(coordinator)
 
     @property
     def available(self) -> bool:
         """Return True if the entity is available."""
         return self.coordinator.last_update_success
+
+
+class NarwalDockEntity(NarwalEntity):
+    """Base class for Narwal dock/base-station entities."""
+
+    def __init__(self, coordinator: NarwalCoordinator) -> None:
+        """Initialize the dock entity."""
+        super().__init__(coordinator)
+        self._attr_device_info = narwal_dock_device_info(coordinator)

--- a/custom_components/narwal/light.py
+++ b/custom_components/narwal/light.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import NarwalConfigEntry
 from .const import DOCK_LIGHT_MODE_NAMES, DOCK_LIGHT_MODES, is_dock_light_supported
 from .coordinator import NarwalCoordinator
-from .entity import NarwalEntity
+from .entity import NarwalDockEntity
 from .narwal_client import CommandResult
 
 _EFFECTS = tuple(mode for mode in DOCK_LIGHT_MODES if mode != "Off")
@@ -35,7 +35,7 @@ async def async_setup_entry(
     async_add_entities([NarwalDockLight(entry.runtime_data)])
 
 
-class NarwalDockLight(NarwalEntity, LightEntity):
+class NarwalDockLight(NarwalDockEntity, LightEntity):
     """Narwal dock ambient light with app effects."""
 
     _attr_translation_key = "dock_light"
@@ -100,7 +100,7 @@ class NarwalDockLight(NarwalEntity, LightEntity):
         response = await client.set_ambient_light_mode(DOCK_LIGHT_MODES[mode])
         if response is None:
             raise HomeAssistantError("Narwal dock light command failed")
-        if response.result_code not in (0, CommandResult.SUCCESS, CommandResult.APPLIED):
+        if not response.accepted:
             try:
                 result_name = CommandResult(response.result_code).name
             except ValueError:

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import random
 import time
@@ -13,6 +14,7 @@ import websockets
 import websockets.exceptions
 
 from .const import (
+    ACTIVE_CLEANING_STATUSES,
     BROADCAST_STALE_TIMEOUT,
     COMMAND_RESPONSE_TIMEOUT,
     DEFAULT_PORT,
@@ -28,7 +30,9 @@ from .const import (
     TOPIC_CMD_APP_HEARTBEAT,
     TOPIC_CMD_CANCEL,
     TOPIC_CMD_CLEAN_TASK,
+    TOPIC_CMD_DRY_DUST_BAG,
     TOPIC_CMD_DRY_MOP,
+    TOPIC_CMD_DRY_STATION_BAG,
     TOPIC_CMD_DUST_GATHERING,
     TOPIC_CMD_EASY_CLEAN,
     TOPIC_CMD_FORCE_END,
@@ -50,6 +54,7 @@ from .const import (
     TOPIC_CMD_SET_MOP_HUMIDITY,
     TOPIC_CMD_TAKE_PICTURE,
     TOPIC_CMD_WASH_MOP,
+    TOPIC_CMD_WASH_MOP_BY_ROBOT_STATUS,
     TOPIC_CMD_YELL,
     WAKE_TIMEOUT,
     AmbientLightCtrlType,
@@ -60,7 +65,18 @@ from .const import (
     WorkingStatus,
     WorkMode,
 )
-from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState
+from .models import (
+    DOCK_TASK_DRY_DOCK_BAG,
+    DOCK_TASK_DRY_DUST_BIN,
+    DOCK_TASK_DRY_MOP,
+    DOCK_TASK_EMPTY_DUSTBIN,
+    DOCK_TASK_WASH_MOP,
+    CommandResponse,
+    DeviceInfo,
+    MapData,
+    MapDisplayData,
+    NarwalState,
+)
 from .protocol import (
     PROTOBUF_FIELD5_TAG,
     NarwalMessage,
@@ -78,6 +94,61 @@ _STALE_DOCK_BASE_STATUSES = {
     WorkingStatus.CHARGED,
     WorkingStatus.DOCKED_V2,
 }
+
+_DOCK_TASK_REFRESH_DELAY = 6.0
+_DOCK_TASK_IDENTIFY_ATTEMPTS = 4
+_DOCK_TASK_IDENTIFY_DELAY = 1.5
+_DOCK_TASK_FORCE_END_PAYLOADS = {
+    # Live-validated on Flow 2: the app's ForceEndTask.Request uses field 1
+    # with ParallelTaskType.DRY_STATION_BAG to stop dock-bag drying.
+    DOCK_TASK_DRY_DOCK_BAG: b"\x08\x01",
+    # Live-validated on Flow 2: the app's ForceEndTask.Request uses field 1
+    # with ParallelTaskType.DRY_BAG to stop robot dust-bin drying.
+    DOCK_TASK_DRY_DUST_BIN: b"\x08\x05",
+}
+
+
+def _accepted_response(response: CommandResponse) -> bool:
+    """Return true for response codes that mean the robot accepted a command."""
+    return response.accepted
+
+
+def _clean_session_context(state: NarwalState) -> bool:
+    """Return true while robot-side work or its accepted-command guard is active."""
+    return (
+        state.is_cleaning
+        or state.has_assumed_robot_clean
+        or state.working_status in ACTIVE_CLEANING_STATUSES
+        or state.working_status == WorkingStatus.TASK_COMPLETED
+        or state.has_recent_active_working_status
+        or state.is_returning
+    )
+
+
+def _robot_work_blocks_generic_dock_stop(state: NarwalState) -> bool:
+    """Return true when generic force-end could target robot work, not dock work."""
+    return (
+        state.is_cleaning
+        or state.has_assumed_robot_clean
+        or state.working_status in ACTIVE_CLEANING_STATUSES
+        or state.has_recent_active_working_status
+        or state.is_returning
+    )
+
+
+def _robot_start_blocked(state: NarwalState) -> bool:
+    """Return true when a private guard or dock task blocks a start."""
+    return state.has_assumed_robot_clean or state.blocks_robot_start_for_dock_task
+
+
+def _can_force_end_scoped_dock_task(state: NarwalState, task: str | None) -> bool:
+    """Return true when a typed force-end can safely target a known task."""
+    return task in _DOCK_TASK_FORCE_END_PAYLOADS and task in state.telemetry_dock_task_keys
+
+
+def _has_generic_dock_stop_proof(state: NarwalState) -> bool:
+    """Return true when generic force-end can only target dock-side work."""
+    return state.is_docked and state.has_dock_presence_signal
 
 
 def _base_status_working_status(decoded: dict[str, Any] | object) -> WorkingStatus | None:
@@ -119,6 +190,49 @@ def _base_status_confirms_docked(
         or int_field(field3, "3") in (1, 6)
         or int_field(field3, "10") == 1
         or int_field(field3, "12") > 0
+    )
+
+
+def _base_status_payload(response: CommandResponse) -> dict[str, Any] | None:
+    """Return the decoded robot_base_status payload from a command response."""
+    if not isinstance(response.data, dict):
+        return None
+    status_data = response.data.get("2")
+    if isinstance(status_data, dict) and status_data:
+        return status_data
+    return None
+
+
+def _has_dock_status_payload(response: CommandResponse) -> bool:
+    """Return true when a response carries the dock/base status submessage."""
+    if not response.accepted:
+        return False
+    status_data = _base_status_payload(response)
+    if status_data is None:
+        return False
+    field3 = status_data.get("3")
+    if isinstance(field3, list):
+        field3 = field3[0] if field3 else None
+    if not isinstance(field3, dict):
+        return False
+    return bool({"1", "2", "3", "7", "10", "12", "18"}.intersection(field3))
+
+
+def _dock_status_confirms_idle(state: NarwalState) -> bool:
+    """Return true when fresh dock status reports no active station task."""
+    return (
+        state.station_activity <= 0
+        and state.dock_activity in (0, 2, 6)
+        and state.has_dock_presence_signal
+        and state.working_status
+        in (
+            WorkingStatus.UNKNOWN,
+            WorkingStatus.STANDBY,
+            WorkingStatus.DOCKED,
+            WorkingStatus.CHARGED,
+            WorkingStatus.DOCKED_V2,
+            WorkingStatus.TASK_COMPLETED,
+        )
     )
 
 
@@ -175,6 +289,12 @@ class NarwalClient:
         self._response_queue: asyncio.Queue[NarwalMessage] = asyncio.Queue()
         # Lock to prevent concurrent send_command calls from racing on the queue
         self._command_lock = asyncio.Lock()
+        # Lock high-level action preflight through accepted-command reservation.
+        # The lower command lock only serializes wire traffic; this prevents
+        # direct robot and dock commands from validating the same idle snapshot.
+        self._action_lock = asyncio.Lock()
+        self._dock_task_lock = self._action_lock
+        self._robot_start_lock = self._action_lock
 
     def _full_topic(self, short_topic: str) -> str:
         """Build the full topic path."""
@@ -316,7 +436,7 @@ class NarwalClient:
                 data = await asyncio.wait_for(
                     self._ws.recv(), timeout=min(remaining, 2.0)
                 )
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 # Re-send wake commands, cycling through prefixes
                 try:
                     await self._ws.send(wake_frames[wake_index % len(wake_frames)])
@@ -397,7 +517,7 @@ class NarwalClient:
             try:
                 await asyncio.wait_for(self._ws.recv(), timeout=0.05)
                 drained += 1
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 break
             except Exception:
                 break
@@ -414,10 +534,8 @@ class NarwalClient:
         for task in (self._heartbeat_task, self._keepalive_task, self._listen_task):
             if task and not task.done():
                 task.cancel()
-                try:
+                with contextlib.suppress(asyncio.CancelledError):
                     await task
-                except asyncio.CancelledError:
-                    pass
 
         if self._ws:
             await self._ws.close()
@@ -955,7 +1073,7 @@ class NarwalClient:
                     msg = await asyncio.wait_for(
                         self._response_queue.get(), timeout=timeout
                     )
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     raise NarwalCommandError(
                         f"No response for command '{short_topic}' within {timeout}s"
                     ) from None
@@ -1001,7 +1119,7 @@ class NarwalClient:
                 data = await asyncio.wait_for(
                     self._ws.recv(), timeout=min(remaining, 1.0)
                 )
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 continue
 
             if not isinstance(data, bytes) or len(data) < 4:
@@ -1098,6 +1216,12 @@ class NarwalClient:
             "start(): no map rooms available; falling back to clean/plan/start, "
             "which re-runs the robot's saved plan rather than cleaning every room"
         )
+        if self.state.blocks_robot_start_for_dock_task:
+            _LOGGER.warning(
+                "start(): dock task active (%s); not starting saved plan",
+                self.state.active_dock_task_keys or "unmapped",
+            )
+            return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
         return await self.send_command(
             TOPIC_CMD_PLAN_START,
             payload=self._DEFAULT_CLEAN_PAYLOAD,
@@ -1125,6 +1249,12 @@ class NarwalClient:
         plan-runner that discards payloads (#66), so it survives only as a
         last-resort fallback when no map rooms are known.
         """
+        if _robot_start_blocked(self.state):
+            _LOGGER.warning(
+                "start: robot or dock task active (%s); not starting whole-house clean",
+                self.state.active_dock_task_keys or "unmapped",
+            )
+            return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
         room_ids = await self._all_room_ids()
         if not room_ids:
             return await self._start_saved_plan()
@@ -1349,44 +1479,63 @@ class NarwalClient:
             # No rooms selected — do not call start(), which would resolve the
             # full room list and come straight back here.
             return await self._start_saved_plan()
-
-        map_data = self.state.map_data
-        if not map_data or not map_data.map_id:
-            map_data = await self.get_map()
-        map_id = map_data.map_id if map_data else 0
-        if not map_id:
-            _LOGGER.warning(
-                "start_rooms: no active map id available; cannot start room clean"
-            )
-            return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
-
-        payload = self._build_start_clean_payload(
-            room_ids, map_id, work_mode=work_mode, fan=fan, water=water,
-            mop_strength=mop_strength, passes=passes,
-        )
-        resp = await self.send_command(
-            TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
-        )
-        for _ in range(3):
-            if resp.result_code != CommandResult.NOT_READY:
-                break
-            if not self.state.is_docked:
+        async with self._robot_start_lock:
+            if _robot_start_blocked(self.state):
                 _LOGGER.warning(
-                    "start_rooms: robot not docked (status=%s); clean/start_clean "
-                    "requires the robot on the dock",
-                    self.state.working_status.name,
+                    "start_rooms: robot or dock guard active (%s); not starting room clean",
+                    self.state.active_dock_task_keys or "private",
                 )
-                break
-            _LOGGER.info("start_rooms: robot docking/settling, retrying clean/start_clean")
-            await asyncio.sleep(3.0)
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+
+            map_data = self.state.map_data
+            if not map_data or not map_data.map_id:
+                map_data = await self.get_map()
+            map_id = map_data.map_id if map_data else 0
+            if not map_id:
+                _LOGGER.warning(
+                    "start_rooms: no active map id available; cannot start room clean"
+                )
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+
+            payload = self._build_start_clean_payload(
+                room_ids, map_id, work_mode=work_mode, fan=fan, water=water,
+                mop_strength=mop_strength, passes=passes,
+            )
             resp = await self.send_command(
                 TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
             )
-        return resp
+            for _ in range(3):
+                if resp.result_code != CommandResult.NOT_READY:
+                    break
+                if not self.state.is_docked:
+                    _LOGGER.warning(
+                        "start_rooms: robot not docked (status=%s); clean/start_clean "
+                        "requires the robot on the dock",
+                        self.state.working_status.name,
+                    )
+                    break
+                _LOGGER.info("start_rooms: robot docking/settling, retrying clean/start_clean")
+                await asyncio.sleep(3.0)
+                resp = await self.send_command(
+                    TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
+                )
+            if _accepted_response(resp):
+                self.state.assume_robot_clean()
+            return resp
 
     async def start_easy_clean(self) -> CommandResponse:
         """Start quick/easy clean."""
-        return await self.send_command(TOPIC_CMD_EASY_CLEAN)
+        async with self._robot_start_lock:
+            if _robot_start_blocked(self.state):
+                _LOGGER.warning(
+                    "start_easy_clean: robot or dock guard active (%s); not starting quick clean",
+                    self.state.active_dock_task_keys or "private",
+                )
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            response = await self.send_command(TOPIC_CMD_EASY_CLEAN)
+            if _accepted_response(response):
+                self.state.assume_robot_clean()
+            return response
 
     async def pause(self) -> CommandResponse:
         """Pause current task."""
@@ -1407,6 +1556,117 @@ class NarwalClient:
     async def cancel(self) -> CommandResponse:
         """Cancel current task."""
         return await self.send_command(TOPIC_CMD_CANCEL)
+
+    async def _refresh_after_dock_stop(self) -> bool:
+        """Refresh robot state after a dock stop command."""
+        try:
+            response = await self.get_status(
+                full_update=not self.state.has_recent_active_working_status
+            )
+        except (NarwalCommandError, NarwalConnectionError) as err:
+            _LOGGER.debug("Status refresh after dock stop failed: %s", err)
+            return False
+        return _has_dock_status_payload(response)
+
+    def _should_wait_for_scoped_dock_task(self, task: str | None) -> bool:
+        """Return true when a typed scoped-stop target may still be settling."""
+        if task not in _DOCK_TASK_FORCE_END_PAYLOADS:
+            return False
+        if task in self.state.telemetry_dock_task_keys:
+            return False
+        if task == self.state.assumed_active_dock_task:
+            return True
+        if self.state.has_unmapped_active_dock_task:
+            return True
+        if task == DOCK_TASK_DRY_DUST_BIN and self.state.dock_activity == 6:
+            return True
+        return self.state.station_activity == 4 and not self.state.active_dock_drying_tasks
+
+    async def _refresh_before_dock_stop(
+        self,
+        task: str | None,
+    ) -> CommandResponse:
+        """Refresh dock state, allowing typed scoped-stop telemetry to settle."""
+        response = await self.get_status(
+            full_update=not self.state.has_recent_active_working_status
+        )
+        if not response.accepted or not _has_dock_status_payload(response):
+            return response
+        if not self._should_wait_for_scoped_dock_task(task):
+            return response
+
+        for _ in range(_DOCK_TASK_IDENTIFY_ATTEMPTS):
+            await asyncio.sleep(_DOCK_TASK_IDENTIFY_DELAY)
+            response = await self.get_status(
+                full_update=not self.state.has_recent_active_working_status
+            )
+            if not response.accepted or not _has_dock_status_payload(response):
+                return response
+            if not self._should_wait_for_scoped_dock_task(task):
+                return response
+        return response
+
+    async def stop_dock_task(self, task: str | None = None) -> CommandResponse:
+        """Stop the active dock task without targeting a different task."""
+        async with self._dock_task_lock:
+            if (
+                self.state.has_unmapped_active_dock_task
+                and task not in _DOCK_TASK_FORCE_END_PAYLOADS
+                and not _can_force_end_scoped_dock_task(self.state, task)
+            ):
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            refresh = await self._refresh_before_dock_stop(task)
+            if not refresh.accepted:
+                return refresh
+            if not _has_dock_status_payload(refresh):
+                return CommandResponse(
+                    result_code=CommandResult.NOT_READY,
+                    data=refresh.data,
+                    raw_payload=refresh.raw_payload,
+                )
+            if self.state.has_unmapped_active_dock_task and not (
+                _can_force_end_scoped_dock_task(self.state, task)
+            ):
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            active_tasks = self.state.active_dock_task_keys
+            if task is not None and task not in active_tasks:
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            if task is None and len(active_tasks) != 1:
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            active_task = task or (active_tasks[0] if active_tasks else None)
+            if active_task is None:
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            if (
+                _robot_work_blocks_generic_dock_stop(self.state)
+                and active_task not in _DOCK_TASK_FORCE_END_PAYLOADS
+            ):
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+
+            payload = _DOCK_TASK_FORCE_END_PAYLOADS.get(active_task)
+            if payload is None:
+                if active_task == DOCK_TASK_DRY_DUST_BIN:
+                    return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+                if not _has_generic_dock_stop_proof(self.state):
+                    return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+                if len(active_tasks) > 1:
+                    return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+                response = await self.stop(timeout=15.0)
+            else:
+                if active_task not in self.state.telemetry_dock_task_keys:
+                    return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+                response = await self.send_command(
+                    TOPIC_CMD_FORCE_END,
+                    payload=payload,
+                    timeout=15.0,
+                )
+
+            await asyncio.sleep(_DOCK_TASK_REFRESH_DELAY)
+            refreshed = await self._refresh_after_dock_stop()
+            if _accepted_response(response):
+                self.state.clear_assumed_dock_task(active_task)
+                if refreshed and _dock_status_confirms_idle(self.state):
+                    self.state.clear_dock_drying_task(active_task)
+            return response
 
     async def return_to_base(self, timeout: float = COMMAND_RESPONSE_TIMEOUT) -> CommandResponse:
         """Return to charging dock."""
@@ -1434,15 +1694,81 @@ class NarwalClient:
 
     async def wash_mop(self) -> CommandResponse:
         """Wash the mop pads at the station."""
-        return await self.send_command(TOPIC_CMD_WASH_MOP)
+        return await self._start_dock_task(DOCK_TASK_WASH_MOP, TOPIC_CMD_WASH_MOP)
+
+    async def wash_mop_by_robot_status(self) -> CommandResponse:
+        """Wash mop pads using the app's status-gated station command."""
+        return await self._start_dock_task(
+            DOCK_TASK_WASH_MOP,
+            TOPIC_CMD_WASH_MOP_BY_ROBOT_STATUS,
+        )
 
     async def dry_mop(self) -> CommandResponse:
         """Dry the mop pads at the station."""
-        return await self.send_command(TOPIC_CMD_DRY_MOP)
+        return await self._start_dock_task(DOCK_TASK_DRY_MOP, TOPIC_CMD_DRY_MOP)
+
+    async def dry_dust_bag(self) -> CommandResponse:
+        """Dry or disinfect the robot dust bin at the station."""
+        return await self._start_dock_task(
+            DOCK_TASK_DRY_DUST_BIN,
+            TOPIC_CMD_DRY_DUST_BAG,
+        )
+
+    async def dry_station_bag(self) -> CommandResponse:
+        """Dry or disinfect the dock dust bag at the station."""
+        return await self._start_dock_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            TOPIC_CMD_DRY_STATION_BAG,
+        )
 
     async def empty_dustbin(self) -> CommandResponse:
         """Empty the dustbin at the station."""
-        return await self.send_command(TOPIC_CMD_DUST_GATHERING)
+        return await self._start_dock_task(
+            DOCK_TASK_EMPTY_DUSTBIN,
+            TOPIC_CMD_DUST_GATHERING,
+        )
+
+    async def _start_dock_task(self, task: str, topic: str) -> CommandResponse:
+        """Start one dock task after atomically validating reported state."""
+        async with self._dock_task_lock:
+            if not self._can_start_dock_task(task):
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            refresh = await self.get_status(
+                full_update=not self.state.has_recent_active_working_status
+            )
+            if not refresh.accepted:
+                return refresh
+            if not _has_dock_status_payload(refresh):
+                return CommandResponse(
+                    result_code=CommandResult.NOT_READY,
+                    data=refresh.data,
+                    raw_payload=refresh.raw_payload,
+                )
+            if not self._can_start_dock_task(task):
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            response = await self.send_command(topic)
+            if _accepted_response(response):
+                self.state.assume_dock_task(task)
+            return response
+
+    def _can_start_dock_task(self, task: str) -> bool:
+        """Return true when reported state permits a new dock-side command."""
+        state = self.state
+        if state.has_error or state.working_status in (
+            WorkingStatus.ERROR,
+            WorkingStatus.UNKNOWN,
+        ):
+            return False
+        if not state.is_docked or _clean_session_context(state):
+            return False
+        if state.has_unmapped_active_dock_task:
+            return False
+        if state.assumed_active_dock_task is not None:
+            return False
+        active_tasks = set(state.active_dock_task_keys)
+        if task in active_tasks:
+            return False
+        return not active_tasks
 
     # --- Query commands ---
 
@@ -1489,8 +1815,8 @@ class NarwalClient:
                 working_status in the response may be stale.
         """
         resp = await self.send_command(TOPIC_CMD_GET_BASE_STATUS)
-        status_data = resp.data.get("2", {})
-        if status_data:
+        status_data = _base_status_payload(resp)
+        if status_data is not None:
             # Log the whole field map, not a chosen few: field-level bug reports
             # (wrong tank state, a value we don't map) are unanswerable from a log
             # that omits the field in question — see #77.
@@ -1507,6 +1833,12 @@ class NarwalClient:
                 self.state.update_battery_from_base_status(status_data)
         else:
             _LOGGER.debug("get_status response has no field 2; keys: %s", list(resp.data.keys()))
+            if resp.accepted:
+                return CommandResponse(
+                    result_code=CommandResult.NOT_READY,
+                    data=resp.data,
+                    raw_payload=resp.raw_payload,
+                )
         return resp
 
     async def get_current_task(self) -> CommandResponse:

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -1668,7 +1668,12 @@ class NarwalClient:
             refreshed = await self._refresh_after_dock_stop()
             if _accepted_response(response):
                 self.state.clear_assumed_dock_task(active_task)
-                if refreshed and _dock_status_confirms_idle(self.state):
+                # Scoped force-end acknowledges the exact drying task. Clear its
+                # cached timer after a fresh dock response instead of waiting for
+                # the old timer snapshot to expire.
+                if refreshed and (
+                    payload is not None or _dock_status_confirms_idle(self.state)
+                ):
                     self.state.clear_dock_drying_task(active_task)
             return response
 

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -1216,17 +1216,21 @@ class NarwalClient:
             "start(): no map rooms available; falling back to clean/plan/start, "
             "which re-runs the robot's saved plan rather than cleaning every room"
         )
-        if self.state.blocks_robot_start_for_dock_task:
-            _LOGGER.warning(
-                "start(): dock task active (%s); not starting saved plan",
-                self.state.active_dock_task_keys or "unmapped",
+        async with self._robot_start_lock:
+            if _robot_start_blocked(self.state):
+                _LOGGER.warning(
+                    "start(): robot or dock guard active (%s); not starting saved plan",
+                    self.state.active_dock_task_keys or "private",
+                )
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            response = await self.send_command(
+                TOPIC_CMD_PLAN_START,
+                payload=self._DEFAULT_CLEAN_PAYLOAD,
+                timeout=10.0,
             )
-            return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
-        return await self.send_command(
-            TOPIC_CMD_PLAN_START,
-            payload=self._DEFAULT_CLEAN_PAYLOAD,
-            timeout=10.0,
-        )
+            if _accepted_response(response):
+                self.state.assume_robot_clean()
+            return response
 
     async def start(
         self,

--- a/custom_components/narwal/narwal_client/const.py
+++ b/custom_components/narwal/narwal_client/const.py
@@ -86,7 +86,10 @@ TOPIC_CMD_CANCEL = "task/cancel"
 TOPIC_CMD_AMBIENT_LIGHT_CTRL = "supply/ambient_light_ctrl"
 TOPIC_CMD_RECALL = "supply/recall"
 TOPIC_CMD_WASH_MOP = "supply/wash_mop"
+TOPIC_CMD_WASH_MOP_BY_ROBOT_STATUS = "supply/wash_mop_by_robot_status"
 TOPIC_CMD_DRY_MOP = "supply/dry_mop"
+TOPIC_CMD_DRY_DUST_BAG = "supply/dry_dust_bag"
+TOPIC_CMD_DRY_STATION_BAG = "supply/dry_station_bag"
 TOPIC_CMD_DUST_GATHERING = "supply/dust_gathering"
 
 # Cleaning (Pita protocol — correct for AX12)

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import struct
 import time
 from dataclasses import dataclass, field
 from typing import Any, ClassVar
+
+from .const import (
+    ACTIVE_CLEANING_STATUSES,
+    CommandResult,
+    WorkingStatus,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -15,15 +22,39 @@ _LOGGER = logging.getLogger(__name__)
 # identical lines (#46). Warn once per distinct value instead.
 _WARNED_WORKING_STATUS: set[Any] = set()
 
-from .const import (
-    ACTIVE_CLEANING_STATUSES,
-    CommandResult,
-    FanLevel,
-    MopHumidity,
-    WorkingStatus,
-)
-
 _ACTIVE_WORKING_STATUS_TTL = 15.0
+_DOCK_DRYING_STATUS_TTL = 180.0
+_DOCK_TASK_ASSUME_TTL = 30.0
+_ROBOT_START_ASSUME_TTL = 30.0
+_KNOWN_DOCK_ACTIVITY_VALUES = {0, 2, 3, 4, 6}
+
+DOCK_TASK_EMPTY_DUSTBIN = "empty_dustbin"
+DOCK_TASK_WASH_MOP = "wash_mop"
+DOCK_TASK_DRY_MOP = "dry_mop"
+DOCK_TASK_DRY_DUST_BIN = "dry_dust_bin"
+DOCK_TASK_DRY_DOCK_BAG = "dry_dock_bag"
+
+DOCK_TASK_KEYS = (
+    DOCK_TASK_EMPTY_DUSTBIN,
+    DOCK_TASK_WASH_MOP,
+    DOCK_TASK_DRY_MOP,
+    DOCK_TASK_DRY_DUST_BIN,
+    DOCK_TASK_DRY_DOCK_BAG,
+)
+_DOCK_DRYING_TASK_ORDER = (
+    DOCK_TASK_DRY_MOP,
+    DOCK_TASK_DRY_DUST_BIN,
+    DOCK_TASK_DRY_DOCK_BAG,
+)
+_DOCK_DRYING_TIMER_PAIRS: tuple[tuple[str, str, str], ...] = (
+    (DOCK_TASK_DRY_MOP, "8", "9"),
+    (DOCK_TASK_DRY_DUST_BIN, "10", "11"),
+    (DOCK_TASK_DRY_DOCK_BAG, "12", "13"),
+)
+_UNMAPPED_DOCK_DRYING_TIMER_PAIRS: tuple[tuple[str, str], ...] = (
+    ("14", "15"),
+    ("16", "17"),
+)
 
 
 @dataclass
@@ -33,6 +64,34 @@ class DeviceInfo:
     product_key: str = ""
     device_id: str = ""
     firmware_version: str = ""
+
+
+@dataclass(frozen=True)
+class DockTaskTimer:
+    """Timer details for one active dock task."""
+
+    task: str
+    elapsed: int
+    target: int
+    fields: tuple[str, str]
+    observed_at: float = field(default_factory=time.monotonic)
+
+    @property
+    def current_elapsed(self) -> int:
+        """Return the elapsed seconds reported by the latest timer snapshot."""
+        return min(self.target, max(0, self.elapsed))
+
+    @property
+    def remaining(self) -> int:
+        """Return remaining seconds, clamped at zero."""
+        return max(0, self.target - self.current_elapsed)
+
+    @property
+    def progress_percent(self) -> int:
+        """Return elapsed task progress as an integer percentage."""
+        if self.target <= 0:
+            return 0
+        return min(100, round(self.current_elapsed / self.target * 100))
 
 
 @dataclass
@@ -53,7 +112,10 @@ class RoomInfo:
     category: int = 0  # 1=room, 2=utility (field 4)
     instance_index: int = 0  # numbering for duplicates (field 8)
 
-    # RoomType enum (MapBaseType.RoomType, 0-15) → the app's own en-US.json room-name strings. One shared switch (map_engine_i18n_configer.roomTypei18nKey) takes no model parameter, so every model resolves these same names. See #22.
+    # RoomType enum (MapBaseType.RoomType, 0-15) to the app's own en-US.json
+    # room-name strings. One shared switch
+    # (map_engine_i18n_configer.roomTypei18nKey) takes no model parameter, so
+    # every model resolves these same names. See #22.
     ROOM_TYPE_NAMES: ClassVar[dict[int, str]] = {
         0: "Room",
         1: "Master bedroom",
@@ -75,7 +137,7 @@ class RoomInfo:
 
     @property
     def display_name(self) -> str:
-        """User name if set, else the RoomType default name, with an instance-number suffix for duplicates ("Bathroom 2")."""
+        """User name, or default RoomType name with suffix for duplicates."""
         if self.name:
             return self.name
         base = self.ROOM_TYPE_NAMES.get(self.room_sub_type, "Room")
@@ -181,6 +243,59 @@ def _to_float32(val: Any) -> float | None:
         except struct.error:
             return None
     return None
+
+
+def _optional_int(value: Any) -> int | None:
+    """Coerce a protobuf scalar to int when possible."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _dock_drying_timers(decoded: dict[str, Any]) -> dict[str, DockTaskTimer]:
+    """Return active dock drying timers from a working-status packet."""
+    timers: dict[str, DockTaskTimer] = {}
+    for task, elapsed_field, target_field in _DOCK_DRYING_TIMER_PAIRS:
+        elapsed = _optional_int(decoded.get(elapsed_field))
+        target = _optional_int(decoded.get(target_field))
+        if elapsed is None or target is None:
+            continue
+        if target <= 0 or elapsed < 0 or elapsed > target:
+            continue
+        if elapsed > 0:
+            timers[task] = DockTaskTimer(
+                task,
+                elapsed,
+                target,
+                (elapsed_field, target_field),
+            )
+    return timers
+
+
+def _has_dock_drying_timer_fields(decoded: dict[str, Any]) -> bool:
+    """Return true when a packet contains any dock timer field."""
+    return any(
+        _optional_int(decoded.get(elapsed_field)) is not None
+        or _optional_int(decoded.get(target_field)) is not None
+        for _, elapsed_field, target_field in _DOCK_DRYING_TIMER_PAIRS
+    ) or any(
+        _optional_int(decoded.get(elapsed_field)) is not None
+        or _optional_int(decoded.get(target_field)) is not None
+        for elapsed_field, target_field in _UNMAPPED_DOCK_DRYING_TIMER_PAIRS
+    )
+
+
+def _has_unmapped_dock_drying_timer(decoded: dict[str, Any]) -> bool:
+    """Return true when an unmapped dock timer pair reports active work."""
+    for elapsed_field, target_field in _UNMAPPED_DOCK_DRYING_TIMER_PAIRS:
+        elapsed = _optional_int(decoded.get(elapsed_field))
+        target = _optional_int(decoded.get(target_field))
+        if elapsed is None or target is None:
+            continue
+        if 0 < elapsed < target:
+            return True
+    return False
 
 
 def _packed_varints(raw: bytes) -> list[int]:
@@ -331,14 +446,10 @@ class MapData:
         origin_y = 0
         field6 = payload.get("6")
         if isinstance(field6, dict):
-            try:
+            with contextlib.suppress(ValueError, TypeError):
                 origin_x = int(field6.get("3", 0))
-            except (ValueError, TypeError):
-                pass
-            try:
+            with contextlib.suppress(ValueError, TypeError):
                 origin_y = int(field6.get("1", 0))
-            except (ValueError, TypeError):
-                pass
 
         # Parse dock position from field 8 (dock/charging station location).
         # Field 8 structure: {1: {1: x_dm, 2: y_dm}, 2: heading_rad}
@@ -474,10 +585,8 @@ class MapDisplayData:
 
         # Timestamp — field 10 (milliseconds since epoch)
         if "10" in decoded:
-            try:
+            with contextlib.suppress(ValueError, TypeError):
                 result.timestamp = int(decoded["10"])
-            except (ValueError, TypeError):
-                pass
 
         return result
 
@@ -502,6 +611,11 @@ class CommandResponse:
     @property
     def success(self) -> bool:
         return self.result_code == CommandResult.SUCCESS
+
+    @property
+    def accepted(self) -> bool:
+        """Return true when Narwal accepted or applied the command."""
+        return self.result_code in (0, CommandResult.SUCCESS, CommandResult.APPLIED)
 
     @property
     def not_applicable(self) -> bool:
@@ -580,6 +694,19 @@ class NarwalState:
     # Dock activity (field 3 sub-field 12: 2/6 observed when docked)
     dock_activity: int = 0
 
+    # Station activity (field 3 sub-field 18).
+    # Observed: 1 during dust gathering, 4 during dock dry/disinfection work.
+    station_activity: int = 0
+
+    # Dock task timers from working_status fields 8..13.
+    dock_drying_tasks: dict[str, DockTaskTimer] = field(default_factory=dict)
+    dock_drying_status_time: float = 0.0
+    has_dock_drying_timer_snapshot: bool = False
+    has_unmapped_dock_drying_timer: bool = False
+    assumed_dock_task: str = ""
+    assumed_dock_task_until: float = 0.0
+    assumed_robot_clean_until: float = 0.0
+
     # Dock presence (field 3 sub-field 3)
     # Values observed: 1=on dock, 2=off dock, 6=on dock (charged idle)
     dock_presence: int = 0
@@ -639,11 +766,27 @@ class NarwalState:
         )
 
     @property
+    def has_explicit_off_dock_signal(self) -> bool:
+        """True when dock telemetry explicitly says the robot is not seated."""
+        if (
+            self.dock_sub_state == 1
+            or self.dock_field11 >= 2
+            or self.dock_field47 in (1, 3)
+        ):
+            return False
+        return (
+            self.dock_presence == 2
+            or self.dock_sub_state == 2
+            or (self.dock_field11 == 1 and self.dock_field47 == 2)
+        )
+
+    @property
     def is_docked(self) -> bool:
         """True when on dock: DOCKED(10), CHARGED(14), DOCKED_V2(2), or dock field signals.
 
         Dock signals (checked for STANDBY, UNKNOWN, and any unmapped status):
           - dock_sub_state == 1 (field 3.10, old FW only)
+          - dock_presence in (1, 6) (field 3.3, dock-present variants)
           - dock_activity > 0 (field 3.12, old FW only)
           - dock_field11 >= 2 (field 11: old FW 2=docked/1=undocked,
                                v01.07.23 3=docked)
@@ -654,6 +797,8 @@ class NarwalState:
         cleaning is not active, since the robot can report unmapped states
         (e.g. self-test) while physically docked.
         """
+        if self.has_explicit_off_dock_signal:
+            return False
         if self.working_status in (
             WorkingStatus.DOCKED, WorkingStatus.CHARGED, WorkingStatus.DOCKED_V2,
         ):
@@ -668,13 +813,26 @@ class NarwalState:
         #   v01.07.23.00: dock_sub_state absent, dock_field11=3, dock_field47=1
         if self.dock_sub_state == 1:
             return True
+        if self.dock_presence in (1, 6):
+            return True
         if self.dock_activity > 0:
             return True
         if self.dock_field11 >= 2:
             return True
-        if self.dock_field47 in (1, 3):
-            return True
-        return False
+        return self.dock_field47 in (1, 3)
+
+    @property
+    def has_dock_presence_signal(self) -> bool:
+        """True when any field reports the robot is on the dock."""
+        if self.has_explicit_off_dock_signal:
+            return False
+        return (
+            self.dock_presence in (1, 6)
+            or self.dock_sub_state == 1
+            or self.dock_activity > 0
+            or self.dock_field11 >= 2
+            or self.dock_field47 in (1, 3)
+        )
 
     @property
     def is_returning(self) -> bool:
@@ -696,6 +854,201 @@ class NarwalState:
         if self.working_status not in ACTIVE_CLEANING_STATUSES:
             return False
         return self.is_returning_to_dock and self.dock_sub_state == 2
+
+    @property
+    def is_station_active(self) -> bool:
+        """True when the dock/base station is running a dock-side task."""
+        return (
+            self.is_washing_mop
+            or self.is_drying_mop
+            or bool(self.active_dock_drying_tasks)
+            or (
+                self.station_activity > 0
+                and not (
+                    self.station_activity == 4
+                    and self.has_fresh_idle_dock_drying_snapshot
+                )
+            )
+        )
+
+    @property
+    def blocks_robot_start_for_dock_task(self) -> bool:
+        """True when dock-side activity should block a new robot clean."""
+        if self.has_unmapped_active_dock_task:
+            return True
+        if self.assumed_active_dock_task is not None:
+            return True
+        telemetry_tasks = set(self.telemetry_dock_task_keys)
+        if not telemetry_tasks:
+            return False
+        return not (
+            telemetry_tasks == {DOCK_TASK_DRY_DOCK_BAG}
+            and self.has_recent_dock_drying_status
+            and self.dock_task_timer(DOCK_TASK_DRY_DOCK_BAG) is not None
+        )
+
+    @property
+    def is_washing_mop(self) -> bool:
+        """True when the dock is washing the mop pads."""
+        return self.station_activity in (2, 3) or self.dock_activity == 3
+
+    @property
+    def is_drying_mop(self) -> bool:
+        """True when the dock is drying the mop pads."""
+        if self.dock_task_timer(DOCK_TASK_DRY_MOP) is not None:
+            return True
+        if self.has_recent_dock_drying_status and self.has_dock_drying_timer_snapshot:
+            return False
+        return self.dock_activity == 4
+
+    @property
+    def active_dock_task_keys(self) -> tuple[str, ...]:
+        """Return active known dock task keys from telemetry and accepted guards."""
+        tasks = set(self.telemetry_dock_task_keys)
+        if assumed := self.assumed_active_dock_task:
+            tasks.add(assumed)
+        return tuple(task for task in DOCK_TASK_KEYS if task in tasks)
+
+    @property
+    def telemetry_dock_task_keys(self) -> tuple[str, ...]:
+        """Return active dock task keys from robot telemetry only."""
+        tasks: list[str] = []
+        if self.station_activity == 1:
+            tasks.append(DOCK_TASK_EMPTY_DUSTBIN)
+        if self.is_washing_mop:
+            tasks.append(DOCK_TASK_WASH_MOP)
+        tasks.extend(self.telemetry_dock_drying_tasks)
+        if self.is_drying_mop and DOCK_TASK_DRY_MOP not in tasks:
+            tasks.append(DOCK_TASK_DRY_MOP)
+        active = set(tasks)
+        return tuple(task for task in DOCK_TASK_KEYS if task in active)
+
+    @property
+    def has_unmapped_active_dock_task(self) -> bool:
+        """True when station work is active but not mapped to one of five tasks."""
+        if self.has_unmapped_dock_drying_timer and self.has_recent_dock_drying_status:
+            return True
+        if self.dock_activity not in _KNOWN_DOCK_ACTIVITY_VALUES:
+            return True
+        if self.station_activity <= 0:
+            return False
+        if self.station_activity in (1, 2, 3):
+            return False
+        if self.station_activity == 4 and self.has_fresh_idle_dock_drying_snapshot:
+            return False
+        return not (self.station_activity == 4 and self.active_dock_drying_tasks)
+
+    @property
+    def active_dock_drying_tasks(self) -> tuple[str, ...]:
+        """Return active dock drying/disinfection tasks from telemetry only."""
+        return self.telemetry_dock_drying_tasks
+
+    @property
+    def telemetry_dock_drying_tasks(self) -> tuple[str, ...]:
+        """Return active dock drying/disinfection tasks from telemetry only."""
+        tasks = [
+            task
+            for task in _DOCK_DRYING_TASK_ORDER
+            if self.dock_task_timer(task) is not None
+        ]
+        return tuple(tasks)
+
+    @property
+    def assumed_active_dock_task(self) -> str | None:
+        """Return a short accepted-command dock task reservation, if valid."""
+        if not self.assumed_dock_task:
+            return None
+        if time.monotonic() > self.assumed_dock_task_until:
+            return None
+        return self.assumed_dock_task
+
+    @property
+    def assumed_active_dock_drying_task(self) -> str | None:
+        """Return an assumed dock drying task, if the reservation is drying."""
+        assumed = self.assumed_active_dock_task
+        if assumed in _DOCK_DRYING_TASK_ORDER:
+            return assumed
+        return None
+
+    @property
+    def has_recent_dock_drying_status(self) -> bool:
+        """True while live dock drying timer fields are still fresh."""
+        return (
+            self.dock_drying_status_time > 0
+            and time.monotonic() - self.dock_drying_status_time
+            <= _DOCK_DRYING_STATUS_TTL
+        )
+
+    @property
+    def has_fresh_idle_dock_drying_snapshot(self) -> bool:
+        """True when fresh typed timer telemetry says no drying task is active."""
+        return (
+            self.has_recent_dock_drying_status
+            and self.has_dock_drying_timer_snapshot
+            and not self.telemetry_dock_drying_tasks
+        )
+
+    @property
+    def has_assumed_robot_clean(self) -> bool:
+        """Return a short accepted-command robot-clean reservation."""
+        return (
+            self.assumed_robot_clean_until > 0
+            and time.monotonic() <= self.assumed_robot_clean_until
+        )
+
+    def assume_robot_clean(self) -> None:
+        """Temporarily reserve robot-clean command context after an accepted start."""
+        self.assumed_robot_clean_until = time.monotonic() + _ROBOT_START_ASSUME_TTL
+
+    def clear_assumed_robot_clean(self) -> None:
+        """Clear the local robot-clean command reservation."""
+        self.assumed_robot_clean_until = 0.0
+
+    def dock_task_timer(self, task: str) -> DockTaskTimer | None:
+        """Return timer details for one active dock task."""
+        timer = self.dock_drying_tasks.get(task)
+        if timer is None or timer.remaining <= 0:
+            return None
+        if not self.has_recent_dock_drying_status:
+            return None
+        if task == DOCK_TASK_DRY_DOCK_BAG:
+            return timer
+        if not self.has_dock_presence_signal and not self.is_docked:
+            return None
+        return timer
+
+    def set_dock_drying_task(
+        self,
+        task: str,
+        elapsed: int,
+        target: int,
+        fields: tuple[str, str],
+    ) -> None:
+        """Set one dock drying timer from typed telemetry or a test fixture."""
+        self.dock_drying_tasks[task] = DockTaskTimer(task, elapsed, target, fields)
+        self.dock_drying_status_time = time.monotonic()
+
+    def clear_dock_drying_task(self, task: str | None = None) -> None:
+        """Clear one or all dock drying timers."""
+        if task is None:
+            self.dock_drying_tasks.clear()
+        else:
+            self.dock_drying_tasks.pop(task, None)
+        if not self.dock_drying_tasks:
+            self.dock_drying_status_time = 0.0
+            self.has_dock_drying_timer_snapshot = False
+
+    def assume_dock_task(self, task: str, *, ttl: float = _DOCK_TASK_ASSUME_TTL) -> None:
+        """Briefly reserve a dock task after an accepted command."""
+        self.assumed_dock_task = task
+        self.assumed_dock_task_until = time.monotonic() + ttl
+
+    def clear_assumed_dock_task(self, task: str | None = None) -> None:
+        """Clear a local dock task reservation."""
+        if task is not None and task != self.assumed_dock_task:
+            return
+        self.assumed_dock_task = ""
+        self.assumed_dock_task_until = 0.0
 
     @property
     def current_room_name(self) -> str | None:
@@ -726,6 +1079,16 @@ class NarwalState:
         not area — reading it as area is why the sensor was stuck at 1.8 m².
         """
         self.raw_working_status = decoded
+        if _has_dock_drying_timer_fields(decoded):
+            timers = _dock_drying_timers(decoded)
+            self.dock_drying_tasks = timers
+            self.has_dock_drying_timer_snapshot = True
+            self.has_unmapped_dock_drying_timer = _has_unmapped_dock_drying_timer(
+                decoded
+            )
+            self.dock_drying_status_time = time.monotonic()
+            if timers:
+                self.clear_assumed_dock_task()
         # Only a positive session counter is evidence of an active clean. Field
         # presence alone is not: a robot reporting timeConsuming=0 would
         # otherwise be flipped to CLEANING and shown as running while parked.
@@ -752,10 +1115,13 @@ class NarwalState:
         if active_payload:
             self.working_status = WorkingStatus.CLEANING
             self.last_active_working_status_time = time.monotonic()
+            self.clear_assumed_robot_clean()
             self.is_paused = False
             self.is_returning_to_dock = False
             self.dock_sub_state = 0
             self.dock_activity = 0
+            self.station_activity = 0
+            self.clear_assumed_dock_task()
             self.dock_presence = 2
             self.dock_field11 = 1
             self.dock_field47 = 2
@@ -803,8 +1169,9 @@ class NarwalState:
             self.dock_light_mode = 0
         # Field 3 is a nested message: {1: state_int, ...}
         # Sub-field layout differs across firmware versions:
-        #   Old FW: {1: ws, 2: paused, 3: dock_presence, 7: returning, 10: dock_sub, 12: dock_activity}
-        #   v01.07.23+: {1: ws, 4: ?, 11: ?} — sub-fields 2/3/7/10/12 absent
+        #   Old FW: {1: ws, 2: paused, 3: dock_presence, 7: returning,
+        #            10: dock_sub, 12: dock_activity}
+        #   v01.07.23+: {1: ws, 4: ?, 11: ?}; sub-fields 2/3/7/10/12 absent
         # bbp may also return a list for repeated messages.
         field3 = decoded.get("3")
         if isinstance(field3, list):
@@ -833,39 +1200,80 @@ class NarwalState:
             # Only treat value 1 as returning — other values are not the flag.
             self.is_returning_to_dock = field3.get("7") == 1
             if "10" in field3:
-                try:
+                with contextlib.suppress(ValueError, TypeError):
                     self.dock_sub_state = int(field3["10"])
-                except (ValueError, TypeError):
-                    pass
             if "12" in field3:
-                try:
+                with contextlib.suppress(ValueError, TypeError):
                     self.dock_activity = int(field3["12"])
-                except (ValueError, TypeError):
-                    pass
+            elif self.working_status not in ACTIVE_CLEANING_STATUSES:
+                self.dock_activity = 0
+            self.station_activity = 0
+            if "18" in field3:
+                with contextlib.suppress(ValueError, TypeError):
+                    self.station_activity = int(field3["18"])
             if "3" in field3:
-                try:
+                with contextlib.suppress(ValueError, TypeError):
                     self.dock_presence = int(field3["3"])
-                except (ValueError, TypeError):
-                    pass
             if self.working_status in ACTIVE_CLEANING_STATUSES:
+                self.clear_assumed_robot_clean()
                 if "10" not in field3:
                     self.dock_sub_state = 0
-                if "12" not in field3:
-                    self.dock_activity = 0
+                self.dock_activity = 0
+                self.station_activity = 0
+                self.clear_assumed_dock_task()
                 if "3" not in field3:
                     self.dock_presence = 2
                 if "11" not in decoded:
                     self.dock_field11 = 1
                 if "47" not in decoded:
                     self.dock_field47 = 2
+            elif self.dock_activity > 0:
+                # Cleaning packets synthesize off-dock defaults for omitted
+                # fields. Do not let those stale defaults override a later
+                # dock-activity packet, but retain any off-dock value that the
+                # current packet reports explicitly.
+                if "3" not in field3:
+                    self.dock_presence = 0
+                if "10" not in field3:
+                    self.dock_sub_state = 0
+                if "11" not in decoded:
+                    self.dock_field11 = 0
+                if "47" not in decoded:
+                    self.dock_field47 = 0
             # Log unrecognized sub-fields for future firmware mapping
-            _known_f3 = {"1", "2", "3", "7", "10", "12"}
+            _known_f3 = {"1", "2", "3", "7", "10", "12", "18"}
             _unknown_f3 = set(field3.keys()) - _known_f3
             if _unknown_f3:
                 _LOGGER.debug(
                     "field3 unrecognized sub-fields: %s",
                     {k: field3[k] for k in sorted(_unknown_f3)},
                 )
+            if (
+                self.station_activity <= 0
+                and self.dock_activity in (0, 2, 6)
+                and self.has_dock_presence_signal
+                and self.assumed_active_dock_task is None
+                and self.working_status
+                in (
+                    WorkingStatus.UNKNOWN,
+                    WorkingStatus.STANDBY,
+                    WorkingStatus.DOCKED,
+                    WorkingStatus.CHARGED,
+                    WorkingStatus.DOCKED_V2,
+                    WorkingStatus.TASK_COMPLETED,
+                )
+                and not self.has_recent_dock_drying_status
+            ):
+                self.clear_dock_drying_task()
+                self.has_dock_drying_timer_snapshot = False
+                self.has_unmapped_dock_drying_timer = False
+                self.clear_assumed_dock_task()
+            telemetry_tasks = self.telemetry_dock_task_keys
+            if (
+                telemetry_tasks
+                and self.assumed_active_dock_task is not None
+            ):
+                self.clear_assumed_dock_task()
         elif field3 is not None:
             _LOGGER.warning(
                 "field3 is %s (expected dict): %r — state may not update. "
@@ -888,13 +1296,11 @@ class NarwalState:
                 if self.binded_uuid.startswith("b'"):
                     self.binded_uuid = self.binded_uuid[2:-1]
         if "15" in decoded:
-            try:
+            with contextlib.suppress(ValueError, TypeError):
                 self.terminate_reason = int(decoded["15"])
-            except (ValueError, TypeError):
-                pass
 
     def _update_consumables(self, decoded: dict[str, Any]) -> None:
-        """Parse base_status consumable/station/fault fields — hardware-sampled, so trustworthy even in deep-sleep battery-only updates."""
+        """Parse trustworthy hardware-sampled base_status fields."""
         if "35" in decoded:
             score = _to_float32(decoded["35"])
             if score is not None:
@@ -905,7 +1311,9 @@ class NarwalState:
             self.curing_agent_consumption_percent = int(decoded["38"])
         if "36" in decoded:
             self.station_bag_health_reset_time = int(decoded["36"])
-        # Always reparse (even when field 1 is absent) — protobuf omits an empty repeated field, so a recovered robot drops it; without this the prior fault would stick forever.
+        # Always reparse, even when field 1 is absent. Protobuf omits an empty
+        # repeated field, so a recovered robot drops it; otherwise the prior
+        # fault would stick forever.
         self._parse_error_codes(decoded.get("1"))
         for attr, key in (
             ("clean_water_tank_state", "23"), ("sewage_tank_state", "24"),
@@ -913,10 +1321,8 @@ class NarwalState:
             ("station_bag_state", "39"),
         ):
             if key in decoded:
-                try:
+                with contextlib.suppress(ValueError, TypeError):
                     setattr(self, attr, int(decoded[key]))
-                except (ValueError, TypeError):
-                    pass
 
     def _parse_error_codes(self, raw: Any) -> None:
         """Decode base_status field 1 (repeated ErrorCode{1:identityCode, 2:level, 3:debugDetail}).
@@ -934,10 +1340,8 @@ class NarwalState:
                 codes.append(int(entry["1"]))
             except (ValueError, TypeError):
                 continue
-            try:
+            with contextlib.suppress(ValueError, TypeError):
                 level = max(level, int(entry.get("2", 0)))
-            except (ValueError, TypeError):
-                pass
             raw_detail = entry.get("3")
             if isinstance(raw_detail, bytes):
                 detail = detail or raw_detail.decode("utf-8", errors="replace")
@@ -949,9 +1353,12 @@ class NarwalState:
         self.has_error = bool(codes)
 
     def update_battery_from_base_status(self, decoded: dict[str, Any]) -> None:
-        """Update only the trustworthy hardware-sampled fields (battery + consumable/station/fault/tank state, via _update_consumables) from a base_status response.
+        """Update only trustworthy hardware-sampled base_status fields.
 
-        Used when the robot is not broadcasting (deep sleep on dock): get_status() returns a current battery counter but a stale working_status (firmware cache from the last active session), so working_status is deliberately skipped.
+        Used when the robot is not broadcasting, such as deep sleep on dock.
+        get_status() returns a current battery counter but a stale
+        working_status firmware cache from the last active session, so
+        working_status is deliberately skipped.
         """
         self.raw_base_status = decoded
         if "2" in decoded:

--- a/custom_components/narwal/sensor.py
+++ b/custom_components/narwal/sensor.py
@@ -15,12 +15,11 @@ from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfArea, UnitOfTi
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .narwal_client import NarwalState
-
 from . import NarwalConfigEntry
 from .const import TASK_RESULT_OPTIONS
 from .coordinator import NarwalCoordinator
-from .entity import NarwalEntity
+from .entity import NarwalDockEntity, NarwalEntity
+from .narwal_client import NarwalState
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -28,6 +27,7 @@ class NarwalSensorEntityDescription(SensorEntityDescription):
     """Describes a Narwal sensor entity."""
 
     value_fn: Callable[[NarwalState], float | str | None]
+    dock_device: bool = False
 
 
 SENSOR_DESCRIPTIONS: tuple[NarwalSensorEntityDescription, ...] = (
@@ -67,6 +67,7 @@ SENSOR_DESCRIPTIONS: tuple[NarwalSensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        dock_device=True,
         # base_status field 35 stationBagHealthScore (float32 %); present only with a station.
         value_fn=lambda state: round(state.dust_bag_health, 1)
         if "35" in state.raw_base_status
@@ -78,6 +79,7 @@ SENSOR_DESCRIPTIONS: tuple[NarwalSensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        dock_device=True,
         # base_status field 41 heavyDetergentRemainPercent.
         value_fn=lambda state: state.detergent_remaining
         if "41" in state.raw_base_status
@@ -117,7 +119,12 @@ async def async_setup_entry(
     """Set up Narwal sensor entities."""
     coordinator = entry.runtime_data
     entities: list[SensorEntity] = [
-        NarwalSensor(coordinator, description) for description in SENSOR_DESCRIPTIONS
+        (
+            NarwalDockSensor(coordinator, description)
+            if description.dock_device
+            else NarwalSensor(coordinator, description)
+        )
+        for description in SENSOR_DESCRIPTIONS
     ]
     entities.append(NarwalChargingStateSensor(coordinator))
     async_add_entities(entities)
@@ -134,6 +141,31 @@ class NarwalSensor(NarwalEntity, SensorEntity):
         description: NarwalSensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        device_id = coordinator.config_entry.data["device_id"]
+        self._attr_unique_id = f"{device_id}_{description.key}"
+
+    @property
+    def native_value(self) -> float | str | None:
+        """Return the sensor value."""
+        state = self.coordinator.data
+        if state is None:
+            return None
+        return self.entity_description.value_fn(state)
+
+
+class NarwalDockSensor(NarwalDockEntity, SensorEntity):
+    """A description-driven Narwal sensor assigned to the dock device."""
+
+    entity_description: NarwalSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: NarwalCoordinator,
+        description: NarwalSensorEntityDescription,
+    ) -> None:
+        """Initialize the dock sensor."""
         super().__init__(coordinator)
         self.entity_description = description
         device_id = coordinator.config_entry.data["device_id"]

--- a/custom_components/narwal/strings.json
+++ b/custom_components/narwal/strings.json
@@ -160,6 +160,21 @@
       }
     },
     "switch": {
+      "empty_dustbin": {
+        "name": "Empty dustbin"
+      },
+      "wash_mop": {
+        "name": "Wash mop"
+      },
+      "dry_mop": {
+        "name": "Dry mop"
+      },
+      "dry_dust_bin": {
+        "name": "Dry and disinfect dust bin"
+      },
+      "dry_dock_bag": {
+        "name": "Dry and disinfect dock bag"
+      },
       "show_room_labels": {
         "name": "Show room labels"
       },

--- a/custom_components/narwal/switch.py
+++ b/custom_components/narwal/switch.py
@@ -1,12 +1,14 @@
-"""Switch entities for Narwal map display options."""
+"""Switch entities for Narwal dock tasks and map display options."""
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import NarwalConfigEntry
@@ -17,7 +19,33 @@ from .const import (
     MAP_OPTION_DEFAULTS,
 )
 from .coordinator import NarwalCoordinator
-from .entity import NarwalEntity
+from .dock_tasks import (
+    DOCK_TASKS,
+    can_start_dock_task,
+    can_stop_dock_task,
+    is_robot_work_context,
+)
+from .entity import NarwalDockEntity, NarwalEntity
+from .narwal_client import CommandResponse, CommandResult
+
+
+@dataclass(frozen=True, kw_only=True)
+class NarwalDockTaskSwitchEntityDescription(SwitchEntityDescription):
+    """Description for a Narwal dock task switch."""
+
+    action: str
+    icon: str
+
+
+DOCK_TASK_SWITCHES: tuple[NarwalDockTaskSwitchEntityDescription, ...] = tuple(
+    NarwalDockTaskSwitchEntityDescription(
+        key=task.key,
+        translation_key=task.translation_key,
+        action=task.action,
+        icon=task.icon,
+    )
+    for task in DOCK_TASKS
+)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -54,9 +82,144 @@ async def async_setup_entry(
     """Set up Narwal switch entities."""
     coordinator = entry.runtime_data
     async_add_entities(
+        NarwalDockTaskSwitch(coordinator, description)
+        for description in DOCK_TASK_SWITCHES
+    )
+    async_add_entities(
         NarwalMapOptionSwitch(coordinator, description)
         for description in MAP_SWITCHES
     )
+
+
+def _format_duration(seconds: int) -> str:
+    """Return a short human-readable duration."""
+    minutes = _duration_minutes(seconds)
+    hours, minutes = divmod(minutes, 60)
+    if hours and minutes:
+        return f"{hours}h {minutes}m"
+    if hours:
+        return f"{hours}h"
+    return f"{minutes}m"
+
+
+def _duration_minutes(seconds: int) -> int:
+    """Return remaining duration rounded up to whole minutes."""
+    if seconds <= 0:
+        return 0
+    return (seconds + 59) // 60
+
+
+def _accepted_response(response: CommandResponse) -> bool:
+    """Return true for response codes that mean the robot accepted a command."""
+    return response.accepted
+
+
+class NarwalDockTaskSwitch(NarwalDockEntity, SwitchEntity):
+    """Stateful start/stop control for one Narwal dock task."""
+
+    entity_description: NarwalDockTaskSwitchEntityDescription
+
+    def __init__(
+        self,
+        coordinator: NarwalCoordinator,
+        description: NarwalDockTaskSwitchEntityDescription,
+    ) -> None:
+        """Initialize the dock task switch."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        device_id = coordinator.config_entry.data["device_id"]
+        self._attr_unique_id = f"{device_id}_{description.key}"
+        self._attr_icon = description.icon
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether this dock task is active."""
+        state = self.coordinator.data
+        if state is None:
+            return None
+        return self.entity_description.key in state.active_dock_task_keys
+
+    @property
+    def available(self) -> bool:
+        """Return True when this dock task can be started or stopped."""
+        if not self.coordinator.client.connected:
+            return False
+        state = self.coordinator.data
+        if state is None:
+            return False
+        if not self.coordinator.has_fresh_state:
+            # Keep the service reachable so it can wake the robot and replace a
+            # stale cached decision with an authoritative dock refresh.
+            return True
+        if self.is_on:
+            return can_stop_dock_task(state, self.entity_description.key)
+        return can_start_dock_task(state, self.entity_description.key)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | int] | None:
+        """Return task progress attributes from typed dock telemetry."""
+        state = self.coordinator.data
+        if state is None or not self.is_on:
+            return None
+        timer = state.dock_task_timer(self.entity_description.key)
+        if timer is None:
+            return None
+        return {
+            "time_left": _format_duration(timer.remaining),
+            "progress": timer.progress_percent,
+        }
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Start this dock task."""
+        async with self.coordinator.dock_action_lock:
+            client = self.coordinator.client
+            stale_state = not self.coordinator.has_fresh_state
+            force_wake = stale_state and not is_robot_work_context(client.state)
+            if not client.robot_awake or force_wake:
+                await client.wake(timeout=10.0, force=force_wake)
+            if not await self.coordinator.async_refresh_dock_status():
+                raise HomeAssistantError("Narwal dock status could not be refreshed")
+            if not can_start_dock_task(client.state, self.entity_description.key):
+                raise HomeAssistantError("Narwal dock task cannot be started right now")
+
+            command: Callable[[], Awaitable[CommandResponse]] = getattr(
+                client,
+                self.entity_description.action,
+            )
+            response = await command()
+            self._raise_if_command_failed(response, "start")
+            self.coordinator.async_set_updated_data(client.state)
+            await self.coordinator.async_refresh_dock_status()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Stop this dock task."""
+        async with self.coordinator.dock_action_lock:
+            client = self.coordinator.client
+            stale_state = not self.coordinator.has_fresh_state
+            force_wake = stale_state and not is_robot_work_context(client.state)
+            if not client.robot_awake or force_wake:
+                await client.wake(timeout=10.0, force=force_wake)
+            if not await self.coordinator.async_refresh_dock_status():
+                raise HomeAssistantError("Narwal dock status could not be refreshed")
+            if not can_stop_dock_task(client.state, self.entity_description.key):
+                raise HomeAssistantError("Narwal dock task cannot be stopped right now")
+
+            response = await client.stop_dock_task(self.entity_description.key)
+            self._raise_if_command_failed(response, "stop")
+            self.coordinator.async_set_updated_data(client.state)
+            await self.coordinator.async_refresh_dock_status()
+
+    def _raise_if_command_failed(self, response: CommandResponse, action: str) -> None:
+        """Raise a Home Assistant service error for rejected dock commands."""
+        if _accepted_response(response):
+            return
+        try:
+            result_name = CommandResult(response.result_code).name
+        except (TypeError, ValueError):
+            result_name = f"UNKNOWN({response.result_code})"
+        raise HomeAssistantError(
+            f"Narwal {action} {self.entity_description.key} failed: {result_name}"
+        )
 
 
 class NarwalMapOptionSwitch(NarwalEntity, SwitchEntity):

--- a/custom_components/narwal/translations/en.json
+++ b/custom_components/narwal/translations/en.json
@@ -160,6 +160,21 @@
       }
     },
     "switch": {
+      "empty_dustbin": {
+        "name": "Empty dustbin"
+      },
+      "wash_mop": {
+        "name": "Wash mop"
+      },
+      "dry_mop": {
+        "name": "Dry mop"
+      },
+      "dry_dust_bin": {
+        "name": "Dry and disinfect dust bin"
+      },
+      "dry_dock_bag": {
+        "name": "Dry and disinfect dock bag"
+      },
       "show_room_labels": {
         "name": "Show room labels"
       },

--- a/custom_components/narwal/translations/fr.json
+++ b/custom_components/narwal/translations/fr.json
@@ -157,6 +157,21 @@
       }
     },
     "switch": {
+      "empty_dustbin": {
+        "name": "Vider le bac a poussiere"
+      },
+      "wash_mop": {
+        "name": "Laver la serpilliere"
+      },
+      "dry_mop": {
+        "name": "Secher la serpilliere"
+      },
+      "dry_dust_bin": {
+        "name": "Secher et desinfecter le bac a poussiere"
+      },
+      "dry_dock_bag": {
+        "name": "Secher et desinfecter le sac de station"
+      },
       "show_room_labels": {
         "name": "Afficher les noms des pièces"
       },

--- a/custom_components/narwal/vacuum.py
+++ b/custom_components/narwal/vacuum.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-
 from typing import Any
 
 from homeassistant.components.vacuum import (
@@ -11,6 +10,7 @@ from homeassistant.components.vacuum import (
     VacuumActivity,
     VacuumEntityFeature,
 )
+from homeassistant.exceptions import HomeAssistantError
 
 try:
     from homeassistant.components.vacuum import Segment
@@ -20,19 +20,23 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .narwal_client import CommandResult, WorkingStatus
-from .narwal_client.const import ACTIVE_CLEANING_STATUSES
-
 from . import NarwalConfigEntry
 from .const import FAN_SPEED_LIST, FAN_SPEED_MAP, fan_speed_list_for
 from .coordinator import NarwalCoordinator
+from .dock_tasks import (
+    can_start_robot_clean,
+    can_stop_dock_task,
+    has_active_dock_work,
+    is_clean_session_context,
+)
 from .entity import NarwalEntity
+from .narwal_client import CommandResult, WorkingStatus
+from .narwal_client.const import ACTIVE_CLEANING_STATUSES
 
 _LOGGER = logging.getLogger(__name__)
 
 # working_status values already reported as unmapped. Activity is recomputed on
-# every state broadcast (~1.5s), so an unmapped value otherwise floods the log
-# with thousands of identical lines (#46). Warn once per distinct value.
+# every state broadcast, so warn once per distinct value instead of flooding.
 _WARNED_UNMAPPED_ACTIVITY: set[int] = set()
 
 WORKING_STATUS_TO_ACTIVITY: dict[WorkingStatus, VacuumActivity] = {
@@ -43,12 +47,24 @@ WORKING_STATUS_TO_ACTIVITY: dict[WorkingStatus, VacuumActivity] = {
     WorkingStatus.CLEANING_V2: VacuumActivity.CLEANING,
     WorkingStatus.CLEANING: VacuumActivity.CLEANING,
     WorkingStatus.CLEANING_ALT: VacuumActivity.CLEANING,
-    WorkingStatus.REMAPPING: VacuumActivity.CLEANING,  # mapping/exploration — robot is actively busy
+    # Mapping/exploration is active robot work.
+    WorkingStatus.REMAPPING: VacuumActivity.CLEANING,
     WorkingStatus.TASK_COMPLETED: VacuumActivity.RETURNING,
     WorkingStatus.ERROR: VacuumActivity.ERROR,
 }
 
-# FanLevel value -> fan_speed label (canonical labels only; FAN_SPEED_MAP also holds back-compat aliases).
+
+def _result_name(result_code: int | CommandResult) -> str:
+    """Return a readable Narwal command result name."""
+    if result_code == 0:
+        return "ACCEPTED"
+    try:
+        return CommandResult(result_code).name
+    except ValueError:
+        return f"UNKNOWN({result_code})"
+
+
+# FanLevel value -> fan_speed label. FAN_SPEED_MAP also holds back-compat aliases.
 _FAN_LABELS: dict[int, str] = {int(FAN_SPEED_MAP[label]): label for label in FAN_SPEED_LIST}
 
 
@@ -66,7 +82,7 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
     """Representation of a Narwal robot vacuum."""
 
     _attr_translation_key = "vacuum"
-    _attr_supported_features = (
+    _BASE_SUPPORTED_FEATURES = (
         VacuumEntityFeature.STATE
         | VacuumEntityFeature.START
         | VacuumEntityFeature.STOP
@@ -75,6 +91,24 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         | VacuumEntityFeature.FAN_SPEED
         | VacuumEntityFeature.LOCATE
     ) | (VacuumEntityFeature.CLEAN_AREA if Segment is not None else VacuumEntityFeature(0))
+
+    @property
+    def supported_features(self) -> VacuumEntityFeature:
+        """Hide robot actions while dock work makes them unsafe or ambiguous."""
+        features = self._BASE_SUPPORTED_FEATURES
+        state = self.coordinator.data
+        if not has_active_dock_work(state):
+            return features
+        features &= ~(
+            VacuumEntityFeature.START
+            | VacuumEntityFeature.PAUSE
+            | VacuumEntityFeature.RETURN_HOME
+            | VacuumEntityFeature.LOCATE
+            | VacuumEntityFeature.CLEAN_AREA
+        )
+        if not is_clean_session_context(state):
+            features &= ~VacuumEntityFeature.STOP
+        return features
 
     def __init__(self, coordinator: NarwalCoordinator) -> None:
         """Initialize the vacuum entity."""
@@ -116,16 +150,17 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         activity = WORKING_STATUS_TO_ACTIVITY.get(state.working_status)
         if activity is not None:
             return activity
-        # Unknown working_status value — infer from dock signals so we
-        # don't report IDLE while the robot is clearly active off-dock.
-        # New firmware versions may introduce values we haven't mapped yet.
+        # Unknown working_status value: infer from dock signals so we don't
+        # report IDLE while the robot is clearly active off-dock. New firmware
+        # versions may introduce values we haven't mapped yet.
         if not state.is_docked:
             if state.working_status.value not in _WARNED_UNMAPPED_ACTIVITY:
                 _WARNED_UNMAPPED_ACTIVITY.add(state.working_status.value)
                 _LOGGER.warning(
-                    "Unmapped working_status %s (%d) while off-dock — reporting "
-                    "CLEANING (further occurrences of this value are suppressed)",
-                    state.working_status.name, state.working_status.value,
+                    "Unmapped working_status %s (%d) while off-dock; reporting "
+                    "CLEANING (further occurrences are suppressed)",
+                    state.working_status.name,
+                    state.working_status.value,
                 )
             return VacuumActivity.CLEANING
         return VacuumActivity.IDLE
@@ -156,6 +191,13 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
             _LOGGER.debug("Robot not awake — sending wake burst")
             await client.wake(timeout=10.0)
 
+    async def _validate_clean_start(self) -> None:
+        """Refresh dock state and reject starts that conflict with dock work."""
+        if not await self.coordinator.async_refresh_dock_status():
+            raise HomeAssistantError("Narwal status could not be refreshed")
+        if not can_start_robot_clean(self.coordinator.client.state):
+            raise HomeAssistantError("Narwal dock task is active")
+
     async def async_start(self) -> None:
         """Start or resume cleaning."""
         await self._ensure_awake()
@@ -165,32 +207,42 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         if is_cleaning and state.is_paused:
             await self.coordinator.client.resume(timeout=self._ACTION_TIMEOUT)
             return
+        room_ids: list[int] = []
+        async with self.coordinator.dock_action_lock:
+            await self._validate_clean_start()
 
-        # Whole-house clean enumerates every room via clean/start_clean, matching the
-        # app's allRoomIds() path. clean/plan/start (StartWithPlan) would instead re-run
-        # the saved current plan — i.e. the last room selection — not the whole house.
-        room_ids = await self._all_room_ids()
-        if room_ids:
-            settings = self.coordinator.clean_settings
-            resp = await self.coordinator.client.start_rooms(
-                room_ids,
-                work_mode=settings.work_mode,
-                fan=settings.fan,
-                water=settings.water,
-                mop_strength=settings.mop_strength,
-                passes=settings.passes,
-            )
-        else:
-            # No map rooms known — best-effort fall back to the saved-plan start.
-            resp = await self.coordinator.client.start()
+            # Whole-house clean enumerates every room via clean/start_clean, matching the
+            # app's allRoomIds() path. clean/plan/start (StartWithPlan) would instead re-run
+            # the saved current plan — i.e. the last room selection — not the whole house.
+            room_ids = await self._all_room_ids()
+            if room_ids:
+                settings = self.coordinator.clean_settings
+                resp = await self.coordinator.client.start_rooms(
+                    room_ids,
+                    work_mode=settings.work_mode,
+                    fan=settings.fan,
+                    water=settings.water,
+                    mop_strength=settings.mop_strength,
+                    passes=settings.passes,
+                )
+            else:
+                # No map rooms known — best-effort fall back to the saved-plan start.
+                resp = await self.coordinator.client.start()
+            if resp.accepted:
+                self.coordinator.client.state.assume_robot_clean()
+                self.coordinator.async_set_updated_data(self.coordinator.client.state)
         _LOGGER.info(
             "Whole-house start: code=%s, success=%s, rooms=%s",
             resp.result_code, resp.success, room_ids or "(saved plan)",
         )
-        if not resp.success:
+        if not resp.accepted:
             _LOGGER.warning(
-                "Start command did not succeed (code=%s) — robot may not have started",
+                "Start command was rejected: %s (code=%s)",
+                _result_name(resp.result_code),
                 resp.result_code,
+            )
+            raise HomeAssistantError(
+                f"Narwal start command failed: {_result_name(resp.result_code)}"
             )
 
     async def _all_room_ids(self) -> list[int]:
@@ -217,31 +269,71 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
     async def async_stop(self, **kwargs) -> None:
         """Stop cleaning."""
         await self._ensure_awake()
-        resp = await self.coordinator.client.stop()
+        async with self.coordinator.dock_action_lock:
+            refreshed = await self.coordinator.async_refresh_dock_status()
+            state = self.coordinator.client.state
+            clean_context = is_clean_session_context(state)
+            if state.has_unmapped_active_dock_task and not clean_context:
+                raise HomeAssistantError(
+                    "Narwal dock task cannot be stopped safely right now"
+                )
+            if state.is_station_active and not clean_context:
+                if not can_stop_dock_task(state):
+                    raise HomeAssistantError(
+                        "Narwal dock task cannot be stopped safely right now"
+                    )
+                resp = await self.coordinator.client.stop_dock_task()
+            elif not clean_context:
+                if not refreshed:
+                    raise HomeAssistantError("Narwal status could not be refreshed")
+                raise HomeAssistantError("Narwal has no active task to stop")
+            else:
+                resp = await self.coordinator.client.stop()
         _LOGGER.info("Stop response: code=%s, success=%s", resp.result_code, resp.success)
+        if not resp.accepted:
+            raise HomeAssistantError(
+                f"Narwal stop command failed: {_result_name(resp.result_code)}"
+            )
 
     async def async_pause(self) -> None:
         """Pause cleaning."""
-        resp = await self.coordinator.client.pause()
+        async with self.coordinator.dock_action_lock:
+            if not await self.coordinator.async_refresh_dock_status():
+                raise HomeAssistantError("Narwal status could not be refreshed")
+            if has_active_dock_work(self.coordinator.client.state):
+                raise HomeAssistantError("Narwal dock task is active")
+            resp = await self.coordinator.client.pause()
         _LOGGER.info("Pause response: code=%s, success=%s", resp.result_code, resp.success)
 
     async def async_return_to_base(self, **kwargs) -> None:
         """Return to the dock."""
         await self._ensure_awake()
-        resp = await self.coordinator.client.return_to_base(timeout=self._ACTION_TIMEOUT)
+        async with self.coordinator.dock_action_lock:
+            if not await self.coordinator.async_refresh_dock_status():
+                raise HomeAssistantError("Narwal status could not be refreshed")
+            if has_active_dock_work(self.coordinator.client.state):
+                raise HomeAssistantError("Narwal dock task is active")
+            resp = await self.coordinator.client.return_to_base(timeout=self._ACTION_TIMEOUT)
         _LOGGER.info(
             "Return-to-base response: code=%s, success=%s",
             resp.result_code, resp.success,
         )
-        if not resp.success:
+        if not resp.accepted:
             _LOGGER.warning(
-                "Return-to-base did not succeed (code=%s)", resp.result_code,
+                "Return-to-base did not succeed: %s (code=%s)",
+                _result_name(resp.result_code),
+                resp.result_code,
             )
 
     async def async_locate(self, **kwargs) -> None:
         """Locate the vacuum — robot says 'Robot is here'."""
         await self._ensure_awake()
-        await self.coordinator.client.locate()
+        async with self.coordinator.dock_action_lock:
+            if not await self.coordinator.async_refresh_dock_status():
+                raise HomeAssistantError("Narwal status could not be refreshed")
+            if has_active_dock_work(self.coordinator.client.state):
+                raise HomeAssistantError("Narwal dock task is active")
+            await self.coordinator.client.locate()
 
     async def async_set_fan_speed(self, fan_speed: str, **kwargs) -> None:
         """Set the fan speed.
@@ -296,37 +388,64 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         a room-specific clean command to the robot.
         """
         await self._ensure_awake()
-        room_ids = [int(sid) for sid in segment_ids]
-        settings = self.coordinator.clean_settings
-        _LOGGER.info(
-            "Starting room-specific clean: rooms=%s mode=%s fan=%s water=%s "
-            "mop_strength=%s passes=%s",
-            room_ids, settings.work_mode.name, settings.fan.name,
-            settings.water.name, settings.mop_strength.name, settings.passes,
-        )
-        resp = await self.coordinator.client.start_rooms(
-            room_ids,
-            work_mode=settings.work_mode,
-            fan=settings.fan,
-            water=settings.water,
-            mop_strength=settings.mop_strength,
-            passes=settings.passes,
-        )
         try:
-            result_name = CommandResult(resp.result_code).name
-        except ValueError:
-            result_name = f"UNKNOWN({resp.result_code})"
+            room_ids = [int(sid) for sid in segment_ids]
+        except (TypeError, ValueError) as err:
+            raise HomeAssistantError("Narwal segment IDs must be numeric") from err
+
+        async with self.coordinator.dock_action_lock:
+            await self._validate_clean_start()
+            try:
+                await self.coordinator.client.get_map()
+            except Exception:
+                _LOGGER.debug("Could not refresh Narwal map before segment clean")
+            state = self.coordinator.client.state
+            known_room_ids = {
+                room.room_id
+                for room in getattr(getattr(state, "map_data", None), "rooms", ())
+                if room.room_id > 0
+            }
+            if known_room_ids:
+                unknown_room_ids = [
+                    room_id for room_id in room_ids if room_id not in known_room_ids
+                ]
+                if unknown_room_ids:
+                    raise HomeAssistantError(
+                        f"Unknown Narwal room ID: {', '.join(map(str, unknown_room_ids))}"
+                    )
+            settings = self.coordinator.clean_settings
+            _LOGGER.info(
+                "Starting room-specific clean: rooms=%s mode=%s fan=%s water=%s "
+                "mop_strength=%s passes=%s",
+                room_ids, settings.work_mode.name, settings.fan.name,
+                settings.water.name, settings.mop_strength.name, settings.passes,
+            )
+            resp = await self.coordinator.client.start_rooms(
+                room_ids,
+                work_mode=settings.work_mode,
+                fan=settings.fan,
+                water=settings.water,
+                mop_strength=settings.mop_strength,
+                passes=settings.passes,
+            )
+            if resp.accepted:
+                self.coordinator.client.state.assume_robot_clean()
+                self.coordinator.async_set_updated_data(self.coordinator.client.state)
+        result_name = _result_name(resp.result_code)
         _LOGGER.info(
             "Room clean response: %s (code=%s), rooms=%s",
             result_name, resp.result_code, room_ids,
         )
-        if not resp.success:
+        if not resp.accepted:
             _LOGGER.warning(
                 "Room clean failed: %s (code=%s), rooms=%s. "
                 "CONFLICT means robot is busy (cleaning, returning, or docked cycle in progress). "
                 "NOT_APPLICABLE means robot cannot clean right now. "
                 "Try again after the robot is idle on the dock.",
                 result_name, resp.result_code, room_ids,
+            )
+            raise HomeAssistantError(
+                f"Narwal room clean failed: {result_name}"
             )
 
     @callback

--- a/docs/DOCK_TASKS.md
+++ b/docs/DOCK_TASKS.md
@@ -1,0 +1,142 @@
+# Narwal Dock Task Design
+
+This document records the intended Home Assistant contract for Narwal dock
+tasks. It is a design note, not protocol proof. Verified field mappings belong
+in `docs/PROTOCOL.md` once they have been confirmed on hardware.
+
+## Goals
+
+- Model the robot and dock as separate Home Assistant devices.
+- Expose dock work as five stateful task controls.
+- Keep task identity, availability, progress, and safety rules inside the
+  integration.
+- Keep Lovelace simple: render entities and their attributes, without deriving
+  Narwal state from raw protocol fields.
+- Avoid extra progress, duration, or "current dock task" entities.
+
+Trails and map path rendering are deliberately out of scope for this design.
+
+## Devices
+
+| Device | Identifier | Owns |
+|---|---|---|
+| Robot | `(narwal, <device_id>)` | Vacuum, camera/map, robot clean metrics, room cleaning, robot diagnostics |
+| Dock | `(narwal, <device_id>_dock)` | Dock task switches, dock light, dock/tank/consumable entities |
+
+The dock should use `via_device=(narwal, <device_id>)` so Home Assistant shows
+it as the robot's base station rather than an unrelated device.
+
+## Dock Task Entities
+
+Expose exactly five dock task entities:
+
+| Task | Domain | Stable unique ID suffix | Command | Active state |
+|---|---|---|---|---|
+| Empty dustbin | `switch` | `_empty_dustbin` | `empty_dustbin()` | `emptying_dustbin` |
+| Wash mop | `switch` | `_wash_mop` | `wash_mop_by_robot_status()` | `washing_mop` |
+| Dry mop | `switch` | `_dry_mop` | `dry_mop()` | `drying_mop` |
+| Dry dust bin | `switch` | `_dry_dust_bin` | `dry_dust_bag()` | `dry_dust_bin` |
+| Dry dock bag | `switch` | `_dry_dock_bag` | `dry_station_bag()` | `dry_dock_bag` |
+
+The existing unique IDs should be preserved unless an explicit entity registry
+migration is added.
+
+Each switch owns:
+
+- `is_on`: true when that exact dock task is active.
+- `available`: true only when turning the switch on or off is currently safe.
+- `progress`: integer `0..100`, only when a typed timer provides enough data.
+- `time_left`: formatted remaining time, for example `10m` or `2h 30m`, only
+  when a trustworthy timer exists.
+
+Do not expose separate dock progress sensors such as `progress`,
+`progress_percent`, `progress_display`, `station_task`, or
+`dry_mop_remaining_time`. Robot cleaning progress can remain on the vacuum
+entity or a robot-side sensor; dock task progress belongs to the active dock
+task switch.
+
+## Availability Rules
+
+The integration should have one authoritative dock-task state layer. Raw
+`station_activity`, `dock_activity`, timer fields, command assumptions, and
+polling-only fallbacks should be normalized there before any entity decides
+availability.
+
+Rules:
+
+- If Home Assistant has no fresh coordinator state, connected dock task
+  switches remain actionable so a command can wake the robot, refresh dock
+  state, and revalidate against authoritative data before dispatch.
+- If the robot reports a blocking error, all dock tasks are unavailable.
+- If the robot is off the dock, all dock task starts are unavailable.
+- If the robot is actively cleaning, all dock task starts are unavailable.
+- If the dock is idle and the robot is docked, all five task switches are off
+  and available.
+- If one known task is active, the matching switch is on. It is available only
+  when stopping that exact task is safe.
+- If station work is active but unmapped, all starts are unavailable and no fake
+  sixth task entity is created.
+- Active timer fields that are not mapped to one of the five dock tasks are
+  treated as unmapped station work until hardware testing identifies them.
+- If multiple tasks are active, untyped generic stop must not be exposed as a
+  task-specific stop.
+- Typed timers beat stale coarse activity fields.
+- A bounded local assumption is acceptable only as a polling-only fallback after
+  a command was accepted, and must clear on authoritative idle state, explicit
+  stop, terminal evidence, or expiry.
+
+Current verified policy should be conservative:
+
+- Do not allow dock-to-dock parallel starts unless hardware testing proves the
+  exact combination.
+- Allow robot start during `dry_dock_bag` only when there is typed live evidence
+  that the active task is dock-bag drying.
+- Block robot starts for emptying, washing, mop drying, dust-bin drying, and
+  unmapped station activity.
+- Keep robot `stop` available during a dock-side phase that belongs to an
+  active clean.
+- Do not infer charge-to-resume from dock maintenance.
+
+## Integration Boundary
+
+The integration owns:
+
+- Protocol field decoding.
+- Raw-to-normalized dock task mapping.
+- Task concurrency and conflict rules.
+- Wake, refresh, and selected-task revalidation before commands.
+- Progress and time-left calculation.
+- Polling-only fallback assumptions.
+- Robot/dock interaction rules.
+
+Lovelace owns only presentation:
+
+- Show the five switch entities.
+- Use switch state for active/inactive display.
+- Use `available` for disabled controls.
+- Show `progress` and `time_left` attributes if present.
+- Use normal problem/consumable entities for alerts.
+
+Lovelace should not inspect `station_activity`, `dock_activity`,
+`task_status`, timer field numbers, or raw Narwal task names.
+
+## PR Scope
+
+A clean upstream PR should include only the dock task model:
+
+- Dock device info.
+- Five task switches.
+- One normalized dock-task state path.
+- Safe start/stop gating.
+- Typed timer attributes on the task switches.
+- Removal or registry cleanup for older dock action buttons and obsolete dock
+  progress/task sensors if they exist on that branch.
+- Tests for the entity contract and safety matrix.
+
+Keep these out of the dock PR:
+
+- Room-specific cleaning settings.
+- Vacuum supported-feature cleanup.
+- Cloud accessory consumables.
+- Tank-state semantic fixes.
+- Trail persistence or native trajectory rendering.

--- a/docs/DOCK_TASK_TEST_PLAN.md
+++ b/docs/DOCK_TASK_TEST_PLAN.md
@@ -1,0 +1,270 @@
+# Narwal Dock Task Test Plan
+
+This plan is for discovering which dock commands can run, stop, and conflict on
+real hardware. It should be run before loosening the integration's conservative
+availability matrix.
+
+Classify every result as:
+
+- `verified`: command result and follow-up telemetry agree, and the result is
+  reproduced.
+- `inferred`: behavior depends on coarse station activity, a local assumption,
+  stale timer data, or a one-off accept/reject result.
+- `unknown`: no safe conclusion.
+
+## Setup
+
+Use a test Home Assistant instance first. Repeat ambiguous cases with a direct
+client script after disabling the HA integration, because Narwal robots allow
+one local connection per client IP.
+
+Enable debug logging for:
+
+```yaml
+logger:
+  logs:
+    custom_components.narwal: debug
+```
+
+For every command attempt, capture state at `T0`, `T+2s`, `T+10s`, and `T+30s`.
+
+Record:
+
+- Service or client call.
+- Command response code and mapped name.
+- Whether the Narwal app shows the same task/state.
+- All five dock switch states and attributes.
+- Vacuum state and attributes, including task summary and supported commands.
+- Raw state fields: `working_status`, `station_activity`, `dock_activity`,
+  `dock_sub_state`, `dock_field11`, `dock_field47`, dock presence and off-dock
+  indicators, active dock timers, assumed dock task, mop drying remaining time,
+  and dock timer freshness.
+
+Preserve log lines about wake, status refresh, command result codes, unmapped
+fields, and post-stop task refresh.
+
+## Controls
+
+Home Assistant services:
+
+- `switch.turn_on` and `switch.turn_off` for each dock task switch.
+- `vacuum.start`
+- `vacuum.pause`
+- `vacuum.stop`
+- `vacuum.return_to_base`
+- `vacuum.locate`
+- `narwal.clean_rooms`
+
+Direct client calls:
+
+- `client.empty_dustbin()`
+- `client.wash_mop()`
+- `client.wash_mop_by_robot_status()`
+- `client.dry_mop()`
+- `client.dry_dust_bag()`
+- `client.dry_station_bag()`
+- `client.stop_dock_task(raw_task)`
+- `client.get_status(full_update=True)`
+- auxiliary mop timer query, if the branch under test exposes one
+
+## Baseline Matrix
+
+| State | Start attempts | Stop attempts | Purpose |
+|---|---|---|---|
+| Docked idle, awake | all five dock tasks | after each successful start | Baseline task support |
+| Docked idle, asleep | all five dock tasks | after each successful start | Wake, refresh, revalidation |
+| Off-dock standby | all five dock tasks | none | Unsafe start rejection |
+| Active robot clean, off dock | all five dock tasks | none | Robot-session gating |
+| Returning to dock | all five dock tasks | none | Transition conflict gating |
+| Charging to resume | all five dock tasks | active task if present | Separate recharge from dock maintenance |
+| Dock-side phase during clean | none | robot stop, matching dock stop | Keep robot cancellation available |
+| Unmapped active station task | all five dock tasks | active task if known | Block unsafe starts |
+| `dry_dock_bag` active | room clean, all other dock tasks | `dry_dock_bag` | Validate robot-compatible dock task |
+| Robot leaves while `dry_dock_bag` active | no dock starts | `dry_dock_bag` | Preserve dock-owned task after departure |
+
+## Conflict Matrix
+
+For each active dock task, try every other dock task:
+
+| Active task | Start `empty_dustbin` | Start `wash_mop` | Start `dry_mop` | Start `dry_dust_bin` | Start `dry_dock_bag` |
+|---|---|---|---|---|---|
+| `empty_dustbin` | n/a | record | record | record | record |
+| `wash_mop` | record | n/a | record | record | record |
+| `dry_mop` | record | record | n/a | record | record |
+| `dry_dust_bin` | record | record | record | n/a | record |
+| `dry_dock_bag` | record | record | record | record | n/a |
+
+For each active dock task, also try:
+
+- `vacuum.start`
+- `narwal.clean_rooms`
+- `vacuum.pause`
+- `vacuum.stop`
+- `vacuum.return_to_base`
+- `vacuum.locate`
+
+Expected conservative default before verification:
+
+- Other dock task starts are unavailable.
+- Robot start is unavailable except during verified `dry_dock_bag`.
+- Robot stop remains available only when the dock task is part of an active
+  robot clean session.
+- Locate and return-to-base should not run while station work would make the
+  result ambiguous.
+
+## Live Evidence
+
+### 2026-08-26, Flow 2 robot A, firmware `v01.09.08.00`
+
+Tested through Home Assistant service calls against a live docked robot:
+
+| Task | Start from idle | Stop from HA | Follow-up state |
+|---|---|---|---|
+| `dry_mop` | verified | verified | task cleared and all dock switches returned to idle |
+| `dry_dock_bag` | verified | verified | scoped `task/force_end` cleared the task; also verified while `dry_mop` remained active |
+| `dry_dust_bin` | verified | verified | scoped `task/force_end` cleared the task; generic robot stop remains blocked |
+
+Notes:
+
+- `dry_mop` exposed a `3h 30m` timer and stopped through the single-task
+  generic stop path.
+- `dry_dock_bag` exposed a `5h` timer. A stale/unmapped coarse station flag
+  initially blocked the scoped stop despite typed dock-bag telemetry; the stop
+  gate was corrected so typed dock-bag force-end is allowed while generic stops
+  remain blocked. The retry returned HTTP 200 and cleared the task.
+- `dry_dust_bin` exposed a `45m` timer and progress. After a bounded payload
+  sweep found `task/force_end` payload `0805`, a fresh start/stop repeat
+  returned success and cleared the task.
+- Parallel dock-task starts were not relaxed. While one task was active, the
+  other task switches were unavailable.
+
+### 2026-08-27, Flow 2 robot B
+
+Tested with Home Assistant Core stopped and a direct local client connected
+from the HA SSH environment. The test started one dock task from idle, sent one
+robot-side command, captured state at roughly `T+2s` and `T+10s`, then cleaned
+up to idle before the next cell.
+
+Verified robot-command behavior while `empty_dustbin` was active:
+
+| Robot command | Response | Follow-up state | Integration rule |
+|---|---|---|---|
+| `locate` | `SUCCESS` | Emptying continued | Safe but optional to expose |
+| `return_to_base` | `CONFLICT` | Emptying continued | Hide while docked/dock task active |
+| `pause` | `SUCCESS` | Emptying cleared/idle | Hide; raw command affects dock work |
+| `stop` | `SUCCESS` | Emptying cleared/idle | Keep on dock switch only, not vacuum entity |
+| `clean/start_clean` | `CONFLICT` | Emptying continued | Hide start/clean-area |
+
+Verified robot-command behavior while `wash_mop` was active:
+
+| Robot command | Response | Follow-up state | Integration rule |
+|---|---|---|---|
+| `locate` | `SUCCESS` | Washing continued | Safe but optional to expose |
+| `return_to_base` | `APPLIED` | Stale paused/docked-looking state | Hide while docked/dock task active |
+| `pause` | `SUCCESS` | Stale paused/docked-looking state | Hide; raw command affects dock work |
+| `stop` | `SUCCESS` | Transitioned into `dry_mop` | Keep stop scoped to dock task controls |
+| `clean/start_clean` | `SUCCESS` | Did not start cleaning; left contradictory dock fields | Hide start/clean-area |
+
+After the raw `clean/start_clean` attempt during `wash_mop`, the robot reported
+`working_status=DOCKED_V2` while explicit dock fields reported off-dock
+(`dock_field11=1`, `dock_field47=2`, later `dock_presence=0`). Recall was
+accepted in that state. The integration must therefore treat explicit off-dock
+fields as stronger than the coarse `DOCKED_V2` value for dock readiness and
+return-home availability.
+
+Drying-task cross-section rows were not considered verified in this run because
+`dry_mop`, `dry_dust_bin`, and `dry_dock_bag` setup starts returned `CONFLICT`
+after the contradictory post-wash state. Their start/stop baseline remains the
+2026-08-26 robot A evidence above until a fresh accepted drying run is
+captured.
+
+Follow-up after redeploying Home Assistant on the cleaned branch: HA reported
+`switch.upstairs_narwal_dock_dry_and_disinfect_dust_bin` as active with live
+`time_left` and `progress` attributes after restart, and the Narwal app
+confirmed the same dust-bin drying task was active. Treat that as real device
+telemetry, not a restored HA switch assumption. Dock task switches should only
+come from robot telemetry or a short accepted-command guard.
+
+## Per-Task Evidence
+
+### Empty dustbin
+
+Verify:
+
+- Start command accepted from docked idle.
+- Active state maps to `emptying_dustbin`.
+- Matching switch turns on.
+- Other dock starts are blocked or rejected.
+- Stop either succeeds or is correctly unavailable.
+- No progress/time attributes are exposed unless telemetry proves them.
+
+### Wash mop
+
+Verify:
+
+- Whether `supply/wash_mop` or `supply/wash_mop_by_robot_status` is required.
+- Active state maps to `washing_mop`.
+- Intermediate mop washing during a clean does not hide robot `stop`.
+- Stop behavior is task-specific or generic single-task only.
+
+### Dry mop
+
+Verify:
+
+- Active state maps to `drying_mop`.
+- Timer fields or mop remaining-time query produce correct `time_left`.
+- Progress is omitted when only remaining time is known.
+- Fresh typed timer suppresses stale coarse `dock_activity`.
+
+### Dry dust bin
+
+Verify:
+
+- Start command accepted from docked idle.
+- Active state maps to `dry_dust_bin`.
+- Timer fields `10/11`, if present, produce `progress` and `time_left`.
+- Polling-only fallback survives the immediate stale post-command refresh.
+- Stop uses scoped `task/force_end`, not generic robot stop.
+- Live 2026-08-26: two Flow 2 runs confirmed `task/force_end` payload
+  `0805` clears `dry_dust_bin` telemetry and keeps it clear.
+
+### Dry dock bag
+
+Verify:
+
+- Start command accepted from docked idle.
+- Active state maps to `dry_dock_bag`.
+- Timer fields `12/13`, if present, produce `progress` and `time_left`.
+- Robot can start a clean while dock-bag drying continues.
+- The switch stays on after the robot leaves the dock if the dock task is still
+  running.
+- Typed stop stops dock-bag drying without cancelling a robot clean.
+
+## Automated Tests
+
+Unit/entity tests should cover:
+
+- Exactly five dock task switches.
+- Dock device ownership and stable unique IDs.
+- Idle, off-dock, robot-cleaning, fault, and unavailable coordinator states.
+- Each known raw task mapping.
+- Unknown active station activity blocks all starts.
+- Malformed, zero, expired, and missing timers do not create false attributes.
+- Typed timers override stale coarse dock activity.
+- Parallel active timers do not allow unscoped stops.
+- Wake paths refresh status and revalidate the selected task before command
+  dispatch.
+- Polling-only command assumptions clear on authoritative idle state or TTL.
+- `dry_dock_bag` is preserved during robot departure only when backed by typed
+  evidence or a bounded accepted-command fallback.
+- Dock maintenance does not create charge-to-resume.
+- Robot stop remains available during active-clean dock phases.
+
+## Separate Work
+
+Keep these topics out of the dock-task PR:
+
+- Room cleaning settings and route-specific clean profiles.
+- Vacuum supported-feature cleanup.
+- Consumables and tank-state semantics.
+- Trail persistence and native trajectory rendering.

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import random
 import time
@@ -13,6 +14,7 @@ import websockets
 import websockets.exceptions
 
 from .const import (
+    ACTIVE_CLEANING_STATUSES,
     BROADCAST_STALE_TIMEOUT,
     COMMAND_RESPONSE_TIMEOUT,
     DEFAULT_PORT,
@@ -28,7 +30,9 @@ from .const import (
     TOPIC_CMD_APP_HEARTBEAT,
     TOPIC_CMD_CANCEL,
     TOPIC_CMD_CLEAN_TASK,
+    TOPIC_CMD_DRY_DUST_BAG,
     TOPIC_CMD_DRY_MOP,
+    TOPIC_CMD_DRY_STATION_BAG,
     TOPIC_CMD_DUST_GATHERING,
     TOPIC_CMD_EASY_CLEAN,
     TOPIC_CMD_FORCE_END,
@@ -50,6 +54,7 @@ from .const import (
     TOPIC_CMD_SET_MOP_HUMIDITY,
     TOPIC_CMD_TAKE_PICTURE,
     TOPIC_CMD_WASH_MOP,
+    TOPIC_CMD_WASH_MOP_BY_ROBOT_STATUS,
     TOPIC_CMD_YELL,
     WAKE_TIMEOUT,
     AmbientLightCtrlType,
@@ -60,7 +65,18 @@ from .const import (
     WorkingStatus,
     WorkMode,
 )
-from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState
+from .models import (
+    DOCK_TASK_DRY_DOCK_BAG,
+    DOCK_TASK_DRY_DUST_BIN,
+    DOCK_TASK_DRY_MOP,
+    DOCK_TASK_EMPTY_DUSTBIN,
+    DOCK_TASK_WASH_MOP,
+    CommandResponse,
+    DeviceInfo,
+    MapData,
+    MapDisplayData,
+    NarwalState,
+)
 from .protocol import (
     PROTOBUF_FIELD5_TAG,
     NarwalMessage,
@@ -78,6 +94,61 @@ _STALE_DOCK_BASE_STATUSES = {
     WorkingStatus.CHARGED,
     WorkingStatus.DOCKED_V2,
 }
+
+_DOCK_TASK_REFRESH_DELAY = 6.0
+_DOCK_TASK_IDENTIFY_ATTEMPTS = 4
+_DOCK_TASK_IDENTIFY_DELAY = 1.5
+_DOCK_TASK_FORCE_END_PAYLOADS = {
+    # Live-validated on Flow 2: the app's ForceEndTask.Request uses field 1
+    # with ParallelTaskType.DRY_STATION_BAG to stop dock-bag drying.
+    DOCK_TASK_DRY_DOCK_BAG: b"\x08\x01",
+    # Live-validated on Flow 2: the app's ForceEndTask.Request uses field 1
+    # with ParallelTaskType.DRY_BAG to stop robot dust-bin drying.
+    DOCK_TASK_DRY_DUST_BIN: b"\x08\x05",
+}
+
+
+def _accepted_response(response: CommandResponse) -> bool:
+    """Return true for response codes that mean the robot accepted a command."""
+    return response.accepted
+
+
+def _clean_session_context(state: NarwalState) -> bool:
+    """Return true while robot-side work or its accepted-command guard is active."""
+    return (
+        state.is_cleaning
+        or state.has_assumed_robot_clean
+        or state.working_status in ACTIVE_CLEANING_STATUSES
+        or state.working_status == WorkingStatus.TASK_COMPLETED
+        or state.has_recent_active_working_status
+        or state.is_returning
+    )
+
+
+def _robot_work_blocks_generic_dock_stop(state: NarwalState) -> bool:
+    """Return true when generic force-end could target robot work, not dock work."""
+    return (
+        state.is_cleaning
+        or state.has_assumed_robot_clean
+        or state.working_status in ACTIVE_CLEANING_STATUSES
+        or state.has_recent_active_working_status
+        or state.is_returning
+    )
+
+
+def _robot_start_blocked(state: NarwalState) -> bool:
+    """Return true when a private guard or dock task blocks a start."""
+    return state.has_assumed_robot_clean or state.blocks_robot_start_for_dock_task
+
+
+def _can_force_end_scoped_dock_task(state: NarwalState, task: str | None) -> bool:
+    """Return true when a typed force-end can safely target a known task."""
+    return task in _DOCK_TASK_FORCE_END_PAYLOADS and task in state.telemetry_dock_task_keys
+
+
+def _has_generic_dock_stop_proof(state: NarwalState) -> bool:
+    """Return true when generic force-end can only target dock-side work."""
+    return state.is_docked and state.has_dock_presence_signal
 
 
 def _base_status_working_status(decoded: dict[str, Any] | object) -> WorkingStatus | None:
@@ -119,6 +190,49 @@ def _base_status_confirms_docked(
         or int_field(field3, "3") in (1, 6)
         or int_field(field3, "10") == 1
         or int_field(field3, "12") > 0
+    )
+
+
+def _base_status_payload(response: CommandResponse) -> dict[str, Any] | None:
+    """Return the decoded robot_base_status payload from a command response."""
+    if not isinstance(response.data, dict):
+        return None
+    status_data = response.data.get("2")
+    if isinstance(status_data, dict) and status_data:
+        return status_data
+    return None
+
+
+def _has_dock_status_payload(response: CommandResponse) -> bool:
+    """Return true when a response carries the dock/base status submessage."""
+    if not response.accepted:
+        return False
+    status_data = _base_status_payload(response)
+    if status_data is None:
+        return False
+    field3 = status_data.get("3")
+    if isinstance(field3, list):
+        field3 = field3[0] if field3 else None
+    if not isinstance(field3, dict):
+        return False
+    return bool({"1", "2", "3", "7", "10", "12", "18"}.intersection(field3))
+
+
+def _dock_status_confirms_idle(state: NarwalState) -> bool:
+    """Return true when fresh dock status reports no active station task."""
+    return (
+        state.station_activity <= 0
+        and state.dock_activity in (0, 2, 6)
+        and state.has_dock_presence_signal
+        and state.working_status
+        in (
+            WorkingStatus.UNKNOWN,
+            WorkingStatus.STANDBY,
+            WorkingStatus.DOCKED,
+            WorkingStatus.CHARGED,
+            WorkingStatus.DOCKED_V2,
+            WorkingStatus.TASK_COMPLETED,
+        )
     )
 
 
@@ -175,6 +289,12 @@ class NarwalClient:
         self._response_queue: asyncio.Queue[NarwalMessage] = asyncio.Queue()
         # Lock to prevent concurrent send_command calls from racing on the queue
         self._command_lock = asyncio.Lock()
+        # Lock high-level action preflight through accepted-command reservation.
+        # The lower command lock only serializes wire traffic; this prevents
+        # direct robot and dock commands from validating the same idle snapshot.
+        self._action_lock = asyncio.Lock()
+        self._dock_task_lock = self._action_lock
+        self._robot_start_lock = self._action_lock
 
     def _full_topic(self, short_topic: str) -> str:
         """Build the full topic path."""
@@ -316,7 +436,7 @@ class NarwalClient:
                 data = await asyncio.wait_for(
                     self._ws.recv(), timeout=min(remaining, 2.0)
                 )
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 # Re-send wake commands, cycling through prefixes
                 try:
                     await self._ws.send(wake_frames[wake_index % len(wake_frames)])
@@ -397,7 +517,7 @@ class NarwalClient:
             try:
                 await asyncio.wait_for(self._ws.recv(), timeout=0.05)
                 drained += 1
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 break
             except Exception:
                 break
@@ -414,10 +534,8 @@ class NarwalClient:
         for task in (self._heartbeat_task, self._keepalive_task, self._listen_task):
             if task and not task.done():
                 task.cancel()
-                try:
+                with contextlib.suppress(asyncio.CancelledError):
                     await task
-                except asyncio.CancelledError:
-                    pass
 
         if self._ws:
             await self._ws.close()
@@ -955,7 +1073,7 @@ class NarwalClient:
                     msg = await asyncio.wait_for(
                         self._response_queue.get(), timeout=timeout
                     )
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     raise NarwalCommandError(
                         f"No response for command '{short_topic}' within {timeout}s"
                     ) from None
@@ -1001,7 +1119,7 @@ class NarwalClient:
                 data = await asyncio.wait_for(
                     self._ws.recv(), timeout=min(remaining, 1.0)
                 )
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 continue
 
             if not isinstance(data, bytes) or len(data) < 4:
@@ -1098,6 +1216,12 @@ class NarwalClient:
             "start(): no map rooms available; falling back to clean/plan/start, "
             "which re-runs the robot's saved plan rather than cleaning every room"
         )
+        if self.state.blocks_robot_start_for_dock_task:
+            _LOGGER.warning(
+                "start(): dock task active (%s); not starting saved plan",
+                self.state.active_dock_task_keys or "unmapped",
+            )
+            return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
         return await self.send_command(
             TOPIC_CMD_PLAN_START,
             payload=self._DEFAULT_CLEAN_PAYLOAD,
@@ -1125,6 +1249,12 @@ class NarwalClient:
         plan-runner that discards payloads (#66), so it survives only as a
         last-resort fallback when no map rooms are known.
         """
+        if _robot_start_blocked(self.state):
+            _LOGGER.warning(
+                "start: robot or dock task active (%s); not starting whole-house clean",
+                self.state.active_dock_task_keys or "unmapped",
+            )
+            return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
         room_ids = await self._all_room_ids()
         if not room_ids:
             return await self._start_saved_plan()
@@ -1349,44 +1479,63 @@ class NarwalClient:
             # No rooms selected — do not call start(), which would resolve the
             # full room list and come straight back here.
             return await self._start_saved_plan()
-
-        map_data = self.state.map_data
-        if not map_data or not map_data.map_id:
-            map_data = await self.get_map()
-        map_id = map_data.map_id if map_data else 0
-        if not map_id:
-            _LOGGER.warning(
-                "start_rooms: no active map id available; cannot start room clean"
-            )
-            return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
-
-        payload = self._build_start_clean_payload(
-            room_ids, map_id, work_mode=work_mode, fan=fan, water=water,
-            mop_strength=mop_strength, passes=passes,
-        )
-        resp = await self.send_command(
-            TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
-        )
-        for _ in range(3):
-            if resp.result_code != CommandResult.NOT_READY:
-                break
-            if not self.state.is_docked:
+        async with self._robot_start_lock:
+            if _robot_start_blocked(self.state):
                 _LOGGER.warning(
-                    "start_rooms: robot not docked (status=%s); clean/start_clean "
-                    "requires the robot on the dock",
-                    self.state.working_status.name,
+                    "start_rooms: robot or dock guard active (%s); not starting room clean",
+                    self.state.active_dock_task_keys or "private",
                 )
-                break
-            _LOGGER.info("start_rooms: robot docking/settling, retrying clean/start_clean")
-            await asyncio.sleep(3.0)
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+
+            map_data = self.state.map_data
+            if not map_data or not map_data.map_id:
+                map_data = await self.get_map()
+            map_id = map_data.map_id if map_data else 0
+            if not map_id:
+                _LOGGER.warning(
+                    "start_rooms: no active map id available; cannot start room clean"
+                )
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+
+            payload = self._build_start_clean_payload(
+                room_ids, map_id, work_mode=work_mode, fan=fan, water=water,
+                mop_strength=mop_strength, passes=passes,
+            )
             resp = await self.send_command(
                 TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
             )
-        return resp
+            for _ in range(3):
+                if resp.result_code != CommandResult.NOT_READY:
+                    break
+                if not self.state.is_docked:
+                    _LOGGER.warning(
+                        "start_rooms: robot not docked (status=%s); clean/start_clean "
+                        "requires the robot on the dock",
+                        self.state.working_status.name,
+                    )
+                    break
+                _LOGGER.info("start_rooms: robot docking/settling, retrying clean/start_clean")
+                await asyncio.sleep(3.0)
+                resp = await self.send_command(
+                    TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
+                )
+            if _accepted_response(resp):
+                self.state.assume_robot_clean()
+            return resp
 
     async def start_easy_clean(self) -> CommandResponse:
         """Start quick/easy clean."""
-        return await self.send_command(TOPIC_CMD_EASY_CLEAN)
+        async with self._robot_start_lock:
+            if _robot_start_blocked(self.state):
+                _LOGGER.warning(
+                    "start_easy_clean: robot or dock guard active (%s); not starting quick clean",
+                    self.state.active_dock_task_keys or "private",
+                )
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            response = await self.send_command(TOPIC_CMD_EASY_CLEAN)
+            if _accepted_response(response):
+                self.state.assume_robot_clean()
+            return response
 
     async def pause(self) -> CommandResponse:
         """Pause current task."""
@@ -1407,6 +1556,117 @@ class NarwalClient:
     async def cancel(self) -> CommandResponse:
         """Cancel current task."""
         return await self.send_command(TOPIC_CMD_CANCEL)
+
+    async def _refresh_after_dock_stop(self) -> bool:
+        """Refresh robot state after a dock stop command."""
+        try:
+            response = await self.get_status(
+                full_update=not self.state.has_recent_active_working_status
+            )
+        except (NarwalCommandError, NarwalConnectionError) as err:
+            _LOGGER.debug("Status refresh after dock stop failed: %s", err)
+            return False
+        return _has_dock_status_payload(response)
+
+    def _should_wait_for_scoped_dock_task(self, task: str | None) -> bool:
+        """Return true when a typed scoped-stop target may still be settling."""
+        if task not in _DOCK_TASK_FORCE_END_PAYLOADS:
+            return False
+        if task in self.state.telemetry_dock_task_keys:
+            return False
+        if task == self.state.assumed_active_dock_task:
+            return True
+        if self.state.has_unmapped_active_dock_task:
+            return True
+        if task == DOCK_TASK_DRY_DUST_BIN and self.state.dock_activity == 6:
+            return True
+        return self.state.station_activity == 4 and not self.state.active_dock_drying_tasks
+
+    async def _refresh_before_dock_stop(
+        self,
+        task: str | None,
+    ) -> CommandResponse:
+        """Refresh dock state, allowing typed scoped-stop telemetry to settle."""
+        response = await self.get_status(
+            full_update=not self.state.has_recent_active_working_status
+        )
+        if not response.accepted or not _has_dock_status_payload(response):
+            return response
+        if not self._should_wait_for_scoped_dock_task(task):
+            return response
+
+        for _ in range(_DOCK_TASK_IDENTIFY_ATTEMPTS):
+            await asyncio.sleep(_DOCK_TASK_IDENTIFY_DELAY)
+            response = await self.get_status(
+                full_update=not self.state.has_recent_active_working_status
+            )
+            if not response.accepted or not _has_dock_status_payload(response):
+                return response
+            if not self._should_wait_for_scoped_dock_task(task):
+                return response
+        return response
+
+    async def stop_dock_task(self, task: str | None = None) -> CommandResponse:
+        """Stop the active dock task without targeting a different task."""
+        async with self._dock_task_lock:
+            if (
+                self.state.has_unmapped_active_dock_task
+                and task not in _DOCK_TASK_FORCE_END_PAYLOADS
+                and not _can_force_end_scoped_dock_task(self.state, task)
+            ):
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            refresh = await self._refresh_before_dock_stop(task)
+            if not refresh.accepted:
+                return refresh
+            if not _has_dock_status_payload(refresh):
+                return CommandResponse(
+                    result_code=CommandResult.NOT_READY,
+                    data=refresh.data,
+                    raw_payload=refresh.raw_payload,
+                )
+            if self.state.has_unmapped_active_dock_task and not (
+                _can_force_end_scoped_dock_task(self.state, task)
+            ):
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            active_tasks = self.state.active_dock_task_keys
+            if task is not None and task not in active_tasks:
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            if task is None and len(active_tasks) != 1:
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            active_task = task or (active_tasks[0] if active_tasks else None)
+            if active_task is None:
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            if (
+                _robot_work_blocks_generic_dock_stop(self.state)
+                and active_task not in _DOCK_TASK_FORCE_END_PAYLOADS
+            ):
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+
+            payload = _DOCK_TASK_FORCE_END_PAYLOADS.get(active_task)
+            if payload is None:
+                if active_task == DOCK_TASK_DRY_DUST_BIN:
+                    return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+                if not _has_generic_dock_stop_proof(self.state):
+                    return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+                if len(active_tasks) > 1:
+                    return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+                response = await self.stop(timeout=15.0)
+            else:
+                if active_task not in self.state.telemetry_dock_task_keys:
+                    return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+                response = await self.send_command(
+                    TOPIC_CMD_FORCE_END,
+                    payload=payload,
+                    timeout=15.0,
+                )
+
+            await asyncio.sleep(_DOCK_TASK_REFRESH_DELAY)
+            refreshed = await self._refresh_after_dock_stop()
+            if _accepted_response(response):
+                self.state.clear_assumed_dock_task(active_task)
+                if refreshed and _dock_status_confirms_idle(self.state):
+                    self.state.clear_dock_drying_task(active_task)
+            return response
 
     async def return_to_base(self, timeout: float = COMMAND_RESPONSE_TIMEOUT) -> CommandResponse:
         """Return to charging dock."""
@@ -1434,15 +1694,81 @@ class NarwalClient:
 
     async def wash_mop(self) -> CommandResponse:
         """Wash the mop pads at the station."""
-        return await self.send_command(TOPIC_CMD_WASH_MOP)
+        return await self._start_dock_task(DOCK_TASK_WASH_MOP, TOPIC_CMD_WASH_MOP)
+
+    async def wash_mop_by_robot_status(self) -> CommandResponse:
+        """Wash mop pads using the app's status-gated station command."""
+        return await self._start_dock_task(
+            DOCK_TASK_WASH_MOP,
+            TOPIC_CMD_WASH_MOP_BY_ROBOT_STATUS,
+        )
 
     async def dry_mop(self) -> CommandResponse:
         """Dry the mop pads at the station."""
-        return await self.send_command(TOPIC_CMD_DRY_MOP)
+        return await self._start_dock_task(DOCK_TASK_DRY_MOP, TOPIC_CMD_DRY_MOP)
+
+    async def dry_dust_bag(self) -> CommandResponse:
+        """Dry or disinfect the robot dust bin at the station."""
+        return await self._start_dock_task(
+            DOCK_TASK_DRY_DUST_BIN,
+            TOPIC_CMD_DRY_DUST_BAG,
+        )
+
+    async def dry_station_bag(self) -> CommandResponse:
+        """Dry or disinfect the dock dust bag at the station."""
+        return await self._start_dock_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            TOPIC_CMD_DRY_STATION_BAG,
+        )
 
     async def empty_dustbin(self) -> CommandResponse:
         """Empty the dustbin at the station."""
-        return await self.send_command(TOPIC_CMD_DUST_GATHERING)
+        return await self._start_dock_task(
+            DOCK_TASK_EMPTY_DUSTBIN,
+            TOPIC_CMD_DUST_GATHERING,
+        )
+
+    async def _start_dock_task(self, task: str, topic: str) -> CommandResponse:
+        """Start one dock task after atomically validating reported state."""
+        async with self._dock_task_lock:
+            if not self._can_start_dock_task(task):
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            refresh = await self.get_status(
+                full_update=not self.state.has_recent_active_working_status
+            )
+            if not refresh.accepted:
+                return refresh
+            if not _has_dock_status_payload(refresh):
+                return CommandResponse(
+                    result_code=CommandResult.NOT_READY,
+                    data=refresh.data,
+                    raw_payload=refresh.raw_payload,
+                )
+            if not self._can_start_dock_task(task):
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            response = await self.send_command(topic)
+            if _accepted_response(response):
+                self.state.assume_dock_task(task)
+            return response
+
+    def _can_start_dock_task(self, task: str) -> bool:
+        """Return true when reported state permits a new dock-side command."""
+        state = self.state
+        if state.has_error or state.working_status in (
+            WorkingStatus.ERROR,
+            WorkingStatus.UNKNOWN,
+        ):
+            return False
+        if not state.is_docked or _clean_session_context(state):
+            return False
+        if state.has_unmapped_active_dock_task:
+            return False
+        if state.assumed_active_dock_task is not None:
+            return False
+        active_tasks = set(state.active_dock_task_keys)
+        if task in active_tasks:
+            return False
+        return not active_tasks
 
     # --- Query commands ---
 
@@ -1489,8 +1815,8 @@ class NarwalClient:
                 working_status in the response may be stale.
         """
         resp = await self.send_command(TOPIC_CMD_GET_BASE_STATUS)
-        status_data = resp.data.get("2", {})
-        if status_data:
+        status_data = _base_status_payload(resp)
+        if status_data is not None:
             # Log the whole field map, not a chosen few: field-level bug reports
             # (wrong tank state, a value we don't map) are unanswerable from a log
             # that omits the field in question — see #77.
@@ -1507,6 +1833,12 @@ class NarwalClient:
                 self.state.update_battery_from_base_status(status_data)
         else:
             _LOGGER.debug("get_status response has no field 2; keys: %s", list(resp.data.keys()))
+            if resp.accepted:
+                return CommandResponse(
+                    result_code=CommandResult.NOT_READY,
+                    data=resp.data,
+                    raw_payload=resp.raw_payload,
+                )
         return resp
 
     async def get_current_task(self) -> CommandResponse:

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -1668,7 +1668,12 @@ class NarwalClient:
             refreshed = await self._refresh_after_dock_stop()
             if _accepted_response(response):
                 self.state.clear_assumed_dock_task(active_task)
-                if refreshed and _dock_status_confirms_idle(self.state):
+                # Scoped force-end acknowledges the exact drying task. Clear its
+                # cached timer after a fresh dock response instead of waiting for
+                # the old timer snapshot to expire.
+                if refreshed and (
+                    payload is not None or _dock_status_confirms_idle(self.state)
+                ):
                     self.state.clear_dock_drying_task(active_task)
             return response
 

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -1216,17 +1216,21 @@ class NarwalClient:
             "start(): no map rooms available; falling back to clean/plan/start, "
             "which re-runs the robot's saved plan rather than cleaning every room"
         )
-        if self.state.blocks_robot_start_for_dock_task:
-            _LOGGER.warning(
-                "start(): dock task active (%s); not starting saved plan",
-                self.state.active_dock_task_keys or "unmapped",
+        async with self._robot_start_lock:
+            if _robot_start_blocked(self.state):
+                _LOGGER.warning(
+                    "start(): robot or dock guard active (%s); not starting saved plan",
+                    self.state.active_dock_task_keys or "private",
+                )
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            response = await self.send_command(
+                TOPIC_CMD_PLAN_START,
+                payload=self._DEFAULT_CLEAN_PAYLOAD,
+                timeout=10.0,
             )
-            return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
-        return await self.send_command(
-            TOPIC_CMD_PLAN_START,
-            payload=self._DEFAULT_CLEAN_PAYLOAD,
-            timeout=10.0,
-        )
+            if _accepted_response(response):
+                self.state.assume_robot_clean()
+            return response
 
     async def start(
         self,

--- a/narwal_client/const.py
+++ b/narwal_client/const.py
@@ -86,7 +86,10 @@ TOPIC_CMD_CANCEL = "task/cancel"
 TOPIC_CMD_AMBIENT_LIGHT_CTRL = "supply/ambient_light_ctrl"
 TOPIC_CMD_RECALL = "supply/recall"
 TOPIC_CMD_WASH_MOP = "supply/wash_mop"
+TOPIC_CMD_WASH_MOP_BY_ROBOT_STATUS = "supply/wash_mop_by_robot_status"
 TOPIC_CMD_DRY_MOP = "supply/dry_mop"
+TOPIC_CMD_DRY_DUST_BAG = "supply/dry_dust_bag"
+TOPIC_CMD_DRY_STATION_BAG = "supply/dry_station_bag"
 TOPIC_CMD_DUST_GATHERING = "supply/dust_gathering"
 
 # Cleaning (Pita protocol — correct for AX12)

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import struct
 import time
 from dataclasses import dataclass, field
 from typing import Any, ClassVar
+
+from .const import (
+    ACTIVE_CLEANING_STATUSES,
+    CommandResult,
+    WorkingStatus,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -15,15 +22,39 @@ _LOGGER = logging.getLogger(__name__)
 # identical lines (#46). Warn once per distinct value instead.
 _WARNED_WORKING_STATUS: set[Any] = set()
 
-from .const import (
-    ACTIVE_CLEANING_STATUSES,
-    CommandResult,
-    FanLevel,
-    MopHumidity,
-    WorkingStatus,
-)
-
 _ACTIVE_WORKING_STATUS_TTL = 15.0
+_DOCK_DRYING_STATUS_TTL = 180.0
+_DOCK_TASK_ASSUME_TTL = 30.0
+_ROBOT_START_ASSUME_TTL = 30.0
+_KNOWN_DOCK_ACTIVITY_VALUES = {0, 2, 3, 4, 6}
+
+DOCK_TASK_EMPTY_DUSTBIN = "empty_dustbin"
+DOCK_TASK_WASH_MOP = "wash_mop"
+DOCK_TASK_DRY_MOP = "dry_mop"
+DOCK_TASK_DRY_DUST_BIN = "dry_dust_bin"
+DOCK_TASK_DRY_DOCK_BAG = "dry_dock_bag"
+
+DOCK_TASK_KEYS = (
+    DOCK_TASK_EMPTY_DUSTBIN,
+    DOCK_TASK_WASH_MOP,
+    DOCK_TASK_DRY_MOP,
+    DOCK_TASK_DRY_DUST_BIN,
+    DOCK_TASK_DRY_DOCK_BAG,
+)
+_DOCK_DRYING_TASK_ORDER = (
+    DOCK_TASK_DRY_MOP,
+    DOCK_TASK_DRY_DUST_BIN,
+    DOCK_TASK_DRY_DOCK_BAG,
+)
+_DOCK_DRYING_TIMER_PAIRS: tuple[tuple[str, str, str], ...] = (
+    (DOCK_TASK_DRY_MOP, "8", "9"),
+    (DOCK_TASK_DRY_DUST_BIN, "10", "11"),
+    (DOCK_TASK_DRY_DOCK_BAG, "12", "13"),
+)
+_UNMAPPED_DOCK_DRYING_TIMER_PAIRS: tuple[tuple[str, str], ...] = (
+    ("14", "15"),
+    ("16", "17"),
+)
 
 
 @dataclass
@@ -33,6 +64,34 @@ class DeviceInfo:
     product_key: str = ""
     device_id: str = ""
     firmware_version: str = ""
+
+
+@dataclass(frozen=True)
+class DockTaskTimer:
+    """Timer details for one active dock task."""
+
+    task: str
+    elapsed: int
+    target: int
+    fields: tuple[str, str]
+    observed_at: float = field(default_factory=time.monotonic)
+
+    @property
+    def current_elapsed(self) -> int:
+        """Return the elapsed seconds reported by the latest timer snapshot."""
+        return min(self.target, max(0, self.elapsed))
+
+    @property
+    def remaining(self) -> int:
+        """Return remaining seconds, clamped at zero."""
+        return max(0, self.target - self.current_elapsed)
+
+    @property
+    def progress_percent(self) -> int:
+        """Return elapsed task progress as an integer percentage."""
+        if self.target <= 0:
+            return 0
+        return min(100, round(self.current_elapsed / self.target * 100))
 
 
 @dataclass
@@ -53,7 +112,10 @@ class RoomInfo:
     category: int = 0  # 1=room, 2=utility (field 4)
     instance_index: int = 0  # numbering for duplicates (field 8)
 
-    # RoomType enum (MapBaseType.RoomType, 0-15) → the app's own en-US.json room-name strings. One shared switch (map_engine_i18n_configer.roomTypei18nKey) takes no model parameter, so every model resolves these same names. See #22.
+    # RoomType enum (MapBaseType.RoomType, 0-15) to the app's own en-US.json
+    # room-name strings. One shared switch
+    # (map_engine_i18n_configer.roomTypei18nKey) takes no model parameter, so
+    # every model resolves these same names. See #22.
     ROOM_TYPE_NAMES: ClassVar[dict[int, str]] = {
         0: "Room",
         1: "Master bedroom",
@@ -75,7 +137,7 @@ class RoomInfo:
 
     @property
     def display_name(self) -> str:
-        """User name if set, else the RoomType default name, with an instance-number suffix for duplicates ("Bathroom 2")."""
+        """User name, or default RoomType name with suffix for duplicates."""
         if self.name:
             return self.name
         base = self.ROOM_TYPE_NAMES.get(self.room_sub_type, "Room")
@@ -181,6 +243,59 @@ def _to_float32(val: Any) -> float | None:
         except struct.error:
             return None
     return None
+
+
+def _optional_int(value: Any) -> int | None:
+    """Coerce a protobuf scalar to int when possible."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _dock_drying_timers(decoded: dict[str, Any]) -> dict[str, DockTaskTimer]:
+    """Return active dock drying timers from a working-status packet."""
+    timers: dict[str, DockTaskTimer] = {}
+    for task, elapsed_field, target_field in _DOCK_DRYING_TIMER_PAIRS:
+        elapsed = _optional_int(decoded.get(elapsed_field))
+        target = _optional_int(decoded.get(target_field))
+        if elapsed is None or target is None:
+            continue
+        if target <= 0 or elapsed < 0 or elapsed > target:
+            continue
+        if elapsed > 0:
+            timers[task] = DockTaskTimer(
+                task,
+                elapsed,
+                target,
+                (elapsed_field, target_field),
+            )
+    return timers
+
+
+def _has_dock_drying_timer_fields(decoded: dict[str, Any]) -> bool:
+    """Return true when a packet contains any dock timer field."""
+    return any(
+        _optional_int(decoded.get(elapsed_field)) is not None
+        or _optional_int(decoded.get(target_field)) is not None
+        for _, elapsed_field, target_field in _DOCK_DRYING_TIMER_PAIRS
+    ) or any(
+        _optional_int(decoded.get(elapsed_field)) is not None
+        or _optional_int(decoded.get(target_field)) is not None
+        for elapsed_field, target_field in _UNMAPPED_DOCK_DRYING_TIMER_PAIRS
+    )
+
+
+def _has_unmapped_dock_drying_timer(decoded: dict[str, Any]) -> bool:
+    """Return true when an unmapped dock timer pair reports active work."""
+    for elapsed_field, target_field in _UNMAPPED_DOCK_DRYING_TIMER_PAIRS:
+        elapsed = _optional_int(decoded.get(elapsed_field))
+        target = _optional_int(decoded.get(target_field))
+        if elapsed is None or target is None:
+            continue
+        if 0 < elapsed < target:
+            return True
+    return False
 
 
 def _packed_varints(raw: bytes) -> list[int]:
@@ -331,14 +446,10 @@ class MapData:
         origin_y = 0
         field6 = payload.get("6")
         if isinstance(field6, dict):
-            try:
+            with contextlib.suppress(ValueError, TypeError):
                 origin_x = int(field6.get("3", 0))
-            except (ValueError, TypeError):
-                pass
-            try:
+            with contextlib.suppress(ValueError, TypeError):
                 origin_y = int(field6.get("1", 0))
-            except (ValueError, TypeError):
-                pass
 
         # Parse dock position from field 8 (dock/charging station location).
         # Field 8 structure: {1: {1: x_dm, 2: y_dm}, 2: heading_rad}
@@ -474,10 +585,8 @@ class MapDisplayData:
 
         # Timestamp — field 10 (milliseconds since epoch)
         if "10" in decoded:
-            try:
+            with contextlib.suppress(ValueError, TypeError):
                 result.timestamp = int(decoded["10"])
-            except (ValueError, TypeError):
-                pass
 
         return result
 
@@ -502,6 +611,11 @@ class CommandResponse:
     @property
     def success(self) -> bool:
         return self.result_code == CommandResult.SUCCESS
+
+    @property
+    def accepted(self) -> bool:
+        """Return true when Narwal accepted or applied the command."""
+        return self.result_code in (0, CommandResult.SUCCESS, CommandResult.APPLIED)
 
     @property
     def not_applicable(self) -> bool:
@@ -580,6 +694,19 @@ class NarwalState:
     # Dock activity (field 3 sub-field 12: 2/6 observed when docked)
     dock_activity: int = 0
 
+    # Station activity (field 3 sub-field 18).
+    # Observed: 1 during dust gathering, 4 during dock dry/disinfection work.
+    station_activity: int = 0
+
+    # Dock task timers from working_status fields 8..13.
+    dock_drying_tasks: dict[str, DockTaskTimer] = field(default_factory=dict)
+    dock_drying_status_time: float = 0.0
+    has_dock_drying_timer_snapshot: bool = False
+    has_unmapped_dock_drying_timer: bool = False
+    assumed_dock_task: str = ""
+    assumed_dock_task_until: float = 0.0
+    assumed_robot_clean_until: float = 0.0
+
     # Dock presence (field 3 sub-field 3)
     # Values observed: 1=on dock, 2=off dock, 6=on dock (charged idle)
     dock_presence: int = 0
@@ -639,11 +766,27 @@ class NarwalState:
         )
 
     @property
+    def has_explicit_off_dock_signal(self) -> bool:
+        """True when dock telemetry explicitly says the robot is not seated."""
+        if (
+            self.dock_sub_state == 1
+            or self.dock_field11 >= 2
+            or self.dock_field47 in (1, 3)
+        ):
+            return False
+        return (
+            self.dock_presence == 2
+            or self.dock_sub_state == 2
+            or (self.dock_field11 == 1 and self.dock_field47 == 2)
+        )
+
+    @property
     def is_docked(self) -> bool:
         """True when on dock: DOCKED(10), CHARGED(14), DOCKED_V2(2), or dock field signals.
 
         Dock signals (checked for STANDBY, UNKNOWN, and any unmapped status):
           - dock_sub_state == 1 (field 3.10, old FW only)
+          - dock_presence in (1, 6) (field 3.3, dock-present variants)
           - dock_activity > 0 (field 3.12, old FW only)
           - dock_field11 >= 2 (field 11: old FW 2=docked/1=undocked,
                                v01.07.23 3=docked)
@@ -654,6 +797,8 @@ class NarwalState:
         cleaning is not active, since the robot can report unmapped states
         (e.g. self-test) while physically docked.
         """
+        if self.has_explicit_off_dock_signal:
+            return False
         if self.working_status in (
             WorkingStatus.DOCKED, WorkingStatus.CHARGED, WorkingStatus.DOCKED_V2,
         ):
@@ -668,13 +813,26 @@ class NarwalState:
         #   v01.07.23.00: dock_sub_state absent, dock_field11=3, dock_field47=1
         if self.dock_sub_state == 1:
             return True
+        if self.dock_presence in (1, 6):
+            return True
         if self.dock_activity > 0:
             return True
         if self.dock_field11 >= 2:
             return True
-        if self.dock_field47 in (1, 3):
-            return True
-        return False
+        return self.dock_field47 in (1, 3)
+
+    @property
+    def has_dock_presence_signal(self) -> bool:
+        """True when any field reports the robot is on the dock."""
+        if self.has_explicit_off_dock_signal:
+            return False
+        return (
+            self.dock_presence in (1, 6)
+            or self.dock_sub_state == 1
+            or self.dock_activity > 0
+            or self.dock_field11 >= 2
+            or self.dock_field47 in (1, 3)
+        )
 
     @property
     def is_returning(self) -> bool:
@@ -696,6 +854,201 @@ class NarwalState:
         if self.working_status not in ACTIVE_CLEANING_STATUSES:
             return False
         return self.is_returning_to_dock and self.dock_sub_state == 2
+
+    @property
+    def is_station_active(self) -> bool:
+        """True when the dock/base station is running a dock-side task."""
+        return (
+            self.is_washing_mop
+            or self.is_drying_mop
+            or bool(self.active_dock_drying_tasks)
+            or (
+                self.station_activity > 0
+                and not (
+                    self.station_activity == 4
+                    and self.has_fresh_idle_dock_drying_snapshot
+                )
+            )
+        )
+
+    @property
+    def blocks_robot_start_for_dock_task(self) -> bool:
+        """True when dock-side activity should block a new robot clean."""
+        if self.has_unmapped_active_dock_task:
+            return True
+        if self.assumed_active_dock_task is not None:
+            return True
+        telemetry_tasks = set(self.telemetry_dock_task_keys)
+        if not telemetry_tasks:
+            return False
+        return not (
+            telemetry_tasks == {DOCK_TASK_DRY_DOCK_BAG}
+            and self.has_recent_dock_drying_status
+            and self.dock_task_timer(DOCK_TASK_DRY_DOCK_BAG) is not None
+        )
+
+    @property
+    def is_washing_mop(self) -> bool:
+        """True when the dock is washing the mop pads."""
+        return self.station_activity in (2, 3) or self.dock_activity == 3
+
+    @property
+    def is_drying_mop(self) -> bool:
+        """True when the dock is drying the mop pads."""
+        if self.dock_task_timer(DOCK_TASK_DRY_MOP) is not None:
+            return True
+        if self.has_recent_dock_drying_status and self.has_dock_drying_timer_snapshot:
+            return False
+        return self.dock_activity == 4
+
+    @property
+    def active_dock_task_keys(self) -> tuple[str, ...]:
+        """Return active known dock task keys from telemetry and accepted guards."""
+        tasks = set(self.telemetry_dock_task_keys)
+        if assumed := self.assumed_active_dock_task:
+            tasks.add(assumed)
+        return tuple(task for task in DOCK_TASK_KEYS if task in tasks)
+
+    @property
+    def telemetry_dock_task_keys(self) -> tuple[str, ...]:
+        """Return active dock task keys from robot telemetry only."""
+        tasks: list[str] = []
+        if self.station_activity == 1:
+            tasks.append(DOCK_TASK_EMPTY_DUSTBIN)
+        if self.is_washing_mop:
+            tasks.append(DOCK_TASK_WASH_MOP)
+        tasks.extend(self.telemetry_dock_drying_tasks)
+        if self.is_drying_mop and DOCK_TASK_DRY_MOP not in tasks:
+            tasks.append(DOCK_TASK_DRY_MOP)
+        active = set(tasks)
+        return tuple(task for task in DOCK_TASK_KEYS if task in active)
+
+    @property
+    def has_unmapped_active_dock_task(self) -> bool:
+        """True when station work is active but not mapped to one of five tasks."""
+        if self.has_unmapped_dock_drying_timer and self.has_recent_dock_drying_status:
+            return True
+        if self.dock_activity not in _KNOWN_DOCK_ACTIVITY_VALUES:
+            return True
+        if self.station_activity <= 0:
+            return False
+        if self.station_activity in (1, 2, 3):
+            return False
+        if self.station_activity == 4 and self.has_fresh_idle_dock_drying_snapshot:
+            return False
+        return not (self.station_activity == 4 and self.active_dock_drying_tasks)
+
+    @property
+    def active_dock_drying_tasks(self) -> tuple[str, ...]:
+        """Return active dock drying/disinfection tasks from telemetry only."""
+        return self.telemetry_dock_drying_tasks
+
+    @property
+    def telemetry_dock_drying_tasks(self) -> tuple[str, ...]:
+        """Return active dock drying/disinfection tasks from telemetry only."""
+        tasks = [
+            task
+            for task in _DOCK_DRYING_TASK_ORDER
+            if self.dock_task_timer(task) is not None
+        ]
+        return tuple(tasks)
+
+    @property
+    def assumed_active_dock_task(self) -> str | None:
+        """Return a short accepted-command dock task reservation, if valid."""
+        if not self.assumed_dock_task:
+            return None
+        if time.monotonic() > self.assumed_dock_task_until:
+            return None
+        return self.assumed_dock_task
+
+    @property
+    def assumed_active_dock_drying_task(self) -> str | None:
+        """Return an assumed dock drying task, if the reservation is drying."""
+        assumed = self.assumed_active_dock_task
+        if assumed in _DOCK_DRYING_TASK_ORDER:
+            return assumed
+        return None
+
+    @property
+    def has_recent_dock_drying_status(self) -> bool:
+        """True while live dock drying timer fields are still fresh."""
+        return (
+            self.dock_drying_status_time > 0
+            and time.monotonic() - self.dock_drying_status_time
+            <= _DOCK_DRYING_STATUS_TTL
+        )
+
+    @property
+    def has_fresh_idle_dock_drying_snapshot(self) -> bool:
+        """True when fresh typed timer telemetry says no drying task is active."""
+        return (
+            self.has_recent_dock_drying_status
+            and self.has_dock_drying_timer_snapshot
+            and not self.telemetry_dock_drying_tasks
+        )
+
+    @property
+    def has_assumed_robot_clean(self) -> bool:
+        """Return a short accepted-command robot-clean reservation."""
+        return (
+            self.assumed_robot_clean_until > 0
+            and time.monotonic() <= self.assumed_robot_clean_until
+        )
+
+    def assume_robot_clean(self) -> None:
+        """Temporarily reserve robot-clean command context after an accepted start."""
+        self.assumed_robot_clean_until = time.monotonic() + _ROBOT_START_ASSUME_TTL
+
+    def clear_assumed_robot_clean(self) -> None:
+        """Clear the local robot-clean command reservation."""
+        self.assumed_robot_clean_until = 0.0
+
+    def dock_task_timer(self, task: str) -> DockTaskTimer | None:
+        """Return timer details for one active dock task."""
+        timer = self.dock_drying_tasks.get(task)
+        if timer is None or timer.remaining <= 0:
+            return None
+        if not self.has_recent_dock_drying_status:
+            return None
+        if task == DOCK_TASK_DRY_DOCK_BAG:
+            return timer
+        if not self.has_dock_presence_signal and not self.is_docked:
+            return None
+        return timer
+
+    def set_dock_drying_task(
+        self,
+        task: str,
+        elapsed: int,
+        target: int,
+        fields: tuple[str, str],
+    ) -> None:
+        """Set one dock drying timer from typed telemetry or a test fixture."""
+        self.dock_drying_tasks[task] = DockTaskTimer(task, elapsed, target, fields)
+        self.dock_drying_status_time = time.monotonic()
+
+    def clear_dock_drying_task(self, task: str | None = None) -> None:
+        """Clear one or all dock drying timers."""
+        if task is None:
+            self.dock_drying_tasks.clear()
+        else:
+            self.dock_drying_tasks.pop(task, None)
+        if not self.dock_drying_tasks:
+            self.dock_drying_status_time = 0.0
+            self.has_dock_drying_timer_snapshot = False
+
+    def assume_dock_task(self, task: str, *, ttl: float = _DOCK_TASK_ASSUME_TTL) -> None:
+        """Briefly reserve a dock task after an accepted command."""
+        self.assumed_dock_task = task
+        self.assumed_dock_task_until = time.monotonic() + ttl
+
+    def clear_assumed_dock_task(self, task: str | None = None) -> None:
+        """Clear a local dock task reservation."""
+        if task is not None and task != self.assumed_dock_task:
+            return
+        self.assumed_dock_task = ""
+        self.assumed_dock_task_until = 0.0
 
     @property
     def current_room_name(self) -> str | None:
@@ -726,6 +1079,16 @@ class NarwalState:
         not area — reading it as area is why the sensor was stuck at 1.8 m².
         """
         self.raw_working_status = decoded
+        if _has_dock_drying_timer_fields(decoded):
+            timers = _dock_drying_timers(decoded)
+            self.dock_drying_tasks = timers
+            self.has_dock_drying_timer_snapshot = True
+            self.has_unmapped_dock_drying_timer = _has_unmapped_dock_drying_timer(
+                decoded
+            )
+            self.dock_drying_status_time = time.monotonic()
+            if timers:
+                self.clear_assumed_dock_task()
         # Only a positive session counter is evidence of an active clean. Field
         # presence alone is not: a robot reporting timeConsuming=0 would
         # otherwise be flipped to CLEANING and shown as running while parked.
@@ -752,10 +1115,13 @@ class NarwalState:
         if active_payload:
             self.working_status = WorkingStatus.CLEANING
             self.last_active_working_status_time = time.monotonic()
+            self.clear_assumed_robot_clean()
             self.is_paused = False
             self.is_returning_to_dock = False
             self.dock_sub_state = 0
             self.dock_activity = 0
+            self.station_activity = 0
+            self.clear_assumed_dock_task()
             self.dock_presence = 2
             self.dock_field11 = 1
             self.dock_field47 = 2
@@ -803,8 +1169,9 @@ class NarwalState:
             self.dock_light_mode = 0
         # Field 3 is a nested message: {1: state_int, ...}
         # Sub-field layout differs across firmware versions:
-        #   Old FW: {1: ws, 2: paused, 3: dock_presence, 7: returning, 10: dock_sub, 12: dock_activity}
-        #   v01.07.23+: {1: ws, 4: ?, 11: ?} — sub-fields 2/3/7/10/12 absent
+        #   Old FW: {1: ws, 2: paused, 3: dock_presence, 7: returning,
+        #            10: dock_sub, 12: dock_activity}
+        #   v01.07.23+: {1: ws, 4: ?, 11: ?}; sub-fields 2/3/7/10/12 absent
         # bbp may also return a list for repeated messages.
         field3 = decoded.get("3")
         if isinstance(field3, list):
@@ -833,39 +1200,80 @@ class NarwalState:
             # Only treat value 1 as returning — other values are not the flag.
             self.is_returning_to_dock = field3.get("7") == 1
             if "10" in field3:
-                try:
+                with contextlib.suppress(ValueError, TypeError):
                     self.dock_sub_state = int(field3["10"])
-                except (ValueError, TypeError):
-                    pass
             if "12" in field3:
-                try:
+                with contextlib.suppress(ValueError, TypeError):
                     self.dock_activity = int(field3["12"])
-                except (ValueError, TypeError):
-                    pass
+            elif self.working_status not in ACTIVE_CLEANING_STATUSES:
+                self.dock_activity = 0
+            self.station_activity = 0
+            if "18" in field3:
+                with contextlib.suppress(ValueError, TypeError):
+                    self.station_activity = int(field3["18"])
             if "3" in field3:
-                try:
+                with contextlib.suppress(ValueError, TypeError):
                     self.dock_presence = int(field3["3"])
-                except (ValueError, TypeError):
-                    pass
             if self.working_status in ACTIVE_CLEANING_STATUSES:
+                self.clear_assumed_robot_clean()
                 if "10" not in field3:
                     self.dock_sub_state = 0
-                if "12" not in field3:
-                    self.dock_activity = 0
+                self.dock_activity = 0
+                self.station_activity = 0
+                self.clear_assumed_dock_task()
                 if "3" not in field3:
                     self.dock_presence = 2
                 if "11" not in decoded:
                     self.dock_field11 = 1
                 if "47" not in decoded:
                     self.dock_field47 = 2
+            elif self.dock_activity > 0:
+                # Cleaning packets synthesize off-dock defaults for omitted
+                # fields. Do not let those stale defaults override a later
+                # dock-activity packet, but retain any off-dock value that the
+                # current packet reports explicitly.
+                if "3" not in field3:
+                    self.dock_presence = 0
+                if "10" not in field3:
+                    self.dock_sub_state = 0
+                if "11" not in decoded:
+                    self.dock_field11 = 0
+                if "47" not in decoded:
+                    self.dock_field47 = 0
             # Log unrecognized sub-fields for future firmware mapping
-            _known_f3 = {"1", "2", "3", "7", "10", "12"}
+            _known_f3 = {"1", "2", "3", "7", "10", "12", "18"}
             _unknown_f3 = set(field3.keys()) - _known_f3
             if _unknown_f3:
                 _LOGGER.debug(
                     "field3 unrecognized sub-fields: %s",
                     {k: field3[k] for k in sorted(_unknown_f3)},
                 )
+            if (
+                self.station_activity <= 0
+                and self.dock_activity in (0, 2, 6)
+                and self.has_dock_presence_signal
+                and self.assumed_active_dock_task is None
+                and self.working_status
+                in (
+                    WorkingStatus.UNKNOWN,
+                    WorkingStatus.STANDBY,
+                    WorkingStatus.DOCKED,
+                    WorkingStatus.CHARGED,
+                    WorkingStatus.DOCKED_V2,
+                    WorkingStatus.TASK_COMPLETED,
+                )
+                and not self.has_recent_dock_drying_status
+            ):
+                self.clear_dock_drying_task()
+                self.has_dock_drying_timer_snapshot = False
+                self.has_unmapped_dock_drying_timer = False
+                self.clear_assumed_dock_task()
+            telemetry_tasks = self.telemetry_dock_task_keys
+            if (
+                telemetry_tasks
+                and self.assumed_active_dock_task is not None
+            ):
+                self.clear_assumed_dock_task()
         elif field3 is not None:
             _LOGGER.warning(
                 "field3 is %s (expected dict): %r — state may not update. "
@@ -888,13 +1296,11 @@ class NarwalState:
                 if self.binded_uuid.startswith("b'"):
                     self.binded_uuid = self.binded_uuid[2:-1]
         if "15" in decoded:
-            try:
+            with contextlib.suppress(ValueError, TypeError):
                 self.terminate_reason = int(decoded["15"])
-            except (ValueError, TypeError):
-                pass
 
     def _update_consumables(self, decoded: dict[str, Any]) -> None:
-        """Parse base_status consumable/station/fault fields — hardware-sampled, so trustworthy even in deep-sleep battery-only updates."""
+        """Parse trustworthy hardware-sampled base_status fields."""
         if "35" in decoded:
             score = _to_float32(decoded["35"])
             if score is not None:
@@ -905,7 +1311,9 @@ class NarwalState:
             self.curing_agent_consumption_percent = int(decoded["38"])
         if "36" in decoded:
             self.station_bag_health_reset_time = int(decoded["36"])
-        # Always reparse (even when field 1 is absent) — protobuf omits an empty repeated field, so a recovered robot drops it; without this the prior fault would stick forever.
+        # Always reparse, even when field 1 is absent. Protobuf omits an empty
+        # repeated field, so a recovered robot drops it; otherwise the prior
+        # fault would stick forever.
         self._parse_error_codes(decoded.get("1"))
         for attr, key in (
             ("clean_water_tank_state", "23"), ("sewage_tank_state", "24"),
@@ -913,10 +1321,8 @@ class NarwalState:
             ("station_bag_state", "39"),
         ):
             if key in decoded:
-                try:
+                with contextlib.suppress(ValueError, TypeError):
                     setattr(self, attr, int(decoded[key]))
-                except (ValueError, TypeError):
-                    pass
 
     def _parse_error_codes(self, raw: Any) -> None:
         """Decode base_status field 1 (repeated ErrorCode{1:identityCode, 2:level, 3:debugDetail}).
@@ -934,10 +1340,8 @@ class NarwalState:
                 codes.append(int(entry["1"]))
             except (ValueError, TypeError):
                 continue
-            try:
+            with contextlib.suppress(ValueError, TypeError):
                 level = max(level, int(entry.get("2", 0)))
-            except (ValueError, TypeError):
-                pass
             raw_detail = entry.get("3")
             if isinstance(raw_detail, bytes):
                 detail = detail or raw_detail.decode("utf-8", errors="replace")
@@ -949,9 +1353,12 @@ class NarwalState:
         self.has_error = bool(codes)
 
     def update_battery_from_base_status(self, decoded: dict[str, Any]) -> None:
-        """Update only the trustworthy hardware-sampled fields (battery + consumable/station/fault/tank state, via _update_consumables) from a base_status response.
+        """Update only trustworthy hardware-sampled base_status fields.
 
-        Used when the robot is not broadcasting (deep sleep on dock): get_status() returns a current battery counter but a stale working_status (firmware cache from the last active session), so working_status is deliberately skipped.
+        Used when the robot is not broadcasting, such as deep sleep on dock.
+        get_status() returns a current battery counter but a stale
+        working_status firmware cache from the last active session, so
+        working_status is deliberately skipped.
         """
         self.raw_base_status = decoded
         if "2" in decoded:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ import pytest
 
 from narwal_client.protocol import build_frame
 
-
 # --- Sample frames for testing ---
 
 # A minimal valid frame with topic "status/working_status" and a small protobuf payload

--- a/tests/ha_stubs.py
+++ b/tests/ha_stubs.py
@@ -43,6 +43,10 @@ def install() -> None:
     # homeassistant.const
     ha_const = _mod("homeassistant.const", ha)
     ha_const.Platform = MagicMock()  # type: ignore[attr-defined]
+    ha_const.PERCENTAGE = "%"  # type: ignore[attr-defined]
+    ha_const.STATE_ON = "on"  # type: ignore[attr-defined]
+    ha_const.UnitOfArea = MagicMock()  # type: ignore[attr-defined]
+    ha_const.UnitOfTime = MagicMock()  # type: ignore[attr-defined]
 
     class _EntityCategory:
         CONFIG = "config"
@@ -99,7 +103,7 @@ def install() -> None:
     # homeassistant.helpers.entity.EntityCategory; it lives in homeassistant.const.
     # Stubbing both paths hid a real ImportError that only surfaced when the
     # integration was loaded in Home Assistant (switch.py, from PR #62).
-    ha_entity = _mod("homeassistant.helpers.entity", ha_helpers)
+    _mod("homeassistant.helpers.entity", ha_helpers)
 
     ha_uc = _mod("homeassistant.helpers.update_coordinator", ha_helpers)
 
@@ -287,9 +291,41 @@ def install() -> None:
     ha_number.RestoreNumber = _RestoreNumber  # type: ignore[attr-defined]
 
     ha_sensor = _mod("homeassistant.components.sensor", ha_comp)
-    ha_sensor.SensorEntity = MagicMock  # type: ignore[attr-defined]
-    ha_sensor.SensorDeviceClass = MagicMock  # type: ignore[attr-defined]
-    ha_sensor.SensorStateClass = MagicMock  # type: ignore[attr-defined]
+
+    class _SensorEntity:
+        """Stub for SensorEntity base class."""
+
+        def __init_subclass__(cls, **kw: object) -> None:
+            pass
+
+    ha_sensor.SensorEntity = _SensorEntity  # type: ignore[attr-defined]
+
+    class _SensorDeviceClass:
+        BATTERY = "battery"
+        DURATION = "duration"
+        ENUM = "enum"
+
+    class _SensorStateClass:
+        MEASUREMENT = "measurement"
+
+    ha_sensor.SensorDeviceClass = _SensorDeviceClass  # type: ignore[attr-defined]
+    ha_sensor.SensorStateClass = _SensorStateClass  # type: ignore[attr-defined]
+
+    @dataclass(frozen=True, kw_only=True)
+    class _SensorEntityDescription:
+        """Stub for SensorEntityDescription (fields our code sets)."""
+
+        key: str
+        name: str | None = None
+        translation_key: str | None = None
+        entity_category: object | None = None
+        device_class: object | None = None
+        icon: str | None = None
+        native_unit_of_measurement: object | None = None
+        state_class: object | None = None
+        options: object | None = None
+
+    ha_sensor.SensorEntityDescription = _SensorEntityDescription  # type: ignore[attr-defined]
 
     ha_bs = _mod("homeassistant.components.binary_sensor", ha_comp)
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -2,16 +2,37 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import tests.ha_stubs
 
 tests.ha_stubs.install()
 
-from narwal_client.models import NarwalState  # noqa: E402
 from custom_components.narwal.binary_sensor import (  # noqa: E402
     BINARY_SENSOR_DESCRIPTIONS,
+    NarwalBinarySensor,
+    NarwalDockBinarySensor,
 )
+from custom_components.narwal.sensor import (  # noqa: E402
+    SENSOR_DESCRIPTIONS,
+    NarwalDockSensor,
+    NarwalSensor,
+)
+from narwal_client.models import NarwalState  # noqa: E402
 
 _DESCS = {d.key: d for d in BINARY_SENSOR_DESCRIPTIONS}
+_SENSOR_DESCS = {d.key: d for d in SENSOR_DESCRIPTIONS}
+
+
+def _coordinator() -> MagicMock:
+    """Return a minimal coordinator stub for entity device tests."""
+    coordinator = MagicMock()
+    coordinator.config_entry.data = {"device_id": "test_device", "model": "flow"}
+    coordinator.config_entry.title = "Narwal Test"
+    coordinator.client.state.firmware_version = "test"
+    coordinator.data = NarwalState()
+    coordinator.last_update_success = True
+    return coordinator
 
 
 def test_error_gated_on_base_status_seen() -> None:
@@ -70,6 +91,36 @@ def test_consumable_alert_sensors() -> None:
     s.update_from_consumable_info({"1": {}})
     assert maint.value_fn(s) is False
     assert repl.value_fn(s) is False
+
+
+def test_station_problem_sensors_belong_to_dock_device() -> None:
+    """Station hardware problem sensors are grouped under the dock device."""
+    dock_sensor = NarwalDockBinarySensor(_coordinator(), _DESCS["clean_water_tank"])
+    robot_sensor = NarwalBinarySensor(_coordinator(), _DESCS["maintenance_required"])
+
+    assert _DESCS["clean_water_tank"].dock_device
+    assert dock_sensor._attr_unique_id == "test_device_clean_water_tank"
+    assert dock_sensor._attr_device_info["identifiers"] == {
+        ("narwal", "test_device_dock")
+    }
+    assert dock_sensor._attr_device_info["via_device"] == ("narwal", "test_device")
+    assert not _DESCS["maintenance_required"].dock_device
+    assert robot_sensor._attr_device_info["identifiers"] == {("narwal", "test_device")}
+
+
+def test_station_value_sensors_belong_to_dock_device() -> None:
+    """Station consumable value sensors are grouped under the dock device."""
+    dock_sensor = NarwalDockSensor(_coordinator(), _SENSOR_DESCS["detergent_remaining"])
+    robot_sensor = NarwalSensor(_coordinator(), _SENSOR_DESCS["battery"])
+
+    assert _SENSOR_DESCS["detergent_remaining"].dock_device
+    assert dock_sensor._attr_unique_id == "test_device_detergent_remaining"
+    assert dock_sensor._attr_device_info["identifiers"] == {
+        ("narwal", "test_device_dock")
+    }
+    assert dock_sensor._attr_device_info["via_device"] == ("narwal", "test_device")
+    assert not _SENSOR_DESCS["battery"].dock_device
+    assert robot_sensor._attr_device_info["identifiers"] == {("narwal", "test_device")}
 
 
 def test_tank_problem_states() -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,13 +12,29 @@ import pytest
 from narwal_client.client import NarwalClient, NarwalConnectionError
 from narwal_client.const import (
     TOPIC_CMD_CLEAN_TASK,
+    TOPIC_CMD_DRY_DUST_BAG,
+    TOPIC_CMD_DRY_MOP,
+    TOPIC_CMD_DRY_STATION_BAG,
+    TOPIC_CMD_DUST_GATHERING,
+    TOPIC_CMD_FORCE_END,
+    TOPIC_CMD_GET_BASE_STATUS,
     TOPIC_CMD_PLAN_START,
+    TOPIC_CMD_WASH_MOP,
     AmbientLightCtrlType,
     CommandResult,
     FanLevel,
     WorkingStatus,
 )
-from narwal_client.models import CommandResponse, MapData, RoomInfo
+from narwal_client.models import (
+    DOCK_TASK_DRY_DOCK_BAG,
+    DOCK_TASK_DRY_DUST_BIN,
+    DOCK_TASK_DRY_MOP,
+    DOCK_TASK_EMPTY_DUSTBIN,
+    DOCK_TASK_WASH_MOP,
+    CommandResponse,
+    MapData,
+    RoomInfo,
+)
 from narwal_client.protocol import PROTOBUF_FIELD5_TAG, build_frame
 
 
@@ -40,6 +56,39 @@ class TestNarwalClientInit:
         client = NarwalClient("10.0.0.1")
         assert not client.connected
         assert client.state.battery_level == 0
+
+    def test_command_response_accepted_codes(self) -> None:
+        """Narwal uses code 0 for accepted async commands and 1 for success."""
+        accepted = CommandResponse(result_code=0)
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        applied = CommandResponse(result_code=CommandResult.APPLIED)
+        rejected = CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+
+        assert accepted.accepted
+        assert not accepted.success
+        assert success.accepted
+        assert success.success
+        assert applied.accepted
+        assert not rejected.accepted
+
+    @pytest.mark.asyncio
+    async def test_get_status_without_base_payload_returns_not_ready(self) -> None:
+        """A get_status ack without robot_base_status field 2 is not a refresh."""
+        client = NarwalClient("10.0.0.1")
+        ack_without_status = CommandResponse(
+            result_code=CommandResult.SUCCESS,
+            data={"1": 1},
+            raw_payload=b"raw",
+        )
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = ack_without_status
+            result = await client.get_status()
+
+        assert result.result_code == CommandResult.NOT_READY
+        assert result.data == {"1": 1}
+        assert result.raw_payload == b"raw"
+        mock_send.assert_awaited_once_with(TOPIC_CMD_GET_BASE_STATUS)
 
     def test_unconfirmed_idle_base_status_preserves_active_metrics(self) -> None:
         """Stale idle base_status must not hide a fresh working_status task."""
@@ -358,6 +407,1067 @@ class TestWholeHouseStart:
         assert mock_send.await_args.args[0] == TOPIC_CMD_PLAN_START
         assert result.result_code == CommandResult.SUCCESS
 
+    @pytest.mark.asyncio
+    async def test_start_rooms_rejects_active_dock_task(self) -> None:
+        """Direct room starts are blocked while incompatible dock work is active."""
+        client = self._connected_client()
+        client.state.map_data = MapData(map_id=1, rooms=[RoomInfo(room_id=2)])
+        client.state.station_activity = 1
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            result = await client.start_rooms([2])
+
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_start_rooms_reserves_private_guard_on_acceptance(self) -> None:
+        """Accepted direct room starts block follow-up starts until telemetry arrives."""
+        client = self._connected_client()
+        client.state.map_data = MapData(map_id=1, rooms=[RoomInfo(room_id=2)])
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = success
+            first = await client.start_rooms([2])
+            second = await client.start_rooms([2])
+
+        assert first is success
+        assert second.result_code == CommandResult.NOT_APPLICABLE
+        assert client.state.has_assumed_robot_clean
+        mock_send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_direct_start_rooms_serialize_preflight(self) -> None:
+        """Only one direct room start validates before the accepted-command guard."""
+        client = self._connected_client()
+        client.state.map_data = MapData(map_id=1, rooms=[RoomInfo(room_id=2)])
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        command_started = asyncio.Event()
+        release_command = asyncio.Event()
+
+        async def slow_send(*args, **kwargs):
+            command_started.set()
+            await release_command.wait()
+            return success
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.side_effect = slow_send
+            first = asyncio.create_task(client.start_rooms([2]))
+            await command_started.wait()
+            second = asyncio.create_task(client.start_rooms([2]))
+            await asyncio.sleep(0)
+            release_command.set()
+            first_result, second_result = await asyncio.gather(first, second)
+
+        assert first_result is success
+        assert second_result.result_code == CommandResult.NOT_APPLICABLE
+        mock_send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_start_rejects_active_dock_task_before_map_fallback(self) -> None:
+        """Whole-house start is blocked even when it would use the saved plan."""
+        client = self._connected_client()
+        client.state.station_activity = 1
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            result = await client.start()
+
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_start_easy_clean_rejects_active_dock_task(self) -> None:
+        """Quick clean uses the same dock-task guard as other robot starts."""
+        client = self._connected_client()
+        client.state.station_activity = 1
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            result = await client.start_easy_clean()
+
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_start_easy_clean_reserves_private_guard_on_acceptance(self) -> None:
+        """Accepted quick-clean starts use the same duplicate-start guard."""
+        client = self._connected_client()
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = success
+            first = await client.start_easy_clean()
+            second = await client.start_easy_clean()
+
+        assert first is success
+        assert second.result_code == CommandResult.NOT_APPLICABLE
+        assert client.state.has_assumed_robot_clean
+        mock_send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_start_rooms_allows_typed_dock_bag_drying(self) -> None:
+        """Dock-bag drying is the one known dock task compatible with robot start."""
+        client = self._connected_client()
+        client.state.map_data = MapData(map_id=1, rooms=[RoomInfo(room_id=2)])
+        client.state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
+        )
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = success
+            result = await client.start_rooms([2])
+
+        assert result is success
+        mock_send.assert_awaited_once()
+
+
+class TestDockTaskCommands:
+    """Dock task commands and scoped dock-task stop behavior."""
+
+    def _docked_client(self) -> NarwalClient:
+        """Return a client with explicit idle-docked robot state."""
+        client = NarwalClient("127.0.0.1")
+        client.state.working_status = WorkingStatus.DOCKED
+        client.state.dock_presence = 6
+        client.state.dock_field11 = 2
+        return client
+
+    def _docked_status_response(self) -> CommandResponse:
+        """Return a valid docked base-status refresh response."""
+        return CommandResponse(
+            data={"2": {"3": {"1": int(WorkingStatus.DOCKED)}, "11": 2}},
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_dustbin_command_assumes_task_on_success(self) -> None:
+        client = self._docked_client()
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send:
+            mock_status.return_value = self._docked_status_response()
+            mock_send.return_value = success
+            result = await client.empty_dustbin()
+
+        assert result is success
+        mock_status.assert_awaited_once_with(full_update=True)
+        mock_send.assert_awaited_once_with(TOPIC_CMD_DUST_GATHERING)
+        assert client.state.assumed_active_dock_task == DOCK_TASK_EMPTY_DUSTBIN
+
+    @pytest.mark.asyncio
+    async def test_wash_mop_command_assumes_task_on_success(self) -> None:
+        client = self._docked_client()
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send:
+            mock_status.return_value = self._docked_status_response()
+            mock_send.return_value = success
+            result = await client.wash_mop()
+
+        assert result is success
+        mock_status.assert_awaited_once_with(full_update=True)
+        mock_send.assert_awaited_once_with(TOPIC_CMD_WASH_MOP)
+        assert client.state.assumed_active_dock_task == DOCK_TASK_WASH_MOP
+
+    @pytest.mark.asyncio
+    async def test_dry_mop_command_assumes_task_on_success(self) -> None:
+        client = self._docked_client()
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send:
+            mock_status.return_value = self._docked_status_response()
+            mock_send.return_value = success
+            result = await client.dry_mop()
+
+        assert result is success
+        mock_status.assert_awaited_once_with(full_update=True)
+        mock_send.assert_awaited_once_with(TOPIC_CMD_DRY_MOP)
+        assert client.state.assumed_active_dock_task == DOCK_TASK_DRY_MOP
+
+    @pytest.mark.asyncio
+    async def test_dry_dust_bag_command_assumes_task_on_success(self) -> None:
+        client = self._docked_client()
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send:
+            mock_status.return_value = self._docked_status_response()
+            mock_send.return_value = success
+            result = await client.dry_dust_bag()
+
+        assert result is success
+        mock_status.assert_awaited_once_with(full_update=True)
+        mock_send.assert_awaited_once_with(TOPIC_CMD_DRY_DUST_BAG)
+        assert client.state.assumed_active_dock_drying_task == DOCK_TASK_DRY_DUST_BIN
+
+    @pytest.mark.asyncio
+    async def test_dry_station_bag_command_assumes_task_on_success(self) -> None:
+        client = self._docked_client()
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send:
+            mock_status.return_value = self._docked_status_response()
+            mock_send.return_value = success
+            result = await client.dry_station_bag()
+
+        assert result is success
+        mock_status.assert_awaited_once_with(full_update=True)
+        mock_send.assert_awaited_once_with(TOPIC_CMD_DRY_STATION_BAG)
+        assert client.state.assumed_active_dock_drying_task == DOCK_TASK_DRY_DOCK_BAG
+
+    @pytest.mark.asyncio
+    async def test_direct_dock_command_rejects_cleaning_state(self) -> None:
+        """Direct client dock commands cannot bypass robot-work gating."""
+        client = NarwalClient("127.0.0.1")
+        client.state.working_status = WorkingStatus.CLEANING
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            result = await client.empty_dustbin()
+
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_direct_dock_command_rejects_existing_dock_task(self) -> None:
+        """Only one unscoped dock start may be dispatched at a time."""
+        client = self._docked_client()
+        client.state.station_activity = 1
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            result = await client.wash_mop_by_robot_status()
+
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_direct_dock_command_rejects_private_command_guard(self) -> None:
+        """Accepted-command guards serialize direct dock starts without publishing state."""
+        client = self._docked_client()
+        client.state.assume_dock_task(DOCK_TASK_EMPTY_DUSTBIN)
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            result = await client.wash_mop_by_robot_status()
+
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_direct_dock_commands_serialize_preflight(self) -> None:
+        """Only one direct dock start validates and reserves an idle snapshot."""
+        client = self._docked_client()
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        command_started = asyncio.Event()
+        release_command = asyncio.Event()
+
+        async def slow_send(*args, **kwargs):
+            command_started.set()
+            await release_command.wait()
+            return success
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send:
+            mock_status.return_value = CommandResponse(
+                data={"2": {"3": {"1": int(WorkingStatus.DOCKED)}, "11": 2}},
+            )
+            mock_send.side_effect = slow_send
+            first = asyncio.create_task(client.dry_dust_bag())
+            await command_started.wait()
+            second = asyncio.create_task(client.dry_station_bag())
+            await asyncio.sleep(0)
+            release_command.set()
+            first_result, second_result = await asyncio.gather(first, second)
+
+        assert first_result is success
+        assert second_result.result_code == CommandResult.NOT_APPLICABLE
+        assert mock_status.await_count == 1
+        mock_send.assert_awaited_once_with(TOPIC_CMD_DRY_DUST_BAG)
+        assert client.state.assumed_active_dock_task == DOCK_TASK_DRY_DUST_BIN
+
+    @pytest.mark.asyncio
+    async def test_direct_robot_and_dock_starts_share_action_preflight(self) -> None:
+        """A robot clean and dock task cannot both validate the same idle snapshot."""
+        client = self._docked_client()
+        client.state.map_data = MapData(map_id=1, rooms=[RoomInfo(room_id=2)])
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        command_started = asyncio.Event()
+        release_command = asyncio.Event()
+
+        async def slow_send(*args, **kwargs):
+            command_started.set()
+            await release_command.wait()
+            return success
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send:
+            mock_status.return_value = self._docked_status_response()
+            mock_send.side_effect = slow_send
+            robot = asyncio.create_task(client.start_rooms([2]))
+            await command_started.wait()
+            dock = asyncio.create_task(client.empty_dustbin())
+            await asyncio.sleep(0)
+            release_command.set()
+            robot_result, dock_result = await asyncio.gather(robot, dock)
+
+        assert robot_result is success
+        assert dock_result.result_code == CommandResult.NOT_APPLICABLE
+        mock_status.assert_not_awaited()
+        mock_send.assert_awaited_once()
+        assert client.state.has_assumed_robot_clean
+
+    @pytest.mark.asyncio
+    async def test_direct_dock_command_refreshes_before_start(self) -> None:
+        """Direct dock starts revalidate the device state inside the action lock."""
+        client = self._docked_client()
+
+        async def stale_refresh(*args, **kwargs):
+            client.state.working_status = WorkingStatus.CLEANING
+            return CommandResponse(
+                data={"2": {"3": {"1": int(WorkingStatus.CLEANING)}}},
+            )
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send:
+            mock_status.side_effect = stale_refresh
+            result = await client.dry_dust_bag()
+
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+        mock_status.assert_awaited_once_with(full_update=True)
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_direct_dock_command_rejects_battery_only_refresh(self) -> None:
+        """Direct dock starts require live dock status, not only any status field."""
+        client = self._docked_client()
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send:
+            mock_status.return_value = CommandResponse(data={"2": {"2": 85.0}})
+            result = await client.empty_dustbin()
+
+        assert result.result_code == CommandResult.NOT_READY
+        mock_status.assert_awaited_once_with(full_update=True)
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_stop_dock_task_rejects_unscoped_clean_context(self) -> None:
+        """Direct dock stops cannot use generic force-end during robot work."""
+        client = self._docked_client()
+        client.state.working_status = WorkingStatus.CLEANING
+        client.state.station_activity = 1
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(client, "stop", new_callable=AsyncMock) as mock_stop:
+            mock_status.return_value = self._docked_status_response()
+            result = await client.stop_dock_task(DOCK_TASK_EMPTY_DUSTBIN)
+
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+        mock_status.assert_awaited_once_with(full_update=True)
+        mock_stop.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_stop_empty_dustbin_allows_task_completed_dock_context(self) -> None:
+        """Dock emptying reports TASK_COMPLETED, but its generic stop is dock-scoped."""
+        client = self._docked_client()
+        client.state.working_status = WorkingStatus.TASK_COMPLETED
+        client.state.station_activity = 1
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "stop", new_callable=AsyncMock
+        ) as mock_stop, patch.object(
+            client, "_refresh_after_dock_stop", new_callable=AsyncMock
+        ) as mock_refresh, patch(
+            "narwal_client.client.asyncio.sleep", new_callable=AsyncMock
+        ):
+            mock_status.return_value = self._docked_status_response()
+            mock_stop.return_value = success
+            mock_refresh.return_value = True
+            result = await client.stop_dock_task(DOCK_TASK_EMPTY_DUSTBIN)
+
+        assert result is success
+        mock_status.assert_awaited_once_with(full_update=True)
+        mock_stop.assert_awaited_once_with(timeout=15.0)
+
+    @pytest.mark.asyncio
+    async def test_stop_empty_dustbin_rejects_task_completed_without_dock_proof(
+        self,
+    ) -> None:
+        """Generic dock stop needs a dock signal, not just TASK_COMPLETED."""
+        client = NarwalClient("127.0.0.1")
+        client.state.working_status = WorkingStatus.TASK_COMPLETED
+        client.state.station_activity = 1
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(client, "stop", new_callable=AsyncMock) as mock_stop:
+            mock_status.return_value = self._docked_status_response()
+            result = await client.stop_dock_task(DOCK_TASK_EMPTY_DUSTBIN)
+
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+        mock_status.assert_awaited_once_with(full_update=True)
+        mock_stop.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_stop_dry_station_bag_uses_scoped_force_end_payload(self) -> None:
+        client = NarwalClient("127.0.0.1")
+        client.state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
+        )
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send, patch.object(
+            client, "_refresh_after_dock_stop", new_callable=AsyncMock
+        ) as mock_refresh, patch(
+            "narwal_client.client.asyncio.sleep", new_callable=AsyncMock
+        ):
+            mock_status.return_value = self._docked_status_response()
+            mock_send.return_value = success
+            mock_refresh.return_value = True
+            result = await client.stop_dock_task(DOCK_TASK_DRY_DOCK_BAG)
+
+        assert result is success
+        mock_send.assert_awaited_once_with(
+            TOPIC_CMD_FORCE_END,
+            payload=b"\x08\x01",
+            timeout=15.0,
+        )
+        mock_status.assert_awaited_once_with(full_update=True)
+        assert client.state.dock_task_timer(DOCK_TASK_DRY_DOCK_BAG) is not None
+
+    @pytest.mark.asyncio
+    async def test_stop_dry_station_bag_allows_unmapped_coarse_activity(self) -> None:
+        """Typed dock-bag force-end stays safe when coarse station flags are stale."""
+        client = NarwalClient("127.0.0.1")
+        client.state.station_activity = 99
+        client.state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
+        )
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send, patch.object(
+            client, "_refresh_after_dock_stop", new_callable=AsyncMock
+        ) as mock_refresh, patch(
+            "narwal_client.client.asyncio.sleep", new_callable=AsyncMock
+        ):
+            mock_status.return_value = self._docked_status_response()
+            mock_send.return_value = success
+            mock_refresh.return_value = True
+            result = await client.stop_dock_task(DOCK_TASK_DRY_DOCK_BAG)
+
+        assert result is success
+        mock_send.assert_awaited_once_with(
+            TOPIC_CMD_FORCE_END,
+            payload=b"\x08\x01",
+            timeout=15.0,
+        )
+        mock_status.assert_awaited_once_with(full_update=True)
+
+    @pytest.mark.asyncio
+    async def test_stop_dry_station_bag_waits_for_typed_task_after_unmapped_snapshot(
+        self,
+    ) -> None:
+        """Scoped dry stop waits for typed telemetry after a coarse active snapshot."""
+        client = NarwalClient("127.0.0.1")
+        client.state.working_status = WorkingStatus.TASK_COMPLETED
+        client.state.station_activity = 4
+        client.state.dock_presence = 6
+        client.state.dock_field11 = 2
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        refresh_count = 0
+
+        async def refresh_status(*args, **kwargs):
+            nonlocal refresh_count
+            refresh_count += 1
+            client.state.station_activity = 4
+            if refresh_count == 2:
+                client.state.set_dock_drying_task(
+                    DOCK_TASK_DRY_DOCK_BAG,
+                    elapsed=60,
+                    target=180,
+                    fields=("12", "13"),
+                )
+            return self._docked_status_response()
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send, patch.object(
+            client, "_refresh_after_dock_stop", new_callable=AsyncMock
+        ) as mock_refresh, patch(
+            "narwal_client.client.asyncio.sleep", new_callable=AsyncMock
+        ) as mock_sleep:
+            mock_status.side_effect = refresh_status
+            mock_send.return_value = success
+            mock_refresh.return_value = True
+            result = await client.stop_dock_task(DOCK_TASK_DRY_DOCK_BAG)
+
+        assert result is success
+        mock_send.assert_awaited_once_with(
+            TOPIC_CMD_FORCE_END,
+            payload=b"\x08\x01",
+            timeout=15.0,
+        )
+        assert mock_status.await_count == 2
+        mock_sleep.assert_any_await(1.5)
+
+    @pytest.mark.asyncio
+    async def test_stop_dry_station_bag_waits_past_local_assumption(
+        self,
+    ) -> None:
+        """Scoped stop waits for telemetry rather than a local task reservation."""
+        client = NarwalClient("127.0.0.1")
+        client.state.working_status = WorkingStatus.TASK_COMPLETED
+        client.state.station_activity = 4
+        client.state.dock_presence = 6
+        client.state.dock_field11 = 2
+        client.state.assume_dock_task(DOCK_TASK_DRY_DOCK_BAG)
+        client.state.update_from_working_status({"12": 0, "13": 18000})
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        refresh_count = 0
+
+        async def refresh_status(*args, **kwargs):
+            nonlocal refresh_count
+            refresh_count += 1
+            client.state.station_activity = 4
+            if refresh_count == 2:
+                client.state.set_dock_drying_task(
+                    DOCK_TASK_DRY_DOCK_BAG,
+                    elapsed=2,
+                    target=18000,
+                    fields=("12", "13"),
+                )
+            return self._docked_status_response()
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send, patch.object(
+            client, "_refresh_after_dock_stop", new_callable=AsyncMock
+        ) as mock_refresh, patch(
+            "narwal_client.client.asyncio.sleep", new_callable=AsyncMock
+        ) as mock_sleep:
+            mock_status.side_effect = refresh_status
+            mock_send.return_value = success
+            mock_refresh.return_value = True
+            result = await client.stop_dock_task(DOCK_TASK_DRY_DOCK_BAG)
+
+        assert result is success
+        assert mock_status.await_count == 2
+        mock_sleep.assert_any_await(1.5)
+        mock_send.assert_awaited_once_with(
+            TOPIC_CMD_FORCE_END,
+            payload=b"\x08\x01",
+            timeout=15.0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_stop_dry_dust_bag_waits_past_local_assumption(
+        self,
+    ) -> None:
+        """Scoped dry dust-bin stop also waits for typed telemetry."""
+        client = NarwalClient("127.0.0.1")
+        client.state.working_status = WorkingStatus.CHARGED
+        client.state.dock_presence = 6
+        client.state.dock_field11 = 2
+        client.state.assume_dock_task(DOCK_TASK_DRY_DUST_BIN)
+        client.state.update_from_working_status({"10": 0, "11": 180})
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        refresh_count = 0
+
+        async def refresh_status(*args, **kwargs):
+            nonlocal refresh_count
+            refresh_count += 1
+            if refresh_count == 2:
+                client.state.set_dock_drying_task(
+                    DOCK_TASK_DRY_DUST_BIN,
+                    elapsed=2,
+                    target=180,
+                    fields=("10", "11"),
+                )
+            return self._docked_status_response()
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send, patch.object(
+            client, "_refresh_after_dock_stop", new_callable=AsyncMock
+        ) as mock_refresh, patch(
+            "narwal_client.client.asyncio.sleep", new_callable=AsyncMock
+        ) as mock_sleep:
+            mock_status.side_effect = refresh_status
+            mock_send.return_value = success
+            mock_refresh.return_value = True
+            result = await client.stop_dock_task(DOCK_TASK_DRY_DUST_BIN)
+
+        assert result is success
+        assert mock_status.await_count == 2
+        mock_sleep.assert_any_await(1.5)
+        mock_send.assert_awaited_once_with(
+            TOPIC_CMD_FORCE_END,
+            payload=b"\x08\x05",
+            timeout=15.0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_stop_dry_dust_bag_waits_for_dock_activity_snapshot(
+        self,
+    ) -> None:
+        """Dry dust-bin can report dock_activity=6 before timer telemetry."""
+        client = NarwalClient("127.0.0.1")
+        client.state.working_status = WorkingStatus.CHARGED
+        client.state.dock_presence = 6
+        client.state.dock_field11 = 2
+        client.state.dock_activity = 6
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        refresh_count = 0
+
+        async def refresh_status(*args, **kwargs):
+            nonlocal refresh_count
+            refresh_count += 1
+            client.state.dock_activity = 6
+            if refresh_count == 2:
+                client.state.set_dock_drying_task(
+                    DOCK_TASK_DRY_DUST_BIN,
+                    elapsed=2,
+                    target=180,
+                    fields=("10", "11"),
+                )
+            return self._docked_status_response()
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send, patch.object(
+            client, "_refresh_after_dock_stop", new_callable=AsyncMock
+        ) as mock_refresh, patch(
+            "narwal_client.client.asyncio.sleep", new_callable=AsyncMock
+        ) as mock_sleep:
+            mock_status.side_effect = refresh_status
+            mock_send.return_value = success
+            mock_refresh.return_value = True
+            result = await client.stop_dock_task(DOCK_TASK_DRY_DUST_BIN)
+
+        assert result is success
+        assert mock_status.await_count == 2
+        mock_sleep.assert_any_await(1.5)
+        mock_send.assert_awaited_once_with(
+            TOPIC_CMD_FORCE_END,
+            payload=b"\x08\x05",
+            timeout=15.0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_stop_dry_station_bag_waits_after_idle_drying_snapshot(
+        self,
+    ) -> None:
+        """Station drying can report an idle timer snapshot before typed telemetry."""
+        client = NarwalClient("127.0.0.1")
+        client.state.working_status = WorkingStatus.TASK_COMPLETED
+        client.state.station_activity = 4
+        client.state.dock_presence = 6
+        client.state.dock_field11 = 2
+        client.state.update_from_working_status({"12": 0, "13": 18000})
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        refresh_count = 0
+
+        async def refresh_status(*args, **kwargs):
+            nonlocal refresh_count
+            refresh_count += 1
+            client.state.station_activity = 4
+            if refresh_count == 2:
+                client.state.set_dock_drying_task(
+                    DOCK_TASK_DRY_DOCK_BAG,
+                    elapsed=2,
+                    target=18000,
+                    fields=("12", "13"),
+                )
+            return self._docked_status_response()
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send, patch.object(
+            client, "_refresh_after_dock_stop", new_callable=AsyncMock
+        ) as mock_refresh, patch(
+            "narwal_client.client.asyncio.sleep", new_callable=AsyncMock
+        ) as mock_sleep:
+            mock_status.side_effect = refresh_status
+            mock_send.return_value = success
+            mock_refresh.return_value = True
+            result = await client.stop_dock_task(DOCK_TASK_DRY_DOCK_BAG)
+
+        assert result is success
+        mock_send.assert_awaited_once_with(
+            TOPIC_CMD_FORCE_END,
+            payload=b"\x08\x01",
+            timeout=15.0,
+        )
+        assert mock_status.await_count == 2
+        mock_sleep.assert_any_await(1.5)
+
+    @pytest.mark.asyncio
+    async def test_stop_dry_dust_bag_uses_scoped_force_end_payload(self) -> None:
+        """Dry dust-bin drying uses the live-validated scoped force-end payload."""
+        client = NarwalClient("127.0.0.1")
+        client.state.set_dock_drying_task(
+            DOCK_TASK_DRY_DUST_BIN,
+            elapsed=60,
+            target=180,
+            fields=("10", "11"),
+        )
+        client.state.dock_presence = 1
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send, patch.object(
+            client, "_refresh_after_dock_stop", new_callable=AsyncMock
+        ) as mock_refresh, patch(
+            "narwal_client.client.asyncio.sleep", new_callable=AsyncMock
+        ):
+            mock_status.return_value = self._docked_status_response()
+            mock_send.return_value = success
+            mock_refresh.return_value = True
+            result = await client.stop_dock_task(DOCK_TASK_DRY_DUST_BIN)
+
+        assert result is success
+        mock_send.assert_awaited_once_with(
+            TOPIC_CMD_FORCE_END,
+            payload=b"\x08\x05",
+            timeout=15.0,
+        )
+        mock_status.assert_awaited_once_with(full_update=True)
+        assert client.state.dock_task_timer(DOCK_TASK_DRY_DUST_BIN) is None
+
+    @pytest.mark.asyncio
+    async def test_unscoped_stop_dry_dust_bag_uses_scoped_force_end(self) -> None:
+        """Unscoped stop can use the dry dust-bin payload when it is the only task."""
+        client = NarwalClient("127.0.0.1")
+        client.state.set_dock_drying_task(
+            DOCK_TASK_DRY_DUST_BIN,
+            elapsed=60,
+            target=180,
+            fields=("10", "11"),
+        )
+        client.state.dock_presence = 1
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send, patch.object(
+            client, "_refresh_after_dock_stop", new_callable=AsyncMock
+        ) as mock_refresh, patch(
+            "narwal_client.client.asyncio.sleep", new_callable=AsyncMock
+        ):
+            mock_status.return_value = self._docked_status_response()
+            mock_send.return_value = success
+            mock_refresh.return_value = True
+            result = await client.stop_dock_task()
+
+        assert result is success
+        mock_send.assert_awaited_once_with(
+            TOPIC_CMD_FORCE_END,
+            payload=b"\x08\x05",
+            timeout=15.0,
+        )
+        mock_status.assert_awaited_once_with(full_update=True)
+        assert client.state.dock_task_timer(DOCK_TASK_DRY_DUST_BIN) is None
+
+    @pytest.mark.asyncio
+    async def test_unscoped_stop_rejects_multiple_scoped_tasks(self) -> None:
+        """An unscoped request cannot choose arbitrarily between typed tasks."""
+        client = NarwalClient("127.0.0.1")
+        client.state.set_dock_drying_task(
+            DOCK_TASK_DRY_DUST_BIN,
+            elapsed=60,
+            target=180,
+            fields=("10", "11"),
+        )
+        client.state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
+        )
+        client.state.dock_presence = 1
+
+        with patch.object(
+            client,
+            "get_status",
+            new_callable=AsyncMock,
+            return_value=self._docked_status_response(),
+        ), patch.object(client, "send_command", new_callable=AsyncMock) as command:
+            result = await client.stop_dock_task()
+
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+        command.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_stop_dock_task_keeps_timer_when_refresh_fails(self) -> None:
+        client = NarwalClient("127.0.0.1")
+        client.state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
+        )
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send, patch.object(
+            client, "_refresh_after_dock_stop", new_callable=AsyncMock
+        ) as mock_refresh, patch(
+            "narwal_client.client.asyncio.sleep", new_callable=AsyncMock
+        ):
+            mock_status.return_value = self._docked_status_response()
+            mock_send.return_value = success
+            mock_refresh.return_value = False
+            result = await client.stop_dock_task(DOCK_TASK_DRY_DOCK_BAG)
+
+        assert result is success
+        mock_status.assert_awaited_once_with(full_update=True)
+        assert client.state.dock_task_timer(DOCK_TASK_DRY_DOCK_BAG) is not None
+
+    @pytest.mark.asyncio
+    async def test_stop_dock_task_clears_timer_after_confirmed_idle_refresh(self) -> None:
+        """Accepted dock stop clears the stopped timer once fresh dock status is idle."""
+        client = NarwalClient("127.0.0.1")
+        client.state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
+        )
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+
+        async def refresh_idle() -> bool:
+            client.state.update_from_base_status(
+                {"3": {"1": int(WorkingStatus.DOCKED), "3": 6}, "11": 2}
+            )
+            return True
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send, patch.object(
+            client, "_refresh_after_dock_stop", new_callable=AsyncMock
+        ) as mock_refresh, patch(
+            "narwal_client.client.asyncio.sleep", new_callable=AsyncMock
+        ):
+            mock_status.return_value = self._docked_status_response()
+            mock_send.return_value = success
+            mock_refresh.side_effect = refresh_idle
+            result = await client.stop_dock_task(DOCK_TASK_DRY_DOCK_BAG)
+
+        assert result is success
+        mock_status.assert_awaited_once_with(full_update=True)
+        assert client.state.dock_task_timer(DOCK_TASK_DRY_DOCK_BAG) is None
+
+    @pytest.mark.asyncio
+    async def test_concurrent_direct_dock_stops_serialize_preflight(self) -> None:
+        """Only one direct dock stop validates an active task snapshot."""
+        client = NarwalClient("127.0.0.1")
+        client.state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
+        )
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        command_started = asyncio.Event()
+        release_command = asyncio.Event()
+
+        async def slow_send(*args, **kwargs):
+            command_started.set()
+            await release_command.wait()
+            return success
+
+        async def refresh_state():
+            client.state.clear_dock_drying_task(DOCK_TASK_DRY_DOCK_BAG)
+            return True
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send, patch.object(
+            client, "_refresh_after_dock_stop", new_callable=AsyncMock
+        ) as mock_refresh, patch(
+            "narwal_client.client.asyncio.sleep", new_callable=AsyncMock
+        ):
+            mock_status.return_value = self._docked_status_response()
+            mock_send.side_effect = slow_send
+            mock_refresh.side_effect = refresh_state
+            first = asyncio.create_task(client.stop_dock_task(DOCK_TASK_DRY_DOCK_BAG))
+            await command_started.wait()
+            second = asyncio.create_task(client.stop_dock_task(DOCK_TASK_DRY_DOCK_BAG))
+            await asyncio.sleep(0)
+            release_command.set()
+            first_result, second_result = await asyncio.gather(first, second)
+
+        assert first_result is success
+        assert second_result.result_code == CommandResult.NOT_APPLICABLE
+        mock_send.assert_awaited_once_with(
+            TOPIC_CMD_FORCE_END,
+            payload=b"\x08\x01",
+            timeout=15.0,
+        )
+        assert mock_status.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_refresh_after_dock_stop_rejects_missing_base_status_payload(self) -> None:
+        client = NarwalClient("127.0.0.1")
+
+        with patch.object(client, "get_status", new_callable=AsyncMock) as mock_status:
+            mock_status.return_value = CommandResponse(
+                result_code=CommandResult.NOT_READY,
+                data={"1": 1},
+            )
+            assert not await client._refresh_after_dock_stop()
+
+        mock_status.assert_awaited_once_with(full_update=True)
+
+    @pytest.mark.asyncio
+    async def test_refresh_after_dock_stop_rejects_empty_dock_status(self) -> None:
+        """An empty dock-status submessage must not clear active dock tasks."""
+        client = NarwalClient("127.0.0.1")
+
+        with patch.object(client, "get_status", new_callable=AsyncMock) as mock_status:
+            mock_status.return_value = CommandResponse(data={"2": {"3": {}}})
+            assert not await client._refresh_after_dock_stop()
+
+        mock_status.assert_awaited_once_with(full_update=True)
+
+    @pytest.mark.asyncio
+    async def test_dock_stop_refresh_preserves_recent_cleaning_state(self) -> None:
+        """Dock refreshes cannot replace authoritative live cleaning telemetry."""
+        client = NarwalClient("127.0.0.1")
+        client.state.working_status = WorkingStatus.CLEANING
+        client.state.last_active_working_status_time = time.monotonic()
+
+        with patch.object(client, "get_status", new_callable=AsyncMock) as mock_status:
+            mock_status.return_value = self._docked_status_response()
+
+            assert await client._refresh_after_dock_stop()
+
+        mock_status.assert_awaited_once_with(full_update=False)
+
+    @pytest.mark.asyncio
+    async def test_pre_stop_refresh_preserves_recent_cleaning_state(self) -> None:
+        """Scoped stop identification also keeps the live robot task authoritative."""
+        client = NarwalClient("127.0.0.1")
+        client.state.working_status = WorkingStatus.CLEANING
+        client.state.last_active_working_status_time = time.monotonic()
+
+        with patch.object(client, "get_status", new_callable=AsyncMock) as mock_status:
+            mock_status.return_value = self._docked_status_response()
+
+            await client._refresh_before_dock_stop(None)
+
+        mock_status.assert_awaited_once_with(full_update=False)
+
+    @pytest.mark.asyncio
+    async def test_stop_dock_task_rejects_ambiguous_generic_stop(self) -> None:
+        client = NarwalClient("127.0.0.1")
+        client.state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+        client.state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
+        )
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(client, "stop", new_callable=AsyncMock) as mock_stop:
+            mock_status.return_value = self._docked_status_response()
+            result = await client.stop_dock_task(DOCK_TASK_DRY_MOP)
+
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+        mock_status.assert_awaited_once_with(full_update=True)
+        mock_stop.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_stop_dock_task_rejects_unmapped_activity(self) -> None:
+        """Unknown active dock work is not safe to stop with the generic command."""
+        client = NarwalClient("127.0.0.1")
+        client.state.station_activity = 99
+
+        with patch.object(client, "stop", new_callable=AsyncMock) as mock_stop:
+            result = await client.stop_dock_task()
+
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+        mock_stop.assert_not_awaited()
+
 
 class TestBroadcastDumpLogging:
     """The DUMP debug line is a parsing contract for tools/, not decoration.
@@ -388,7 +1498,7 @@ class TestBroadcastDumpLogging:
                 await client._handle_message(frame)
 
         dumps = [r.getMessage() for r in caplog.records if "DUMP " in r.getMessage()]
-        assert dumps, "no DUMP line emitted — tools/ capture scripts rely on it"
+        assert dumps, "no DUMP line emitted - tools/ capture scripts rely on it"
         assert dumps[0].startswith("DUMP status/working_status: ")
         assert "{'1': 4}" in dumps[0]
 
@@ -396,7 +1506,7 @@ class TestBroadcastDumpLogging:
     async def test_dump_line_is_debug_only(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """DUMP must not reach INFO — it fires on every broadcast."""
+        """DUMP must not reach INFO - it fires on every broadcast."""
         client, frame = self._client_with_broadcast()
 
         with caplog.at_level(logging.INFO, logger="narwal_client.client"):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -892,7 +892,7 @@ class TestDockTaskCommands:
             timeout=15.0,
         )
         mock_status.assert_awaited_once_with(full_update=True)
-        assert client.state.dock_task_timer(DOCK_TASK_DRY_DOCK_BAG) is not None
+        assert DOCK_TASK_DRY_DOCK_BAG not in client.state.dock_drying_tasks
 
     @pytest.mark.asyncio
     async def test_stop_dry_station_bag_allows_unmapped_coarse_activity(self) -> None:
@@ -1211,7 +1211,7 @@ class TestDockTaskCommands:
             timeout=15.0,
         )
         mock_status.assert_awaited_once_with(full_update=True)
-        assert client.state.dock_task_timer(DOCK_TASK_DRY_DUST_BIN) is None
+        assert DOCK_TASK_DRY_DUST_BIN not in client.state.dock_drying_tasks
 
     @pytest.mark.asyncio
     async def test_unscoped_stop_dry_dust_bag_uses_scoped_force_end(self) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -438,6 +438,22 @@ class TestWholeHouseStart:
         mock_send.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_saved_plan_start_reserves_private_guard_on_acceptance(self) -> None:
+        """Saved-plan fallback shares the direct-start action reservation."""
+        client = self._connected_client()
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = success
+            first = await client.start_rooms([])
+            second = await client.start_rooms([])
+
+        assert first is success
+        assert second.result_code == CommandResult.NOT_APPLICABLE
+        assert client.state.has_assumed_robot_clean
+        mock_send.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_concurrent_direct_start_rooms_serialize_preflight(self) -> None:
         """Only one direct room start validates before the accepted-command guard."""
         client = self._connected_client()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -18,12 +18,18 @@ import tests.ha_stubs  # noqa: E402
 tests.ha_stubs.install()
 
 from custom_components.narwal.const import NO_BROADCAST_PRODUCT_KEYS  # noqa: E402
-from custom_components.narwal.coordinator import (
+from custom_components.narwal.coordinator import (  # noqa: E402
     TOPIC_RESUBSCRIBE_AFTER,
     TOPIC_SUBSCRIPTION_TTL,
     NarwalCoordinator,
-)  # noqa: E402
-from custom_components.narwal.narwal_client import NarwalConnectionError, NarwalState  # noqa: E402
+)
+from custom_components.narwal.narwal_client import (  # noqa: E402
+    CommandResponse,
+    CommandResult,
+    NarwalConnectionError,
+    NarwalState,
+    WorkingStatus,
+)
 
 UpdateFailed = sys.modules["homeassistant.helpers.update_coordinator"].UpdateFailed
 
@@ -72,7 +78,9 @@ class TestCoordinatorResilience:
         coordinator.config_entry = mock_entry
         coordinator.client = MagicMock()
         coordinator.client.state = NarwalState()
+        coordinator.last_update_success = True
         coordinator._consecutive_failures = 0
+        coordinator._dock_status_refresh_failed = False
         coordinator._max_failures = 5
         coordinator._consumable_poll_countdown = 99  # don't fire consumable poll in unit tests
         coordinator._fast_poll_remaining = 0
@@ -134,7 +142,9 @@ class TestCoordinatorResilience:
 
         # Now succeed
         type(coordinator.client).connected = PropertyMock(return_value=True)
-        coordinator.client.get_status = AsyncMock()
+        coordinator.client.get_status = AsyncMock(
+            return_value=CommandResponse(data={"2": {"3": {"1": 10}}})
+        )
 
         result = await coordinator._async_update_data()
 
@@ -157,6 +167,7 @@ class TestCoordinatorResilience:
         """_on_state_update resets _consecutive_failures to 0."""
         coordinator = self._make_coordinator()
         coordinator._consecutive_failures = 3
+        coordinator._dock_status_refresh_failed = True
 
         # Mock methods called by _on_state_update
         coordinator.async_set_updated_data = MagicMock()
@@ -166,6 +177,7 @@ class TestCoordinatorResilience:
         coordinator._on_state_update(state)
 
         assert coordinator._consecutive_failures == 0
+        assert not coordinator.has_fresh_state
 
     async def test_poll_does_not_call_connect(self) -> None:
         """_async_update_data does NOT call client.connect() when disconnected."""
@@ -191,6 +203,133 @@ class TestCoordinatorResilience:
 
         assert result is coordinator.client.state
         assert coordinator._consecutive_failures == 1
+        assert not coordinator.has_fresh_state
+
+    async def test_payloadless_status_poll_counts_as_failed_refresh(self) -> None:
+        """A status ack without base-status data must not mark stale data fresh."""
+        coordinator = self._make_coordinator()
+        type(coordinator.client).connected = PropertyMock(return_value=True)
+        coordinator.client.get_status = AsyncMock(
+            return_value=CommandResponse(
+                result_code=CommandResult.NOT_READY,
+                data={"1": 1},
+            )
+        )
+
+        result = await coordinator._async_update_data()
+
+        assert result is coordinator.client.state
+        assert coordinator._consecutive_failures == 1
+
+    async def test_partial_status_poll_only_marks_dock_state_stale(self) -> None:
+        """A battery-only response proves connectivity, but not dock freshness."""
+        coordinator = self._make_coordinator()
+        type(coordinator.client).connected = PropertyMock(return_value=True)
+        coordinator.client.get_status = AsyncMock(
+            return_value=CommandResponse(data={"2": {"2": 85.0}})
+        )
+
+        result = await coordinator._async_update_data()
+
+        assert result is coordinator.client.state
+        assert coordinator._consecutive_failures == 0
+        assert not coordinator.has_fresh_state
+
+    async def test_refresh_dock_status_rejects_missing_base_status_payload(self) -> None:
+        """Dock command gates require fresh base-status data, not only an ack."""
+        coordinator = self._make_coordinator()
+        coordinator.client.get_status = AsyncMock(return_value=CommandResponse(data={}))
+        coordinator.async_set_updated_data = MagicMock()
+
+        assert not await coordinator.async_refresh_dock_status()
+
+        coordinator.client.get_status.assert_awaited_once_with(full_update=True)
+        coordinator.async_set_updated_data.assert_called_once_with(
+            coordinator.client.state
+        )
+
+    async def test_refresh_dock_status_rejects_rejected_status_response(self) -> None:
+        """Rejected status responses must not unlock dock controls."""
+        coordinator = self._make_coordinator()
+        coordinator.client.get_status = AsyncMock(
+            return_value=CommandResponse(
+                result_code=CommandResult.NOT_APPLICABLE,
+                data={"2": {"3": {"1": 10}}},
+            )
+        )
+        coordinator.async_set_updated_data = MagicMock()
+
+        assert not await coordinator.async_refresh_dock_status()
+
+    async def test_refresh_dock_status_rejects_partial_base_status_payload(self) -> None:
+        """Dock command gates require field 3, not just any base-status field."""
+        coordinator = self._make_coordinator()
+        coordinator.client.get_status = AsyncMock(
+            return_value=CommandResponse(data={"2": {"2": 85.0}})
+        )
+        coordinator.async_set_updated_data = MagicMock()
+
+        assert not await coordinator.async_refresh_dock_status()
+
+    async def test_refresh_dock_status_rejects_empty_dock_status_payload(self) -> None:
+        """Dock command gates require real status subfields inside field 3."""
+        coordinator = self._make_coordinator()
+        coordinator.client.get_status = AsyncMock(
+            return_value=CommandResponse(data={"2": {"3": {}}})
+        )
+        coordinator.async_set_updated_data = MagicMock()
+
+        assert not await coordinator.async_refresh_dock_status()
+
+    async def test_refresh_dock_status_marks_fresh_before_notifying(self) -> None:
+        """Listeners see fresh dock availability on the successful refresh update."""
+        coordinator = self._make_coordinator()
+        coordinator._dock_status_refresh_failed = True
+        coordinator.client.get_status = AsyncMock(
+            return_value=CommandResponse(
+                data={"2": {"3": {"1": int(WorkingStatus.DOCKED)}, "11": 2}}
+            )
+        )
+        seen: list[bool] = []
+
+        def capture_update(_state):
+            seen.append(coordinator.has_fresh_state)
+
+        coordinator.async_set_updated_data = MagicMock(side_effect=capture_update)
+
+        assert await coordinator.async_refresh_dock_status()
+        assert seen == [True]
+
+    async def test_refresh_dock_status_preserves_live_working_status(self) -> None:
+        """Action preflight must not clobber fresh working_status task telemetry."""
+        coordinator = self._make_coordinator()
+        coordinator.client.state.update_from_working_status({"3": 42})
+        coordinator.client.get_status = AsyncMock(
+            return_value=CommandResponse(data={"2": {"2": 85.0}})
+        )
+        coordinator.async_set_updated_data = MagicMock()
+
+        assert await coordinator.async_refresh_dock_status()
+
+        coordinator.client.get_status.assert_awaited_once_with(full_update=False)
+        assert not coordinator._dock_status_refresh_failed
+
+    async def test_refresh_dock_status_marks_stale_before_notifying(self) -> None:
+        """Listeners see stale dock availability on the failed refresh update."""
+        coordinator = self._make_coordinator()
+        coordinator._dock_status_refresh_failed = False
+        coordinator.client.get_status = AsyncMock(
+            return_value=CommandResponse(data={"2": {"2": 85.0}})
+        )
+        seen: list[bool] = []
+
+        def capture_update(_state):
+            seen.append(coordinator.has_fresh_state)
+
+        coordinator.async_set_updated_data = MagicMock(side_effect=capture_update)
+
+        assert not await coordinator.async_refresh_dock_status()
+        assert seen == [False]
 
 
 class TestTopicSubscriptionRenewal:
@@ -215,7 +354,9 @@ class TestTopicSubscriptionRenewal:
         c.client = MagicMock()
         c.client.state = NarwalState()
         c.client.connected = True
-        c.client.get_status = AsyncMock()
+        c.client.get_status = AsyncMock(
+            return_value=CommandResponse(data={"2": {"3": {"1": 10}}})
+        )
         c.client.get_map = AsyncMock()
         c.client.get_consumable_info = AsyncMock()
         c.client.subscribe_to_topics = AsyncMock()

--- a/tests/test_dock_tasks.py
+++ b/tests/test_dock_tasks.py
@@ -1,0 +1,550 @@
+"""Tests for Narwal dock task entities and command gates."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import tests.ha_stubs
+
+tests.ha_stubs.install()
+
+from homeassistant.exceptions import HomeAssistantError  # noqa: E402
+
+from custom_components.narwal.dock_tasks import (  # noqa: E402
+    can_start_dock_task,
+    can_start_robot_clean,
+    can_stop_dock_task,
+)
+from custom_components.narwal.switch import (  # noqa: E402
+    DOCK_TASK_SWITCHES,
+    NarwalDockTaskSwitch,
+)
+from narwal_client.const import CommandResult, WorkingStatus  # noqa: E402
+from narwal_client.models import (  # noqa: E402
+    DOCK_TASK_DRY_DOCK_BAG,
+    DOCK_TASK_DRY_DUST_BIN,
+    DOCK_TASK_DRY_MOP,
+    DOCK_TASK_EMPTY_DUSTBIN,
+    DOCK_TASK_WASH_MOP,
+    CommandResponse,
+    NarwalState,
+)
+
+
+def _docked_state() -> NarwalState:
+    """Return an idle on-dock state."""
+    state = NarwalState(working_status=WorkingStatus.DOCKED)
+    state.dock_presence = 6
+    state.dock_field11 = 2
+    state.dock_field47 = 3
+    return state
+
+
+def _coordinator(state: NarwalState | None = None) -> MagicMock:
+    """Return a minimal coordinator stub for switch entity tests."""
+    state = state or _docked_state()
+    coordinator = MagicMock()
+    coordinator.config_entry.data = {"device_id": "test_device", "model": "flow"}
+    coordinator.config_entry.title = "Narwal Test"
+    coordinator.config_entry.options = {}
+    coordinator.client.state = state
+    coordinator.client.robot_awake = True
+    coordinator.data = state
+    coordinator.last_update_success = True
+    coordinator.has_fresh_state = True
+    coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+    coordinator.dock_action_lock = asyncio.Lock()
+    return coordinator
+
+
+def _switch(task_key: str, state: NarwalState | None = None) -> NarwalDockTaskSwitch:
+    """Build one dock task switch by key."""
+    descriptions = {description.key: description for description in DOCK_TASK_SWITCHES}
+    return NarwalDockTaskSwitch(_coordinator(state), descriptions[task_key])
+
+
+def test_five_dock_task_switches_are_exposed() -> None:
+    """The dock exposes exactly the five app-visible task controls."""
+    assert [description.key for description in DOCK_TASK_SWITCHES] == [
+        DOCK_TASK_EMPTY_DUSTBIN,
+        DOCK_TASK_WASH_MOP,
+        DOCK_TASK_DRY_MOP,
+        DOCK_TASK_DRY_DUST_BIN,
+        DOCK_TASK_DRY_DOCK_BAG,
+    ]
+
+
+def test_dock_task_switch_belongs_to_dock_device() -> None:
+    """Dock task controls are grouped under the dock device."""
+    switch = _switch(DOCK_TASK_EMPTY_DUSTBIN)
+
+    assert switch._attr_device_info["identifiers"] == {("narwal", "test_device_dock")}
+    assert switch._attr_device_info["via_device"] == ("narwal", "test_device")
+
+
+def test_idle_docked_state_can_start_any_single_task() -> None:
+    """An idle dock exposes start controls for all known tasks."""
+    state = _docked_state()
+
+    assert can_start_dock_task(state)
+    assert all(
+        can_start_dock_task(state, description.key)
+        for description in DOCK_TASK_SWITCHES
+    )
+
+
+def test_docked_v2_with_off_dock_fields_hides_dock_start_controls() -> None:
+    """A coarse docked status is not enough when dock telemetry says off-dock."""
+    state = NarwalState()
+    state.update_from_base_status({"3": {"1": 2}, "11": 1, "47": 2})
+
+    assert not state.is_docked
+    assert not can_start_dock_task(state, DOCK_TASK_EMPTY_DUSTBIN)
+
+
+def test_cleaning_state_hides_dock_start_controls() -> None:
+    """Robot cleaning context blocks dock starts."""
+    state = NarwalState(working_status=WorkingStatus.CLEANING)
+    state.dock_presence = 2
+    state.dock_field11 = 1
+    state.dock_field47 = 2
+
+    assert not can_start_dock_task(state, DOCK_TASK_EMPTY_DUSTBIN)
+
+
+def test_task_completed_state_hides_dock_start_controls() -> None:
+    """TASK_COMPLETED is still return-to-dock context, not an idle station."""
+    state = _docked_state()
+    state.working_status = WorkingStatus.TASK_COMPLETED
+
+    assert not can_start_dock_task(state, DOCK_TASK_EMPTY_DUSTBIN)
+
+
+def test_unknown_working_status_hides_dock_start_controls() -> None:
+    """Unknown robot status is not treated as safe dock-idle state."""
+    state = _docked_state()
+    state.working_status = WorkingStatus.UNKNOWN
+
+    assert not can_start_dock_task(state, DOCK_TASK_EMPTY_DUSTBIN)
+    assert not can_start_robot_clean(state)
+    assert not can_stop_dock_task(state, DOCK_TASK_EMPTY_DUSTBIN)
+
+
+def test_assumed_robot_clean_hides_dock_start_controls() -> None:
+    """An accepted robot start blocks dock starts until telemetry catches up."""
+    state = _docked_state()
+    state.assume_robot_clean()
+
+    assert not can_start_dock_task(state, DOCK_TASK_EMPTY_DUSTBIN)
+    assert not can_start_robot_clean(state)
+
+
+def test_active_known_task_is_on_and_stoppable() -> None:
+    """Coarse station activity maps to the relevant dock task switch."""
+    state = _docked_state()
+    state.station_activity = 1
+
+    empty = _switch(DOCK_TASK_EMPTY_DUSTBIN, state)
+    wash = _switch(DOCK_TASK_WASH_MOP, state)
+
+    assert empty.is_on
+    assert empty.available
+    assert not wash.is_on
+    assert not wash.available
+
+
+def test_active_switch_is_unavailable_until_its_stop_is_safe() -> None:
+    """An active switch cannot advertise a stop that its service rejects."""
+    state = _docked_state()
+    state.assume_dock_task(DOCK_TASK_DRY_DOCK_BAG)
+    switch = _switch(DOCK_TASK_DRY_DOCK_BAG, state)
+
+    assert switch.is_on
+    assert not switch.available
+
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_DOCK_BAG,
+        elapsed=45,
+        target=180,
+        fields=("12", "13"),
+    )
+    assert switch.available
+
+
+def test_multi_task_switch_is_available_only_for_a_scoped_stop() -> None:
+    """Parallel telemetry exposes only a task with an unambiguous stop payload."""
+    state = _docked_state()
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_MOP,
+        elapsed=45,
+        target=180,
+        fields=("8", "9"),
+    )
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_DOCK_BAG,
+        elapsed=45,
+        target=180,
+        fields=("12", "13"),
+    )
+
+    assert not _switch(DOCK_TASK_DRY_MOP, state).available
+    assert _switch(DOCK_TASK_DRY_DOCK_BAG, state).available
+
+
+def test_dock_task_switch_available_to_refresh_stale_connected_state() -> None:
+    """A connected switch remains actionable so its service can wake and refresh."""
+    state = _docked_state()
+    state.working_status = WorkingStatus.CLEANING
+    coordinator = _coordinator(state)
+    coordinator.has_fresh_state = False
+    switch = NarwalDockTaskSwitch(coordinator, DOCK_TASK_SWITCHES[0])
+
+    assert switch.available
+
+
+def test_dock_task_switch_unavailable_when_disconnected() -> None:
+    coordinator = _coordinator()
+    coordinator.client.connected = False
+    switch = NarwalDockTaskSwitch(coordinator, DOCK_TASK_SWITCHES[0])
+
+    assert not switch.available
+
+
+async def test_stale_dock_task_start_forces_wake_before_refresh() -> None:
+    coordinator = _coordinator()
+    coordinator.has_fresh_state = False
+    coordinator.client.wake = AsyncMock(return_value=True)
+    coordinator.client.empty_dustbin = AsyncMock(
+        return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+    )
+    switch = NarwalDockTaskSwitch(coordinator, DOCK_TASK_SWITCHES[0])
+
+    await switch.async_turn_on()
+
+    coordinator.client.wake.assert_awaited_once_with(timeout=10.0, force=True)
+    coordinator.client.empty_dustbin.assert_awaited_once()
+
+
+async def test_cached_active_dock_task_is_rechecked_before_start() -> None:
+    """A stale active bit must not discard a start after refresh clears it."""
+    state = _docked_state()
+    state.assume_dock_task(DOCK_TASK_EMPTY_DUSTBIN)
+    coordinator = _coordinator(state)
+    coordinator.client.empty_dustbin = AsyncMock(
+        return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+    )
+
+    async def refresh_dock_status() -> bool:
+        state.clear_assumed_dock_task(DOCK_TASK_EMPTY_DUSTBIN)
+        return True
+
+    coordinator.async_refresh_dock_status = AsyncMock(side_effect=refresh_dock_status)
+    switch = NarwalDockTaskSwitch(coordinator, DOCK_TASK_SWITCHES[0])
+
+    await switch.async_turn_on()
+
+    coordinator.async_refresh_dock_status.assert_awaited()
+    coordinator.client.empty_dustbin.assert_awaited_once()
+
+
+async def test_stale_dock_bag_stop_does_not_force_wake_during_cleaning() -> None:
+    """A live clean must not receive a disruptive forced wake burst."""
+    state = _docked_state()
+    state.working_status = WorkingStatus.CLEANING
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_DOCK_BAG,
+        elapsed=45,
+        target=180,
+        fields=("12", "13"),
+    )
+    coordinator = _coordinator(state)
+    coordinator.has_fresh_state = False
+    coordinator.client.wake = AsyncMock(return_value=True)
+    coordinator.client.stop_dock_task = AsyncMock(
+        return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+    )
+    switch = NarwalDockTaskSwitch(coordinator, DOCK_TASK_SWITCHES[4])
+
+    await switch.async_turn_off()
+
+    coordinator.client.wake.assert_not_awaited()
+    coordinator.client.stop_dock_task.assert_awaited_once_with(
+        DOCK_TASK_DRY_DOCK_BAG
+    )
+
+
+def test_unmapped_dock_activity_blocks_start_and_stop() -> None:
+    """Unknown station activity is not treated as safe idle state."""
+    state = _docked_state()
+    state.station_activity = 99
+
+    assert not can_start_dock_task(state, DOCK_TASK_EMPTY_DUSTBIN)
+    assert not can_stop_dock_task(state)
+
+
+def test_dock_task_attributes_use_timer_progress() -> None:
+    """Task switches expose coarse time-left and percent progress attributes."""
+    state = _docked_state()
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_MOP,
+        elapsed=61,
+        target=180,
+        fields=("8", "9"),
+    )
+    switch = _switch(DOCK_TASK_DRY_MOP, state)
+
+    assert switch.extra_state_attributes == {
+        "time_left": "2m",
+        "progress": 34,
+    }
+
+
+def test_dry_dust_bin_is_active_and_stoppable() -> None:
+    """Dry dust-bin remains visible and can be stopped with its scoped command."""
+    state = _docked_state()
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_DUST_BIN,
+        elapsed=61,
+        target=180,
+        fields=("10", "11"),
+    )
+    switch = _switch(DOCK_TASK_DRY_DUST_BIN, state)
+
+    assert switch.is_on
+    assert switch.available
+    assert can_stop_dock_task(state)
+    assert can_stop_dock_task(state, DOCK_TASK_DRY_DUST_BIN)
+    assert switch.extra_state_attributes == {
+        "time_left": "2m",
+        "progress": 34,
+    }
+
+
+async def test_active_dry_dust_bin_switch_stops_with_scoped_command() -> None:
+    """The dry dust-bin switch uses the validated scoped stop path."""
+    state = _docked_state()
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_DUST_BIN,
+        elapsed=61,
+        target=180,
+        fields=("10", "11"),
+    )
+    coordinator = _coordinator(state)
+    coordinator.client.stop_dock_task = AsyncMock(
+        return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+    )
+    switch = NarwalDockTaskSwitch(coordinator, DOCK_TASK_SWITCHES[3])
+
+    await switch.async_turn_off()
+
+    coordinator.client.stop_dock_task.assert_awaited_once_with(DOCK_TASK_DRY_DUST_BIN)
+
+
+def test_multiple_tasks_only_allow_scoped_stop() -> None:
+    """Generic stop is unavailable for ambiguous multi-task dock activity."""
+    state = _docked_state()
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_MOP,
+        elapsed=30,
+        target=180,
+        fields=("8", "9"),
+    )
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_DOCK_BAG,
+        elapsed=45,
+        target=180,
+        fields=("12", "13"),
+    )
+
+    assert not can_stop_dock_task(state)
+    assert not can_stop_dock_task(state, DOCK_TASK_DRY_MOP)
+    assert can_stop_dock_task(state, DOCK_TASK_DRY_DOCK_BAG)
+
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_DUST_BIN,
+        elapsed=45,
+        target=180,
+        fields=("10", "11"),
+    )
+    assert can_stop_dock_task(state, DOCK_TASK_DRY_DUST_BIN)
+
+
+def test_clean_session_context_rejects_unscoped_dock_stop() -> None:
+    """Generic force-end must not be exposed while robot work is current."""
+    state = _docked_state()
+    state.working_status = WorkingStatus.CLEANING
+    state.station_activity = 1
+
+    assert not can_stop_dock_task(state)
+    assert not can_stop_dock_task(state, DOCK_TASK_EMPTY_DUSTBIN)
+
+
+def test_task_completed_allows_typed_empty_dustbin_stop() -> None:
+    """Dock emptying reports TASK_COMPLETED while its generic stop is valid."""
+    state = _docked_state()
+    state.working_status = WorkingStatus.TASK_COMPLETED
+    state.station_activity = 1
+
+    assert can_stop_dock_task(state)
+    assert can_stop_dock_task(state, DOCK_TASK_EMPTY_DUSTBIN)
+
+
+def test_task_completed_rejects_empty_dustbin_stop_without_dock_proof() -> None:
+    """Generic dock stop is unsafe without an explicit dock presence signal."""
+    state = NarwalState(working_status=WorkingStatus.TASK_COMPLETED)
+    state.station_activity = 1
+
+    assert not can_stop_dock_task(state)
+    assert not can_stop_dock_task(state, DOCK_TASK_EMPTY_DUSTBIN)
+
+
+def test_scoped_dry_stop_requires_telemetry_not_only_assumption() -> None:
+    """Scoped force-end is hidden until the dry task is typed by telemetry."""
+    state = _docked_state()
+    state.assume_dock_task(DOCK_TASK_DRY_DOCK_BAG)
+
+    assert not can_stop_dock_task(state, DOCK_TASK_DRY_DOCK_BAG)
+
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_DOCK_BAG,
+        elapsed=45,
+        target=180,
+        fields=("12", "13"),
+    )
+    assert can_stop_dock_task(state, DOCK_TASK_DRY_DOCK_BAG)
+
+
+def test_clean_session_context_allows_scoped_dock_bag_stop() -> None:
+    """The scoped dock-bag payload remains safe during robot-side work."""
+    state = _docked_state()
+    state.working_status = WorkingStatus.TASK_COMPLETED
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_DOCK_BAG,
+        elapsed=45,
+        target=180,
+        fields=("12", "13"),
+    )
+
+    assert can_stop_dock_task(state, DOCK_TASK_DRY_DOCK_BAG)
+
+
+def test_unmapped_coarse_activity_allows_scoped_dock_bag_stop() -> None:
+    """Typed dock-bag telemetry can still be force-ended with stale coarse fields."""
+    state = _docked_state()
+    state.station_activity = 99
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_DOCK_BAG,
+        elapsed=45,
+        target=180,
+        fields=("12", "13"),
+    )
+
+    assert not can_stop_dock_task(state)
+    assert can_stop_dock_task(state, DOCK_TASK_DRY_DOCK_BAG)
+    assert not can_stop_dock_task(state, DOCK_TASK_DRY_MOP)
+
+
+def test_robot_clean_start_allows_only_typed_dock_bag() -> None:
+    """Robot starts are blocked by dock work except typed dock-bag drying."""
+    state = _docked_state()
+    state.assume_dock_task(DOCK_TASK_DRY_DOCK_BAG)
+    assert not can_start_robot_clean(state)
+
+    state = _docked_state()
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_DOCK_BAG,
+        elapsed=45,
+        target=180,
+        fields=("12", "13"),
+    )
+    assert can_start_robot_clean(state)
+
+
+async def test_wash_mop_switch_uses_status_gated_command() -> None:
+    """Wash mop uses the app-style status-gated dock command directly."""
+    coordinator = _coordinator()
+    coordinator.client.wash_mop = AsyncMock(
+        return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+    )
+    coordinator.client.wash_mop_by_robot_status = AsyncMock(
+        return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+    )
+    switch = NarwalDockTaskSwitch(coordinator, DOCK_TASK_SWITCHES[1])
+
+    await switch.async_turn_on()
+
+    coordinator.client.wash_mop.assert_not_awaited()
+    coordinator.client.wash_mop_by_robot_status.assert_awaited_once()
+
+
+async def test_successful_start_reserves_private_guard_when_post_refresh_fails() -> None:
+    """Accepted starts block follow-up commands without publishing task state."""
+    coordinator = _coordinator()
+    coordinator.client.empty_dustbin = AsyncMock(
+        side_effect=lambda: (
+            coordinator.client.state.assume_dock_task(DOCK_TASK_EMPTY_DUSTBIN)
+            or CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+    )
+    refresh_calls = 0
+
+    async def refresh_dock_status() -> bool:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        if refresh_calls == 2:
+            coordinator.has_fresh_state = False
+            return False
+        return True
+
+    coordinator.async_refresh_dock_status = AsyncMock(side_effect=refresh_dock_status)
+    switch = NarwalDockTaskSwitch(coordinator, DOCK_TASK_SWITCHES[0])
+
+    await switch.async_turn_on()
+
+    assert switch.is_on
+    assert switch.available
+    coordinator.client.empty_dustbin.assert_awaited_once()
+
+
+async def test_concurrent_starts_are_serialized_by_local_reservation() -> None:
+    """Two start requests cannot both dispatch against the same idle state."""
+    coordinator = _coordinator()
+    empty_switch = NarwalDockTaskSwitch(coordinator, DOCK_TASK_SWITCHES[0])
+    wash_switch = NarwalDockTaskSwitch(coordinator, DOCK_TASK_SWITCHES[1])
+    coordinator.client.empty_dustbin = AsyncMock(
+        side_effect=lambda: (
+            coordinator.client.state.assume_dock_task(DOCK_TASK_EMPTY_DUSTBIN)
+            or CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+    )
+    coordinator.client.wash_mop = AsyncMock(
+        return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+    )
+    coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+
+    results = await asyncio.gather(
+        empty_switch.async_turn_on(),
+        wash_switch.async_turn_on(),
+        return_exceptions=True,
+    )
+
+    assert not isinstance(results[0], Exception)
+    assert isinstance(results[1], HomeAssistantError)
+    coordinator.client.empty_dustbin.assert_awaited_once()
+    coordinator.client.wash_mop.assert_not_awaited()
+
+
+async def test_switch_blocks_command_when_preflight_refresh_fails() -> None:
+    """A failed pre-command state refresh prevents sending a start command."""
+    coordinator = _coordinator()
+    coordinator.async_refresh_dock_status = AsyncMock(return_value=False)
+    coordinator.client.empty_dustbin = AsyncMock()
+    switch = NarwalDockTaskSwitch(coordinator, DOCK_TASK_SWITCHES[0])
+
+    with pytest.raises(HomeAssistantError):
+        await switch.async_turn_on()
+
+    coordinator.client.empty_dustbin.assert_not_awaited()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,9 +4,16 @@ from __future__ import annotations
 
 import logging
 import struct
+from dataclasses import replace
+from unittest.mock import patch
 
 from narwal_client.const import WorkingStatus
 from narwal_client.models import (
+    DOCK_TASK_DRY_DOCK_BAG,
+    DOCK_TASK_DRY_DUST_BIN,
+    DOCK_TASK_DRY_MOP,
+    DOCK_TASK_EMPTY_DUSTBIN,
+    DOCK_TASK_WASH_MOP,
     MapData,
     NarwalState,
     ObstacleInfo,
@@ -45,6 +52,149 @@ class TestNarwalState:
         state.update_from_working_status({"13": 18000})
         assert state.working_status == WorkingStatus.UNKNOWN
         assert not state.has_recent_active_working_status
+
+    def test_working_status_maps_dock_task_timers(self) -> None:
+        """Typed dock timer pairs expose task progress without marking cleaning."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 10, "3": 6}, "11": 2, "47": 3})
+
+        state.update_from_working_status({"8": 90, "9": 300, "12": 60, "13": 180})
+
+        assert state.active_dock_task_keys == (
+            DOCK_TASK_DRY_MOP,
+            DOCK_TASK_DRY_DOCK_BAG,
+        )
+        assert not state.is_cleaning
+        timer = state.dock_task_timer(DOCK_TASK_DRY_DOCK_BAG)
+        assert timer is not None
+        assert timer.remaining == 120
+        assert timer.progress_percent == 33
+
+    def test_dry_dock_bag_timer_survives_robot_departure(self) -> None:
+        """Dock-bag drying can continue after the robot leaves the dock."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 10, "3": 6}, "11": 2, "47": 3})
+        state.update_from_working_status({"12": 60, "13": 180})
+
+        state.update_from_base_status({"3": {"1": 4}, "11": 1, "47": 2})
+
+        assert state.active_dock_task_keys == (DOCK_TASK_DRY_DOCK_BAG,)
+        assert state.dock_task_timer(DOCK_TASK_DRY_DOCK_BAG) is not None
+
+    def test_other_dock_timers_require_dock_presence(self) -> None:
+        """Robot-owned dock timers are hidden once the robot is explicitly away."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 10, "3": 6}, "11": 2, "47": 3})
+        state.update_from_working_status({"10": 60, "11": 180})
+
+        state.update_from_base_status({"3": {"1": 4}, "11": 1, "47": 2})
+
+        assert state.active_dock_task_keys == ()
+        assert state.dock_task_timer(DOCK_TASK_DRY_DUST_BIN) is None
+
+    def test_docked_v2_with_off_dock_fields_is_not_docked(self) -> None:
+        """Explicit dock fields override a coarse DOCKED_V2 working status."""
+        state = NarwalState()
+
+        state.update_from_base_status({"3": {"1": 2}, "11": 1, "47": 2})
+
+        assert state.working_status == WorkingStatus.DOCKED_V2
+        assert state.has_explicit_off_dock_signal
+        assert not state.is_docked
+
+    def test_explicit_off_dock_fields_override_retained_dock_activity(self) -> None:
+        """Coarse station activity cannot override current off-dock fields."""
+        state = NarwalState()
+
+        state.update_from_base_status(
+            {"3": {"1": 1, "3": 2, "12": 6}, "11": 1, "47": 2}
+        )
+
+        assert state.has_explicit_off_dock_signal
+        assert not state.is_docked
+
+    def test_dock_task_timer_uses_latest_reported_snapshot(self) -> None:
+        """Timer-backed dock tasks do not locally count down to completion."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 10, "3": 6}, "11": 2, "47": 3})
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=10,
+            target=20,
+            fields=("8", "9"),
+        )
+        timer = state.dock_drying_tasks[DOCK_TASK_DRY_MOP]
+        state.dock_drying_tasks[DOCK_TASK_DRY_MOP] = replace(
+            timer,
+            observed_at=timer.observed_at - 11,
+        )
+        timer = state.dock_drying_tasks[DOCK_TASK_DRY_MOP]
+
+        assert timer.remaining == 10
+        assert timer.progress_percent == 50
+        assert state.active_dock_task_keys == (DOCK_TASK_DRY_MOP,)
+
+    def test_zeroed_timers_do_not_create_dock_tasks(self) -> None:
+        """Configured timer totals at zero elapsed are idle, even with field 19."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 10, "3": 6, "12": 4}, "11": 2})
+
+        state.update_from_working_status(
+            {"8": 0, "9": 300, "12": 0, "13": 180, "19": 1}
+        )
+
+        assert state.active_dock_task_keys == ()
+        assert not state.has_unmapped_active_dock_task
+
+    def test_idle_timer_snapshot_suppresses_stale_station_drying(self) -> None:
+        """Fresh typed timer evidence beats stale coarse station drying state."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 10, "3": 6, "18": 4}, "11": 2})
+
+        state.update_from_working_status({"8": 0, "9": 300})
+
+        assert state.active_dock_task_keys == ()
+        assert not state.has_unmapped_active_dock_task
+        assert not state.is_station_active
+
+    def test_nested_room_field_does_not_clear_dock_drying_timer(self) -> None:
+        """A firmware-specific room payload in field 8 is not timer telemetry."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 10, "10": 1}, "11": 2})
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=300,
+            fields=("8", "9"),
+        )
+
+        state.update_from_working_status({"8": {"1": 4, "3": b"Kitchen"}})
+
+        assert state.active_dock_task_keys == (DOCK_TASK_DRY_MOP,)
+        assert not state.has_fresh_idle_dock_drying_snapshot
+
+    def test_unmapped_dock_timer_expires_by_freshness_window(self) -> None:
+        """Unmapped timer fields stop blocking when their packet is stale."""
+        state = NarwalState()
+        state.update_from_working_status({"14": 60, "15": 180})
+        state.dock_drying_status_time -= 181
+
+        assert not state.has_unmapped_active_dock_task
+
+    def test_zeroed_unmapped_timer_does_not_block_commands(self) -> None:
+        """A zeroed unknown timer pair is a configured total, not active work."""
+        state = NarwalState()
+        state.update_from_working_status({"14": 0, "15": 180})
+
+        assert not state.has_unmapped_active_dock_task
+
+    def test_unmapped_dock_timer_blocks_commands(self) -> None:
+        """Unmapped active timer pairs are kept as a blocking safety signal."""
+        state = NarwalState()
+        state.update_from_working_status({"14": 60, "15": 180})
+
+        assert state.active_dock_task_keys == ()
+        assert state.has_unmapped_active_dock_task
 
     def test_zeroed_task_metrics_do_not_mark_cleaning(self) -> None:
         """A zeroed session counter is not evidence of an active clean.
@@ -93,6 +243,209 @@ class TestNarwalState:
         assert state.working_status == WorkingStatus.DOCKED
         assert state.is_docked
 
+    def test_base_status_maps_station_activity_to_dock_tasks(self) -> None:
+        """Coarse station activity still names emptying and washing tasks."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 10, "3": 6, "18": 1}, "11": 2})
+        assert state.active_dock_task_keys == (DOCK_TASK_EMPTY_DUSTBIN,)
+
+        state.update_from_base_status({"3": {"1": 10, "3": 6, "18": 2}, "11": 2})
+        assert state.active_dock_task_keys == (DOCK_TASK_WASH_MOP,)
+
+    def test_unknown_station_activity_blocks_commands(self) -> None:
+        """Unknown station activity must not be exposed as an idle dock."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 10, "3": 6, "18": 99}, "11": 2})
+
+        assert state.active_dock_task_keys == ()
+        assert state.has_unmapped_active_dock_task
+
+    def test_unknown_dock_activity_blocks_commands(self) -> None:
+        """Unknown nonzero dock activity is not treated as a safe idle dock."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 10, "3": 6, "12": 99}, "11": 2})
+
+        assert state.active_dock_task_keys == ()
+        assert state.has_unmapped_active_dock_task
+
+    def test_idle_base_status_clears_stale_coarse_dock_activity(self) -> None:
+        """A later authoritative idle packet clears stale dock_activity."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 10, "3": 6, "12": 4}, "11": 2})
+        assert state.active_dock_task_keys == (DOCK_TASK_DRY_MOP,)
+
+        state.update_from_base_status({"3": {"1": 10, "3": 6}, "11": 2})
+
+        assert state.dock_activity == 0
+        assert state.active_dock_task_keys == ()
+
+    def test_stale_idle_base_status_preserves_private_dock_task_guard(self) -> None:
+        """Accepted command reservations block starts without publishing task state."""
+        state = NarwalState()
+        state.assume_dock_task(DOCK_TASK_EMPTY_DUSTBIN)
+
+        state.update_from_base_status({"3": {"1": 10, "3": 6}, "11": 2})
+
+        assert state.active_dock_task_keys == (DOCK_TASK_EMPTY_DUSTBIN,)
+        assert state.blocks_robot_start_for_dock_task
+
+    def test_confirmed_dock_task_clears_reservation_then_idle_clears_task(self) -> None:
+        """Hardware activity owns state once a reservation has been confirmed."""
+        state = NarwalState()
+        state.assume_dock_task(DOCK_TASK_EMPTY_DUSTBIN)
+
+        state.update_from_base_status({"3": {"1": 10, "3": 6, "18": 1}, "11": 2})
+
+        assert state.assumed_active_dock_task is None
+        assert state.active_dock_task_keys == (DOCK_TASK_EMPTY_DUSTBIN,)
+
+        state.update_from_base_status({"3": {"1": 10, "3": 6}, "11": 2})
+
+        assert state.active_dock_task_keys == ()
+
+    def test_active_cleaning_clears_stale_station_activity(self) -> None:
+        """Cleaning telemetry clears coarse dock activity from prior station work."""
+        state = NarwalState()
+        state.station_activity = 1
+        state.dock_activity = 4
+        state.assume_dock_task(DOCK_TASK_EMPTY_DUSTBIN)
+
+        state.update_from_working_status({"3": 120})
+
+        assert state.station_activity == 0
+        assert state.dock_activity == 0
+        assert not state.is_station_active
+        assert state.active_dock_task_keys == ()
+
+    def test_active_base_status_clears_stale_station_activity(self) -> None:
+        """Active robot base-status packets cannot keep stale dock switches on."""
+        state = NarwalState()
+        state.assume_dock_task(DOCK_TASK_EMPTY_DUSTBIN)
+
+        state.update_from_base_status({"3": {"1": 4, "12": 4, "18": 1}, "11": 2})
+
+        assert state.dock_activity == 0
+        assert state.station_activity == 0
+        assert state.active_dock_task_keys == ()
+
+    def test_dock_activity_is_timer_presence_signal(self) -> None:
+        """Dock activity alone is enough to keep a robot-owned timer visible."""
+        state = NarwalState()
+        state.dock_activity = 4
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+
+        assert state.dock_task_timer(DOCK_TASK_DRY_MOP) is not None
+
+    def test_explicit_docked_status_is_timer_presence_signal(self) -> None:
+        """Docked working status keeps typed dock timers active without field 11/47."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 2}})
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+
+        assert state.working_status == WorkingStatus.DOCKED_V2
+        assert state.is_docked
+        assert not state.has_dock_presence_signal
+        assert state.dock_task_timer(DOCK_TASK_DRY_MOP) is not None
+        assert state.active_dock_task_keys == (DOCK_TASK_DRY_MOP,)
+        assert state.blocks_robot_start_for_dock_task
+
+    def test_stale_dock_timer_does_not_remain_active(self) -> None:
+        """Typed dock timers stop driving visible state after telemetry expires."""
+        state = NarwalState()
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+
+        state.dock_drying_status_time -= 181
+
+        assert state.dock_task_timer(DOCK_TASK_DRY_MOP) is None
+        assert state.active_dock_task_keys == ()
+        assert not state.has_unmapped_active_dock_task
+        assert not state.blocks_robot_start_for_dock_task
+
+    def test_stale_dock_timer_with_station_activity_fails_closed(self) -> None:
+        """Stale typed identity cannot classify fresh-looking station work."""
+        state = NarwalState()
+        state.station_activity = 4
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+
+        state.dock_drying_status_time -= 181
+
+        assert state.dock_task_timer(DOCK_TASK_DRY_MOP) is None
+        assert state.active_dock_task_keys == ()
+        assert state.has_unmapped_active_dock_task
+        assert state.blocks_robot_start_for_dock_task
+
+    def test_robot_start_blocked_by_dock_work_except_typed_dock_bag(self) -> None:
+        """Only typed dock-bag drying is compatible with a new robot clean."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 10, "3": 6, "18": 1}, "11": 2})
+        assert state.blocks_robot_start_for_dock_task
+
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 10, "3": 6}, "11": 2})
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
+        )
+        assert not state.blocks_robot_start_for_dock_task
+
+        state.dock_drying_status_time -= 181
+
+        assert state.active_dock_task_keys == ()
+        assert not state.blocks_robot_start_for_dock_task
+
+    def test_assumed_dock_task_temporarily_blocks_robot_start(self) -> None:
+        """Accepted-command reservations block new robot starts until telemetry arrives."""
+        state = NarwalState()
+        state.assume_dock_task(DOCK_TASK_DRY_DOCK_BAG)
+
+        assert state.active_dock_task_keys == (DOCK_TASK_DRY_DOCK_BAG,)
+        assert state.blocks_robot_start_for_dock_task
+
+    def test_assumed_robot_clean_clears_on_active_telemetry(self) -> None:
+        """Accepted robot-start reservations stop once real cleaning status arrives."""
+        state = NarwalState()
+        state.assume_robot_clean()
+
+        state.update_from_working_status({"3": 120})
+
+        assert not state.has_assumed_robot_clean
+        assert state.is_cleaning
+
+    def test_dock_task_assumption_is_only_a_short_command_guard(self) -> None:
+        """Dock task assumptions must not fabricate long-running device state."""
+        state = NarwalState()
+
+        with patch("narwal_client.models.time.monotonic", return_value=1000.0):
+            state.assume_dock_task(DOCK_TASK_DRY_DOCK_BAG)
+        with patch("narwal_client.models.time.monotonic", return_value=1029.0):
+            assert state.assumed_active_dock_task == DOCK_TASK_DRY_DOCK_BAG
+            assert state.active_dock_task_keys == (DOCK_TASK_DRY_DOCK_BAG,)
+        with patch("narwal_client.models.time.monotonic", return_value=1031.0):
+            assert state.assumed_active_dock_task is None
+            assert state.active_dock_task_keys == ()
+
     def test_update_from_base_status_charged(self) -> None:
         """Status 14 = fully charged on dock."""
         state = NarwalState()
@@ -137,6 +490,13 @@ class TestNarwalState:
         assert state.working_status == WorkingStatus.STANDBY
         assert state.dock_field11 == 2
         assert state.dock_field47 == 3
+        assert state.is_docked
+
+    def test_update_from_base_status_standby_on_dock_presence_only(self) -> None:
+        """STANDBY with field 3.3 dock presence means on dock."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 1, "3": 6}})
+        assert state.working_status == WorkingStatus.STANDBY
         assert state.is_docked
 
     def test_update_from_base_status_standby_on_dock_field47_only(self) -> None:
@@ -240,7 +600,7 @@ class TestNarwalState:
     def test_unknown_working_status_value(self) -> None:
         """Unmapped working_status value falls back to UNKNOWN."""
         state = NarwalState()
-        state.update_from_base_status({"3": {"1": 99}})
+        state.update_from_base_status({"3": {"1": 255}})
         assert state.working_status == WorkingStatus.UNKNOWN
 
     def test_unknown_working_status_warns_once(self, caplog) -> None:
@@ -531,7 +891,7 @@ class TestNarwalState:
         assert state.is_cleaning
         assert not state.is_returning
 
-    def test_unknown_working_status_value(self) -> None:
+    def test_unknown_working_status_high_value(self) -> None:
         """Unknown status values should fall back to UNKNOWN."""
         state = NarwalState()
         state.update_from_base_status({"3": {"1": 255}})
@@ -571,7 +931,13 @@ class TestMapData:
             "4": 341,
             "5": 494,
             "6": {"1": -341, "2": 152, "3": -280, "4": 60},
-            "8": {"1": {"1": _float_to_uint32(-8.0188), "2": _float_to_uint32(0.221)}, "2": _float_to_uint32(0.036)},
+            "8": {
+                "1": {
+                    "1": _float_to_uint32(-8.0188),
+                    "2": _float_to_uint32(0.221),
+                },
+                "2": _float_to_uint32(0.036),
+            },
             "17": b"",
         }}
         m = MapData.from_response(decoded)
@@ -642,7 +1008,14 @@ class TestMapData:
                     {
                         "1": 1,
                         "2": 14,
-                        "3": {"1": {"1": _float_to_uint32(-110.5), "2": _float_to_uint32(-129.5)}, "2": _float_to_uint32(11.0), "3": _float_to_uint32(41.0)},
+                        "3": {
+                            "1": {
+                                "1": _float_to_uint32(-110.5),
+                                "2": _float_to_uint32(-129.5),
+                            },
+                            "2": _float_to_uint32(11.0),
+                            "3": _float_to_uint32(41.0),
+                        },
                         "4": _float_to_uint32(180.0),
                     },
                 ],
@@ -704,13 +1077,27 @@ class TestParseObstacles:
                 {
                     "1": 1,
                     "2": 14,
-                    "3": {"1": {"1": _float_to_uint32(-110.5), "2": _float_to_uint32(-129.5)}, "2": _float_to_uint32(11.0), "3": _float_to_uint32(41.0)},
+                    "3": {
+                        "1": {
+                            "1": _float_to_uint32(-110.5),
+                            "2": _float_to_uint32(-129.5),
+                        },
+                        "2": _float_to_uint32(11.0),
+                        "3": _float_to_uint32(41.0),
+                    },
                     "4": _float_to_uint32(180.0),
                 },
                 {
                     "1": 4,
                     "2": 2,
-                    "3": {"1": {"1": _float_to_uint32(10.0), "2": _float_to_uint32(95.5)}, "2": _float_to_uint32(36.0), "3": _float_to_uint32(29.0)},
+                    "3": {
+                        "1": {
+                            "1": _float_to_uint32(10.0),
+                            "2": _float_to_uint32(95.5),
+                        },
+                        "2": _float_to_uint32(36.0),
+                        "3": _float_to_uint32(29.0),
+                    },
                     "4": _float_to_uint32(180.0),
                 },
             ],
@@ -736,7 +1123,14 @@ class TestParseObstacles:
             "1": {
                 "1": 13,
                 "2": 4,
-                "3": {"1": {"1": _float_to_uint32(-154.0), "2": _float_to_uint32(-55.5)}, "2": _float_to_uint32(13.0), "3": _float_to_uint32(20.0)},
+                "3": {
+                    "1": {
+                        "1": _float_to_uint32(-154.0),
+                        "2": _float_to_uint32(-55.5),
+                    },
+                    "2": _float_to_uint32(13.0),
+                    "3": _float_to_uint32(20.0),
+                },
                 "4": _float_to_uint32(90.0),
             },
         }
@@ -753,7 +1147,14 @@ class TestParseObstacles:
             "1": {
                 "1": 1,
                 "2": 14,
-                "3": {"1": {"1": _float_to_uint32(-110.5), "2": _float_to_uint32(-129.5)}, "2": _float_to_uint32(11.0), "3": _float_to_uint32(41.0)},
+                "3": {
+                    "1": {
+                        "1": _float_to_uint32(-110.5),
+                        "2": _float_to_uint32(-129.5),
+                    },
+                    "2": _float_to_uint32(11.0),
+                    "3": _float_to_uint32(41.0),
+                },
                 "4": _float_to_uint32(180.0),
             },
         }
@@ -908,9 +1309,10 @@ class TestCurrentRoomTracking:
 
 
 class TestRoomInfoNames:
-    """Tests for the shared RoomType→name table (issue #22).
+    """Tests for the shared RoomType-to-name table (issue #22).
 
-    The app names rooms through one switch keyed only on the RoomType enum (no model parameter), so every model resolves the same names — taken verbatim from the app's en-US.json.
+    The app names rooms through one switch keyed only on the RoomType enum, so
+    every model resolves the same names from the app's en-US.json.
     """
 
     def test_shared_table_names(self) -> None:

--- a/tests/test_translation_keys.py
+++ b/tests/test_translation_keys.py
@@ -35,11 +35,14 @@ def _string_constants() -> dict[str, str]:
     tree = ast.parse((PACKAGE / "const.py").read_text(encoding="utf-8"))
     out: dict[str, str] = {}
     for node in tree.body:
-        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
-            if isinstance(node.value.value, str):
-                for target in node.targets:
-                    if isinstance(target, ast.Name):
-                        out[target.id] = node.value.value
+        if (
+            isinstance(node, ast.Assign)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        ):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    out[target.id] = node.value.value
     return out
 
 
@@ -61,9 +64,12 @@ def _translation_keys(module: pathlib.Path, consts: dict[str, str]) -> set[str]:
                 keys.add(key)
         elif isinstance(node, ast.Assign):
             for target in node.targets:
-                if isinstance(target, ast.Name) and target.id == "_attr_translation_key":
-                    if (key := resolve(node.value)) is not None:
-                        keys.add(key)
+                if (
+                    isinstance(target, ast.Name)
+                    and target.id == "_attr_translation_key"
+                    and (key := resolve(node.value)) is not None
+                ):
+                    keys.add(key)
     return keys
 
 

--- a/tests/test_vacuum_segments.py
+++ b/tests/test_vacuum_segments.py
@@ -7,7 +7,9 @@ on the NarwalVacuum entity using HA stubs.
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+import logging
+import sys
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -16,28 +18,40 @@ import tests.ha_stubs  # noqa: E402
 
 tests.ha_stubs.install()
 
-from narwal_client.models import MapData, NarwalState, RoomInfo  # noqa: E402
+from homeassistant.components.vacuum import VacuumEntityFeature  # noqa: E402
+from homeassistant.exceptions import HomeAssistantError  # noqa: E402
+
 from custom_components.narwal.coordinator import CleanSettings  # noqa: E402
 from custom_components.narwal.vacuum import NarwalVacuum  # noqa: E402
-
-# Grab Segment class from stubs for assertions
-import sys
+from narwal_client.const import CommandResult, WorkingStatus  # noqa: E402
+from narwal_client.models import (  # noqa: E402
+    DOCK_TASK_DRY_DOCK_BAG,
+    DOCK_TASK_DRY_MOP,
+    CommandResponse,
+    MapData,
+    NarwalState,
+    RoomInfo,
+)
 
 Segment = sys.modules["homeassistant.components.vacuum"].Segment
 
 
 def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
     """Create a NarwalVacuum with mocked coordinator."""
+    client_state = state or NarwalState()
     coordinator = MagicMock()
     coordinator.data = state
     coordinator.config_entry = MagicMock()
     coordinator.config_entry.data = {"device_id": "test_dev_001"}
     coordinator.config_entry.title = "Narwal Test"
     coordinator.client = MagicMock()
-    coordinator.client.state = MagicMock()
+    coordinator.client.state = client_state
     coordinator.client.state.firmware_version = "1.0.0"
+    coordinator.client.get_map = AsyncMock(return_value=client_state.map_data)
     coordinator.last_update_success = True
     coordinator.clean_settings = CleanSettings()
+    coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+    coordinator.dock_action_lock = asyncio.Lock()
 
     vac = NarwalVacuum.__new__(NarwalVacuum)
     vac.coordinator = coordinator
@@ -50,6 +64,14 @@ def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
     vac.async_write_ha_state = MagicMock()
 
     return vac
+
+
+def _docked_state() -> NarwalState:
+    """Return a state whose reported status is idle on the dock."""
+    state = NarwalState(working_status=WorkingStatus.DOCKED)
+    state.dock_presence = 6
+    state.dock_field11 = 2
+    return state
 
 
 class TestAsyncGetSegments:
@@ -168,11 +190,12 @@ class TestAsyncCleanSegments:
 
     async def test_converts_string_ids_and_calls_start_rooms(self) -> None:
         """Converts string segment IDs to int and calls start_rooms with the settings."""
-        state = NarwalState()
+        state = _docked_state()
+        state.map_data = MapData(rooms=[RoomInfo(room_id=11), RoomInfo(room_id=9)])
         vac = _make_vacuum(state=state)
         settings = vac.coordinator.clean_settings
         vac.coordinator.client.start_rooms = AsyncMock(
-            return_value=MagicMock(result_code=0, success=True)
+            return_value=CommandResponse(result_code=0)
         )
         # Mock wake so it's a no-op
         vac.coordinator.client.robot_awake = True
@@ -188,6 +211,188 @@ class TestAsyncCleanSegments:
             mop_strength=settings.mop_strength,
             passes=settings.passes,
         )
+
+    async def test_segment_clean_accepted_response_does_not_warn(self, caplog) -> None:
+        """Accepted async start responses are not room-clean failures."""
+        state = _docked_state()
+        state.map_data = MapData(rooms=[RoomInfo(room_id=11)])
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+
+        with caplog.at_level(logging.WARNING, logger="custom_components.narwal.vacuum"):
+            await vac.async_clean_segments(["11"])
+
+        assert "Room clean failed" not in caplog.text
+
+    async def test_rejects_room_clean_when_dock_task_is_active(self) -> None:
+        """Room clean requests are blocked before dispatch during dock work."""
+        state = _docked_state()
+        state.station_activity = 1
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError):
+            await vac.async_clean_segments(["11"])
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_accepted_room_clean_reserves_robot_start_context(self) -> None:
+        """Accepted room-start commands block immediate dock starts."""
+        state = _docked_state()
+        state.map_data = MapData(map_id=2, rooms=[RoomInfo(room_id=11)])
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+
+        await vac.async_clean_segments(["11"])
+
+        assert state.has_assumed_robot_clean
+
+    async def test_rejected_room_clean_raises_service_error(self) -> None:
+        """Rejected clean/start_clean responses fail the HA service call."""
+        state = _docked_state()
+        state.map_data = MapData(map_id=2, rooms=[RoomInfo(room_id=11)])
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        )
+
+        with pytest.raises(HomeAssistantError, match="Narwal room clean failed"):
+            await vac.async_clean_segments(["11"])
+
+    async def test_room_clean_waits_for_dock_action_lock(self) -> None:
+        """Robot starts cannot validate against the same idle snapshot as dock tasks."""
+        state = _docked_state()
+        state.map_data = MapData(rooms=[RoomInfo(room_id=11)])
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=MagicMock(result_code=0, success=True)
+        )
+        await vac.coordinator.dock_action_lock.acquire()
+
+        task = asyncio.create_task(vac.async_clean_segments(["11"]))
+        await asyncio.sleep(0)
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+        vac.coordinator.dock_action_lock.release()
+        await task
+        vac.coordinator.client.start_rooms.assert_awaited_once()
+
+    async def test_non_numeric_segment_id_raises(self) -> None:
+        state = _docked_state()
+        state.map_data = MapData(rooms=[RoomInfo(room_id=11)])
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(Exception, match="numeric"):
+            await vac.async_clean_segments(["kitchen"])
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_unknown_segment_id_raises(self) -> None:
+        state = _docked_state()
+        state.map_data = MapData(rooms=[RoomInfo(room_id=11)])
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(Exception, match="Unknown Narwal room ID"):
+            await vac.async_clean_segments(["99"])
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_segment_validation_refreshes_a_stale_room_map(self) -> None:
+        """A room added since startup is validated against a fresh map."""
+        state = _docked_state()
+        state.map_data = MapData(map_id=2, rooms=[RoomInfo(room_id=11)])
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+
+        async def refresh_map() -> MapData:
+            state.map_data = MapData(map_id=2, rooms=[RoomInfo(room_id=12)])
+            return state.map_data
+
+        vac.coordinator.client.get_map = AsyncMock(side_effect=refresh_map)
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_clean_segments(["12"])
+
+        vac.coordinator.client.get_map.assert_awaited_once()
+        vac.coordinator.client.start_rooms.assert_awaited_once()
+
+    async def test_empty_cached_room_table_defers_validation_to_client(self) -> None:
+        """A payloadless cached map must not reject every known HA segment."""
+        state = _docked_state()
+        state.map_data = MapData()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_clean_segments(["11"])
+
+        vac.coordinator.client.start_rooms.assert_awaited_once()
+
+
+class TestDockTaskRobotActionGates:
+    """Dock work must not leak unsafe robot controls through the vacuum."""
+
+    @staticmethod
+    def _active_dock_vacuum() -> NarwalVacuum:
+        state = _docked_state()
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+        vac = _make_vacuum(state)
+        vac.coordinator.client.robot_awake = True
+        return vac
+
+    def test_active_dock_task_hides_robot_actions(self) -> None:
+        vac = self._active_dock_vacuum()
+
+        assert not vac.supported_features & VacuumEntityFeature.START
+        assert not vac.supported_features & VacuumEntityFeature.STOP
+        assert not vac.supported_features & VacuumEntityFeature.PAUSE
+        assert not vac.supported_features & VacuumEntityFeature.RETURN_HOME
+        assert not vac.supported_features & VacuumEntityFeature.LOCATE
+        assert not vac.supported_features & VacuumEntityFeature.CLEAN_AREA
+
+    @pytest.mark.parametrize(
+        ("method_name", "client_method"),
+        (
+            ("async_pause", "pause"),
+            ("async_return_to_base", "return_to_base"),
+            ("async_locate", "locate"),
+        ),
+    )
+    async def test_active_dock_task_rejects_direct_robot_action(
+        self,
+        method_name: str,
+        client_method: str,
+    ) -> None:
+        vac = self._active_dock_vacuum()
+        command = AsyncMock()
+        setattr(vac.coordinator.client, client_method, command)
+
+        with pytest.raises(HomeAssistantError, match="Narwal dock task is active"):
+            await getattr(vac, method_name)()
+
+        command.assert_not_awaited()
 
 
 class TestCheckSegmentChanges:
@@ -256,33 +461,36 @@ class TestCheckSegmentChanges:
 class TestAsyncStartWholeHouse:
     """async_start runs a whole-house clean via start_rooms(all rooms), not the saved plan."""
 
-    async def test_enumerates_all_rooms(self) -> None:
+    async def test_enumerates_all_rooms(self, caplog) -> None:
         """Whole-house start passes every room id to clean/start_clean, skipping plan/start."""
-        state = NarwalState()
+        state = _docked_state()
         state.map_data = MapData(map_id=2, rooms=[
             RoomInfo(room_id=1), RoomInfo(room_id=2), RoomInfo(room_id=0),  # 0 filtered
         ])
         vac = _make_vacuum(state=state)
         vac.coordinator.client.robot_awake = True
         vac.coordinator.client.start_rooms = AsyncMock(
-            return_value=MagicMock(result_code=1, success=True)
+            return_value=CommandResponse(result_code=0)
         )
         vac.coordinator.client.start = AsyncMock()
 
-        await vac.async_start()
+        with caplog.at_level(logging.WARNING, logger="custom_components.narwal.vacuum"):
+            await vac.async_start()
 
         vac.coordinator.client.start_rooms.assert_awaited_once()
         assert vac.coordinator.client.start_rooms.await_args.args[0] == [1, 2]
         vac.coordinator.client.start.assert_not_called()
+        assert "Start command was rejected" not in caplog.text
+        assert state.has_assumed_robot_clean
 
     async def test_falls_back_to_saved_plan_without_map(self) -> None:
         """With no map rooms available, falls back to the saved-plan start()."""
-        state = NarwalState()  # no map_data
+        state = _docked_state()  # no map_data
         vac = _make_vacuum(state=state)
         vac.coordinator.client.robot_awake = True
         vac.coordinator.client.get_map = AsyncMock()  # does not populate map_data
         vac.coordinator.client.start = AsyncMock(
-            return_value=MagicMock(result_code=1, success=True)
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
         )
         vac.coordinator.client.start_rooms = AsyncMock()
 
@@ -290,3 +498,83 @@ class TestAsyncStartWholeHouse:
 
         vac.coordinator.client.start.assert_awaited_once()
         vac.coordinator.client.start_rooms.assert_not_called()
+
+    async def test_rejected_whole_house_start_raises_service_error(self) -> None:
+        """Rejected whole-house starts fail the HA service call."""
+        state = _docked_state()
+        state.map_data = MapData(map_id=2, rooms=[RoomInfo(room_id=1)])
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        )
+
+        with pytest.raises(HomeAssistantError, match="Narwal start command failed"):
+            await vac.async_start()
+
+
+class TestAsyncStop:
+    """Tests for stop routing between robot and dock task contexts."""
+
+    async def test_stop_routes_dock_only_task_through_dock_policy(self) -> None:
+        state = NarwalState(working_status=WorkingStatus.DOCKED)
+        state.dock_presence = 6
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock()
+        vac.coordinator.client.stop_dock_task = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+
+        await vac.async_stop()
+
+        vac.coordinator.client.stop.assert_not_awaited()
+        vac.coordinator.client.stop_dock_task.assert_awaited_once_with()
+
+    async def test_stop_rejects_ambiguous_dock_only_task(self) -> None:
+        state = NarwalState(working_status=WorkingStatus.DOCKED)
+        state.dock_presence = 6
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock()
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="cannot be stopped safely"):
+            await vac.async_stop()
+
+        vac.coordinator.client.stop.assert_not_awaited()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_stop_preserves_robot_stop_during_unmapped_dock_activity(self) -> None:
+        """An unmapped dock phase must not hide stop for a real robot clean."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.dock_activity = 99
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        await vac.async_stop()
+
+        vac.coordinator.client.stop.assert_awaited_once()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()


### PR DESCRIPTION
## Summary
- model the Narwal dock/base station as its own Home Assistant device via the robot
- expose exactly five dock task switches: empty dustbin, wash mop, dry mop, dry dust bin, dry dock bag
- attach dock task progress and `time_left` attributes to the active switch instead of separate progress/status entities
- normalize dock telemetry, short accepted-command fallbacks, and safety gates inside the integration
- serialize dock actions and robot clean starts through the same action lock

## Commit Layout
- client protocol/state decoding and direct dock commands
- Home Assistant dock device plus five task switches
- vacuum command gating while dock tasks are active

## Why
Dock work is separate from robot cleaning. Keeping dock tasks as stateful switches gives Home Assistant a simple contract: a task switch is on when that task is active, enabled when it can be started or safely stopped, and carries its own progress attributes when the robot reports typed timers.

The default concurrency policy is deliberately conservative. Starts require fresh dock state, an idle docked robot, no blocking errors, and no known or unmapped station work. Stops are task-scoped so generic force-end is not exposed when it could cancel the wrong thing.

## Stack
Builds on the autodiscovery fix merged in #85. The dock-task work starts at `bf3ae00`.

## Runtime Evidence
Recorded in `docs/DOCK_TASK_TEST_PLAN.md`:
- Flow 2 robot A: dry mop, dry dust bin, and dry dock bag start/stop behavior including typed stop payloads
- Flow 2 robot B: robot command behavior while emptying and washing are active
- unverified parallel dock combinations remain blocked by default