### PR TITLE
feat(cleaning): add room-specific cleaning settings

### DIFF
--- a/custom_components/narwal/__init__.py
+++ b/custom_components/narwal/__init__.py
@@ -5,24 +5,416 @@ from __future__ import annotations
 import logging
 from typing import TypeAlias
 
+import voluptuous as vol
+from homeassistant.auth.permissions.const import POLICY_CONTROL
+from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.const import ATTR_AREA_ID, ATTR_DEVICE_ID, ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import (
+    ConfigEntryNotReady,
+    HomeAssistantError,
+    Unauthorized,
+    UnknownUser,
+)
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import service
 
 from .const import (
     CONF_MODEL,
     CONF_PRODUCT_KEY,
     DOMAIN,
     PLATFORMS,
+    SERVICE_CLEAN_ROOMS,
     configured_model_name,
+    fan_speed_list_for,
 )
-from .coordinator import NarwalCoordinator
-from .narwal_client import NarwalConnectionError
+from .coordinator import NarwalCoordinator, can_start_cleaning
+from .narwal_client import (
+    CleaningRoute,
+    CommandResult,
+    FanLevel,
+    MopHumidity,
+    MopStrengthLevel,
+    NarwalConnectionError,
+    RoomCleanSettings,
+    WorkMode,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 NarwalConfigEntry: TypeAlias = ConfigEntry[NarwalCoordinator]
+
+FIELD_ROOMS = "rooms"
+FIELD_MODE = "mode"
+FIELD_SUCTION = "suction"
+FIELD_WATER = "water"
+FIELD_MOP_STRENGTH = "mop_strength"
+FIELD_PASSES = "passes"
+FIELD_ROUTE = "route"
+
+WORK_MODE_OPTIONS: dict[str, WorkMode] = {
+    "vacuum": WorkMode.VACUUM,
+    "mop": WorkMode.MOP,
+    "vacuum_then_mop": WorkMode.VACUUM_THEN_MOP,
+    "vacuum_and_mop": WorkMode.VACUUM_AND_MOP,
+}
+SUCTION_OPTIONS: dict[str, FanLevel] = {
+    "ai": FanLevel.UNSPECIFIED,
+    "quiet": FanLevel.MUTE,
+    "standard": FanLevel.NORMAL,
+    "strong": FanLevel.STRONG,
+    "super": FanLevel.DEEP,
+    "ultra": FanLevel.SUPER,
+    "super_powerful": FanLevel.DEEP,
+    "ultra_powerful": FanLevel.SUPER,
+}
+WATER_OPTIONS: dict[str, MopHumidity] = {
+    "dry": MopHumidity.DRY,
+    "normal": MopHumidity.NORMAL,
+    "wet": MopHumidity.WET,
+}
+MOP_STRENGTH_OPTIONS: dict[str, MopStrengthLevel] = {
+    "normal": MopStrengthLevel.NORMAL,
+    "high": MopStrengthLevel.HIGH,
+}
+ROUTE_OPTIONS: dict[str, CleaningRoute] = {
+    "standard": CleaningRoute.STANDARD,
+    "meticulous": CleaningRoute.METICULOUS,
+}
+
+CLEAN_ROOMS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_ENTITY_ID): cv.comp_entity_ids,
+        vol.Optional(ATTR_DEVICE_ID): cv.ensure_list,
+        vol.Optional(ATTR_AREA_ID): cv.ensure_list,
+        vol.Required(FIELD_ROOMS): cv.ensure_list,
+        vol.Optional(FIELD_MODE, default="vacuum_and_mop"): vol.In(WORK_MODE_OPTIONS),
+        vol.Optional(FIELD_SUCTION, default="standard"): vol.In(SUCTION_OPTIONS),
+        vol.Optional(FIELD_WATER, default="normal"): vol.In(WATER_OPTIONS),
+        vol.Optional(FIELD_MOP_STRENGTH, default="normal"): vol.In(
+            MOP_STRENGTH_OPTIONS
+        ),
+        vol.Optional(FIELD_PASSES, default=1): lambda value: _validate_pass_count(
+            value
+        ),
+        vol.Optional(FIELD_ROUTE): vol.In(ROUTE_OPTIONS),
+    }
+)
+
+
+def _domain_data(hass: HomeAssistant) -> dict[str, NarwalCoordinator]:
+    """Return Narwal domain runtime data."""
+    return hass.data.setdefault(DOMAIN, {})
+
+
+def _validate_pass_count(value: object) -> int:
+    """Return a pass count, rejecting fractional coercion."""
+    if isinstance(value, bool):
+        raise vol.Invalid("Narwal pass count must be an integer")
+    if isinstance(value, int):
+        passes = value
+    elif isinstance(value, float):
+        if not value.is_integer():
+            raise vol.Invalid("Narwal pass count must be an integer")
+        passes = int(value)
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text.isdecimal():
+            raise vol.Invalid("Narwal pass count must be an integer")
+        passes = int(text)
+    else:
+        raise vol.Invalid("Narwal pass count must be an integer")
+    if passes < 1 or passes > 3:
+        raise vol.Invalid("Narwal pass count must be between 1 and 3")
+    return passes
+
+
+def _room_tokens(raw_rooms: list) -> list[object]:
+    """Return room request tokens split the same way for all/all+room checks."""
+    tokens: list[object] = []
+    for item in raw_rooms:
+        if isinstance(item, str):
+            cleaned = item.strip().strip("[]")
+            tokens.extend(cleaned.replace(",", " ").split())
+        else:
+            tokens.append(item)
+    return tokens
+
+
+def _normalise_room_ids(raw_rooms: list) -> list[int]:
+    """Return room IDs from HA service data."""
+    room_ids: list[int] = []
+    seen: set[int] = set()
+    for value in _room_tokens(raw_rooms):
+        if isinstance(value, str) and value.lower() == "all":
+            continue
+        if isinstance(value, bool):
+            raise HomeAssistantError(f"Invalid Narwal room ID: {value}")
+        try:
+            if isinstance(value, float):
+                if not value.is_integer():
+                    raise ValueError
+                room_id = int(value)
+            elif isinstance(value, int):
+                room_id = value
+            elif isinstance(value, str) and value.isdecimal():
+                room_id = int(value)
+            else:
+                raise ValueError
+        except (TypeError, ValueError) as err:
+            raise HomeAssistantError(f"Invalid Narwal room ID: {value}") from err
+        if room_id <= 0:
+            raise HomeAssistantError("Narwal room IDs must be positive")
+        if room_id not in seen:
+            seen.add(room_id)
+            room_ids.append(room_id)
+    return room_ids
+
+
+def _rooms_requested_all(raw_rooms: list) -> bool:
+    """Return True if a service call requests all current map rooms."""
+    return any(
+        isinstance(item, str) and item.lower() == "all"
+        for item in _room_tokens(raw_rooms)
+    )
+
+
+async def _async_room_ids_for_coordinator(
+    coordinator: NarwalCoordinator,
+    raw_rooms: list,
+) -> list[int]:
+    """Resolve configured service rooms for a single Narwal coordinator."""
+    requested_all = _rooms_requested_all(raw_rooms)
+    tokens = _room_tokens(raw_rooms)
+    if requested_all and len(tokens) > 1:
+        raise HomeAssistantError('Use either "all" or explicit room IDs, not both')
+    state = coordinator.client.state
+    try:
+        await coordinator.client.get_map()
+    except Exception as err:
+        raise HomeAssistantError("Narwal map could not be refreshed") from err
+    if state.map_data is None:
+        raise HomeAssistantError("Narwal map is not available")
+    known_room_ids = {room.room_id for room in state.map_data.rooms if room.room_id > 0}
+    if requested_all:
+        return sorted(known_room_ids)
+
+    room_ids = _normalise_room_ids(raw_rooms)
+    unknown_ids = [room_id for room_id in room_ids if room_id not in known_room_ids]
+    if unknown_ids:
+        raise HomeAssistantError(
+            f"Unknown Narwal room ID: {', '.join(str(room_id) for room_id in unknown_ids)}"
+        )
+    return room_ids
+
+
+async def _async_validate_target_permissions(
+    hass: HomeAssistant,
+    call: ServiceCall,
+    entity_ids: list[str],
+) -> None:
+    """Validate control permission for service target entities."""
+    user_id = call.context.user_id
+    if not user_id:
+        return
+    user = await hass.auth.async_get_user(user_id)
+    if user is None:
+        raise UnknownUser(context=call.context)
+    if user.is_admin:
+        return
+    for entity_id in entity_ids:
+        if not user.permissions.check_entity(entity_id, POLICY_CONTROL):
+            raise Unauthorized(
+                context=call.context,
+                entity_id=entity_id,
+                permission=POLICY_CONTROL,
+            )
+
+
+async def _async_validate_clean_rooms_targets(
+    hass: HomeAssistant,
+    call: ServiceCall,
+    entity_ids: list[str],
+) -> list[str]:
+    """Validate clean-room target domains and user permissions."""
+    registry = er.async_get(hass)
+    vacuum_entity_ids: list[str] = []
+    for entity_id in entity_ids:
+        registry_entry = registry.async_get(entity_id)
+        if (
+            entity_id.startswith(f"{VACUUM_DOMAIN}.")
+            and registry_entry is not None
+            and registry_entry.platform == DOMAIN
+            and hass.states.get(entity_id) is not None
+        ):
+            vacuum_entity_ids.append(entity_id)
+
+    direct_entity_ids = call.data.get(ATTR_ENTITY_ID, [])
+    if isinstance(direct_entity_ids, str):
+        direct_entity_ids = [direct_entity_ids]
+    direct_entity_ids = [
+        entity_id
+        for entity_id in direct_entity_ids
+        if entity_id != "all" and not entity_id.startswith("group.")
+    ]
+    if any(entity_id not in vacuum_entity_ids for entity_id in direct_entity_ids):
+        raise HomeAssistantError("Target must be a Narwal vacuum entity")
+
+    await _async_validate_target_permissions(hass, call, vacuum_entity_ids)
+    return vacuum_entity_ids
+
+
+async def _async_get_service_coordinators(
+    hass: HomeAssistant,
+    entity_ids: list[str] | None,
+) -> list[NarwalCoordinator]:
+    """Resolve service entity IDs to Narwal coordinators."""
+    data = _domain_data(hass)
+    if not entity_ids:
+        raise HomeAssistantError("Target a Narwal vacuum")
+
+    registry = er.async_get(hass)
+    coordinators: list[NarwalCoordinator] = []
+    for entity_id in entity_ids:
+        registry_entry = registry.async_get(entity_id)
+        if registry_entry is None or registry_entry.config_entry_id is None:
+            raise HomeAssistantError(
+                f"Narwal target is not loaded: {entity_id}"
+            )
+        coordinator = data.get(registry_entry.config_entry_id)
+        if not isinstance(coordinator, NarwalCoordinator):
+            raise HomeAssistantError(
+                f"Narwal target is not loaded: {entity_id}"
+            )
+        if coordinator not in coordinators:
+            coordinators.append(coordinator)
+    if not coordinators:
+        raise HomeAssistantError("Target does not contain a Narwal entity")
+    return coordinators
+
+
+def _async_register_services(hass: HomeAssistant) -> None:
+    """Register Narwal domain services."""
+    if hass.services.has_service(DOMAIN, SERVICE_CLEAN_ROOMS):
+        return
+
+    async def _async_extract_entity_ids(call: ServiceCall) -> list[str]:
+        """Extract target entity IDs across supported HA helper signatures."""
+        try:
+            entity_ids = await service.async_extract_entity_ids(call)
+        except TypeError:
+            entity_ids = await service.async_extract_entity_ids(hass, call)
+        return list(entity_ids)
+
+    async def async_clean_rooms(call: ServiceCall) -> None:
+        entity_ids = await _async_extract_entity_ids(call)
+        if not entity_ids and any(
+            key in call.data for key in (ATTR_ENTITY_ID, ATTR_DEVICE_ID, ATTR_AREA_ID)
+        ):
+            raise HomeAssistantError("Target does not contain a Narwal entity")
+        entity_ids = await _async_validate_clean_rooms_targets(hass, call, entity_ids)
+        coordinators = await _async_get_service_coordinators(hass, entity_ids)
+        if len(coordinators) != 1:
+            raise HomeAssistantError("Target exactly one Narwal vacuum")
+        coordinator = coordinators[0]
+
+        work_mode = WORK_MODE_OPTIONS[call.data[FIELD_MODE]]
+        fan = SUCTION_OPTIONS[call.data[FIELD_SUCTION]]
+        water = WATER_OPTIONS[call.data[FIELD_WATER]]
+        mop_strength = MOP_STRENGTH_OPTIONS[call.data[FIELD_MOP_STRENGTH]]
+        passes = call.data[FIELD_PASSES]
+        route_label = call.data.get(FIELD_ROUTE)
+
+        if not coordinator.client.robot_awake:
+            await coordinator.client.wake(timeout=10.0)
+
+        room_ids = await _async_room_ids_for_coordinator(
+            coordinator,
+            call.data[FIELD_ROOMS],
+        )
+        if not room_ids:
+            raise HomeAssistantError("At least one room must be selected")
+
+        if fan is FanLevel.SUPER and "Ultra" not in fan_speed_list_for(
+            coordinator.config_entry.data
+        ):
+            raise HomeAssistantError(
+                "Ultra suction is not supported by this Narwal model"
+            )
+        route = ROUTE_OPTIONS.get(route_label, coordinator.clean_settings.route)
+        requested_settings = RoomCleanSettings(
+            work_mode=work_mode,
+            fan=fan,
+            water=water,
+            mop_strength=mop_strength,
+            passes=passes,
+            route=route,
+        )
+        room_settings = coordinator.room_clean_settings_for_rooms(
+            room_ids,
+            default=requested_settings,
+            use_room_profiles=False,
+        )
+
+        async with coordinator.dock_action_lock:
+            if not await coordinator.async_refresh_dock_status():
+                raise HomeAssistantError("Narwal status could not be refreshed")
+            if not can_start_cleaning(coordinator.client.state):
+                raise HomeAssistantError("Narwal room clean cannot be started right now")
+
+            client = coordinator.client
+            resp = await client.start_rooms(
+                room_ids,
+                work_mode=requested_settings.work_mode,
+                fan=requested_settings.fan,
+                water=requested_settings.water,
+                mop_strength=requested_settings.mop_strength,
+                passes=requested_settings.passes,
+                route=requested_settings.route,
+                room_settings=room_settings,
+            )
+            if resp.result_code == 0:
+                result_name = "ACCEPTED"
+            else:
+                try:
+                    result_name = CommandResult(resp.result_code).name
+                except ValueError:
+                    result_name = f"UNKNOWN({resp.result_code})"
+            _LOGGER.info(
+                "Clean rooms response: %s (code=%s), rooms=%s",
+                result_name,
+                resp.result_code,
+                room_ids,
+            )
+            if not resp.accepted:
+                raise HomeAssistantError(
+                    f"Narwal room clean failed: {result_name} ({resp.result_code})"
+                )
+            coordinator.clean_settings.work_mode = requested_settings.work_mode
+            coordinator.clean_settings.fan = requested_settings.fan
+            coordinator.clean_settings.water = requested_settings.water
+            coordinator.clean_settings.mop_strength = requested_settings.mop_strength
+            coordinator.clean_settings.passes = requested_settings.passes
+            coordinator.clean_settings.route = requested_settings.route
+            coordinator.record_accepted_clean_start(room_settings)
+            client.state.assume_robot_clean()
+            coordinator.async_set_updated_data(client.state)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CLEAN_ROOMS,
+        async_clean_rooms,
+        schema=CLEAN_ROOMS_SCHEMA,
+    )
+
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Set up Narwal services."""
+    _async_register_services(hass)
+    return True
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
@@ -55,6 +447,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NarwalConfigEntry) -> bo
         ) from err
 
     entry.runtime_data = coordinator
+    _domain_data(hass)[entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -78,5 +471,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: NarwalConfigEntry) -> b
 
     if unload_ok:
         await entry.runtime_data.async_shutdown()
+        _domain_data(hass).pop(entry.entry_id, None)
 
     return unload_ok

--- a/custom_components/narwal/camera.py
+++ b/custom_components/narwal/camera.py
@@ -13,11 +13,11 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import NarwalConfigEntry
 from .const import (
+    CONF_MAP_ROTATION,
+    CONF_MAP_ZOOM,
     CONF_SHOW_FURNITURE,
     CONF_SHOW_FURNITURE_LABELS,
     CONF_SHOW_ROOM_LABELS,
-    CONF_MAP_ROTATION,
-    CONF_MAP_ZOOM,
     MAP_OPTION_DEFAULTS,
     MAP_ROTATION_DEFAULT,
     MAP_ZOOM_DEFAULT,
@@ -45,6 +45,15 @@ _DEBUG_VIEW = False
 _DEBUG_CANVAS_SIZE = 600  # pixels
 _DEBUG_TRAIL_MAX = _TRAIL_MAX_POINTS
 _DEBUG_RECORD_INTERVAL = _TRAIL_RECORD_INTERVAL
+
+_CLEANING_TRAIL_STATUSES = frozenset(
+    {
+        WorkingStatus.CLEANING_V2,
+        WorkingStatus.CLEANING,
+        WorkingStatus.CLEANING_ALT,
+        WorkingStatus.CUSTOM_CLEANING,
+    }
+)
 
 
 async def async_setup_entry(
@@ -280,12 +289,8 @@ class NarwalMapCamera(NarwalEntity, Camera):
 
         # Detect cleaning session transitions — clear trail on new session
         current_status = state.working_status
-        was_cleaning = self._last_cleaning_status in (
-            WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT,
-        )
-        is_cleaning = current_status in (
-            WorkingStatus.CLEANING, WorkingStatus.CLEANING_ALT,
-        )
+        was_cleaning = self._last_cleaning_status in _CLEANING_TRAIL_STATUSES
+        is_cleaning = current_status in _CLEANING_TRAIL_STATUSES
         if is_cleaning and not was_cleaning:
             _LOGGER.info("New cleaning session — clearing trail and vision obstacles")
             self._reset_trail()

--- a/custom_components/narwal/const.py
+++ b/custom_components/narwal/const.py
@@ -115,6 +115,7 @@ MAP_ROTATION_DEFAULT = 0  # degrees clockwise; renderer accepts 0/90/180/270
 MAP_ZOOM_DEFAULT = 1.0  # renderer clamps to 1.0–2.0
 
 CONF_DOCK_LIGHT_SUPPORTED = "dock_light_supported"
+SERVICE_CLEAN_ROOMS = "clean_rooms"
 
 def product_keys_for_model(label: str) -> set[str]:
     """Every product key known to belong to one selector model."""
@@ -144,12 +145,15 @@ DOCK_LIGHT_MODE_NAMES: dict[int, str] = {
     int(value): key for key, value in DOCK_LIGHT_MODES.items()
 }
 
-# HA fan_speed labels → FanLevel, from the app's user-visible suction names (sentence case, as HA shows fan_speed values directly). The enum members keep the app's internal identifiers, so DEEP surfaces as "Super" and SUPER as "Ultra".
+# HA fan_speed labels -> FanLevel, from the app's user-visible suction names
+# (sentence case, as HA shows fan_speed values directly). The enum members keep
+# the app's internal identifiers, so DEEP surfaces as "Super Powerful" and
+# SUPER as "Ultra".
 _FAN_SPEED_CANONICAL: dict[str, FanLevel] = {
     "Quiet": FanLevel.MUTE,
     "Standard": FanLevel.NORMAL,
     "Strong": FanLevel.STRONG,
-    "Super": FanLevel.DEEP,
+    "Super Powerful": FanLevel.DEEP,
     "Ultra": FanLevel.SUPER,
 }
 
@@ -174,9 +178,29 @@ def fan_speed_list_for(data: dict) -> list[str]:
 
 
 # FAN_SPEED_MAP also accepts the "… powerful" labels shipped through v1.0.3 and the
-# original lowercase fan_speed values (quiet/normal/strong/max) so existing automations
-# keep working; these aliases are not offered in FAN_SPEED_LIST.
+# short "Super" label used by this stack, and the original lowercase fan_speed
+# values (quiet/normal/strong/max) so existing automations keep working; these
+# aliases are not offered in FAN_SPEED_LIST.
 FAN_SPEED_MAP: dict[str, FanLevel] = _FAN_SPEED_CANONICAL | {
+    "Super": FanLevel.DEEP,
+    "Super powerful": FanLevel.DEEP,
+    "Ultra powerful": FanLevel.SUPER,
+    "quiet": FanLevel.MUTE,
+    "normal": FanLevel.NORMAL,
+    "strong": FanLevel.STRONG,
+    "max": FanLevel.SUPER,
+}
+
+# Meanings used by v1.0.5 and earlier persisted states. Keep this separate from
+# current UI labels so a rename cannot silently change a restored robot enum.
+UNVERSIONED_FAN_SPEED_MAP: dict[str, FanLevel] = {
+    "AI": FanLevel.UNSPECIFIED,
+    "Quiet": FanLevel.MUTE,
+    "Standard": FanLevel.NORMAL,
+    "Strong": FanLevel.STRONG,
+    "Super Powerful": FanLevel.DEEP,
+    "Ultra": FanLevel.SUPER,
+    "Super": FanLevel.DEEP,
     "Super powerful": FanLevel.DEEP,
     "Ultra powerful": FanLevel.SUPER,
     "quiet": FanLevel.MUTE,
@@ -229,7 +253,8 @@ ERROR_HELP_URL_TEMPLATE = (
     "https://help.narwal.com/helpcenter/vall/#/p2/question/all?eType=1&code={code}&lang=en-US"
 )
 
-# Select option id → robot enum. Option ids are rendered to the app's user-visible labels via translations.
+# Select option id -> robot enum. Option ids are rendered to the app's
+# user-visible labels via translations.
 WORK_MODE_MAP: dict[str, WorkMode] = {
     "vacuum": WorkMode.VACUUM,
     "mop": WorkMode.MOP,

--- a/custom_components/narwal/const.py
+++ b/custom_components/narwal/const.py
@@ -177,6 +177,16 @@ def fan_speed_list_for(data: dict) -> list[str]:
     return FAN_SPEED_LIST
 
 
+def normalize_fan_level_for_model(data: dict, fan: FanLevel) -> FanLevel:
+    """Return a persisted fan level supported by the configured model."""
+    if (
+        fan == FanLevel.SUPER
+        and data.get(CONF_PRODUCT_KEY) in NO_ULTRA_FAN_PRODUCT_KEYS
+    ):
+        return FanLevel.DEEP
+    return fan
+
+
 # FAN_SPEED_MAP also accepts the "… powerful" labels shipped through v1.0.3 and the
 # short "Super" label used by this stack, and the original lowercase fan_speed
 # values (quiet/normal/strong/max) so existing automations keep working; these

--- a/custom_components/narwal/coordinator.py
+++ b/custom_components/narwal/coordinator.py
@@ -6,15 +6,18 @@ import asyncio
 import contextlib
 import logging
 import time
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, fields, replace
 from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, NO_BROADCAST_PRODUCT_KEYS
 from .narwal_client import (
+    CleaningRoute,
     CommandResponse,
     FanLevel,
     MopHumidity,
@@ -22,6 +25,7 @@ from .narwal_client import (
     NarwalClient,
     NarwalConnectionError,
     NarwalState,
+    RoomCleanSettings,
     WorkMode,
 )
 from .narwal_client.const import ACTIVE_CLEANING_STATUSES, WorkingStatus
@@ -36,6 +40,7 @@ FAST_POLL_MAX = 6  # up to 60s of fast polling before falling back to normal
 
 # Consumable alerts change over weeks — poll every ~30 min (30 * POLL_INTERVAL).
 CONSUMABLE_POLL_EVERY = 30
+ROOM_SELECTION_STORE_VERSION = 1
 
 # The robot only broadcasts working_status and display_map while an
 # active_robot_publish subscription is live, and that subscription lasts
@@ -44,6 +49,20 @@ CONSUMABLE_POLL_EVERY = 30
 # base_status-derived value, and the live map stops updating (#73).
 TOPIC_SUBSCRIPTION_TTL = 600.0
 TOPIC_RESUBSCRIBE_AFTER = 240.0
+ROOM_CLEAN_SETTING_ATTRS = frozenset(field.name for field in fields(RoomCleanSettings))
+ROOM_CLEAN_SETTING_VALUE_TYPES = {
+    "work_mode": WorkMode,
+    "fan": FanLevel,
+    "water": MopHumidity,
+    "mop_strength": MopStrengthLevel,
+    "route": CleaningRoute,
+}
+MOP_WORK_MODES = frozenset(
+    {WorkMode.MOP, WorkMode.VACUUM_THEN_MOP, WorkMode.VACUUM_AND_MOP}
+)
+VACUUM_WORK_MODES = frozenset(
+    {WorkMode.VACUUM, WorkMode.VACUUM_THEN_MOP, WorkMode.VACUUM_AND_MOP}
+)
 
 
 def _status_payload(response: CommandResponse) -> dict[str, object] | None:
@@ -70,12 +89,13 @@ def _has_dock_status_payload(response: CommandResponse) -> bool:
 
 
 @dataclass
-class CleanSettings:
-    """User-selected clean parameters, applied at the next room clean start.
+class CleanSettings(RoomCleanSettings):
+    """User-selected clean parameters for the next clean or live controls.
 
-    Single source of truth the select/number entities mutate and the
-    clean-start path reads; each entity persists its value via RestoreEntity.
-    Only fan and water also have live setters.
+    Select/number entities mutate this, and clean-start paths read it. Each
+    entity persists its value via RestoreEntity, so settings survive restarts.
+    Only fan and water have live setters; the other parameters take effect at
+    the next start.
     """
 
     work_mode: WorkMode = WorkMode.VACUUM_AND_MOP
@@ -83,6 +103,113 @@ class CleanSettings:
     water: MopHumidity = MopHumidity.NORMAL
     mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL
     passes: int = 1
+    route: CleaningRoute = CleaningRoute.METICULOUS
+
+
+def _state_attr_is_true(state: NarwalState, attr: str) -> bool:
+    """Return True only for explicit boolean state properties."""
+    return getattr(state, attr, False) is True
+
+
+def has_blocking_error(state: NarwalState | None) -> bool:
+    """Return True when the robot reports a command-blocking error."""
+    return (
+        state is None
+        or state.working_status == WorkingStatus.ERROR
+        or _state_attr_is_true(state, "has_error")
+    )
+
+
+def is_active_clean_session(state: NarwalState | None) -> bool:
+    """Return True while clean parameters are locked to the current task."""
+    if state is None:
+        return False
+    return (
+        state.working_status in ACTIVE_CLEANING_STATUSES
+        or _state_attr_is_true(state, "has_assumed_robot_clean")
+        or _state_attr_is_true(state, "has_recent_active_working_status")
+        or _state_attr_is_true(state, "has_paused_clean_task_context")
+    ) and not _state_attr_is_true(state, "is_returning")
+
+
+def is_clean_session_context(state: NarwalState | None) -> bool:
+    """Return True while robot-side clean task context is still current."""
+    if state is None:
+        return False
+    return (
+        state.working_status in ACTIVE_CLEANING_STATUSES
+        or state.working_status
+        in {WorkingStatus.REMAPPING, WorkingStatus.TASK_COMPLETED}
+        or _state_attr_is_true(state, "has_assumed_robot_clean")
+        or _state_attr_is_true(state, "has_recent_active_working_status")
+        or _state_attr_is_true(state, "has_paused_clean_task_context")
+        or _state_attr_is_true(state, "is_returning")
+        or _state_attr_is_true(state, "is_charging_to_resume")
+    )
+
+
+def is_live_clean_setting_available(state: NarwalState | None) -> bool:
+    """Return True when live clean settings can be changed during a task."""
+    if has_blocking_error(state):
+        return False
+    if state.working_status in {WorkingStatus.REMAPPING, WorkingStatus.TASK_COMPLETED}:
+        return False
+    return (
+        (_state_attr_is_true(state, "is_cleaning") or is_active_clean_session(state))
+        and not _state_attr_is_true(state, "is_charging_to_resume")
+        and not _state_attr_is_true(state, "is_station_active")
+    )
+
+
+def clean_setting_applies_to_mode(attr: str, work_mode: WorkMode | None) -> bool:
+    """Return True when a clean setting is meaningful for the selected mode."""
+    if work_mode is None:
+        return True
+    if attr in {"water", "mop_strength"}:
+        return work_mode in MOP_WORK_MODES
+    if attr == "fan":
+        return work_mode in VACUUM_WORK_MODES
+    return True
+
+
+def is_narwal_task_busy(state: NarwalState | None) -> bool:
+    """Return True while the robot or dock is busy with a task phase."""
+    if state is None:
+        return False
+    return (
+        state.working_status in ACTIVE_CLEANING_STATUSES
+        or state.working_status
+        in {WorkingStatus.REMAPPING, WorkingStatus.TASK_COMPLETED}
+        or _state_attr_is_true(state, "has_assumed_robot_clean")
+        or _state_attr_is_true(state, "has_recent_active_working_status")
+        or _state_attr_is_true(state, "has_paused_clean_task_context")
+        or _state_attr_is_true(state, "is_returning")
+        or _state_attr_is_true(state, "is_charging_to_resume")
+        or (
+            _state_attr_is_true(state, "is_station_active")
+            and _state_attr_is_true(state, "blocks_robot_start_for_dock_task")
+        )
+    )
+
+
+def can_edit_pending_clean_settings(state: NarwalState | None) -> bool:
+    """Return True when pending next-clean settings can be edited locally."""
+    if state is None:
+        return True
+    if has_blocking_error(state):
+        return False
+    return not is_narwal_task_busy(state)
+
+
+def can_start_cleaning(state: NarwalState | None) -> bool:
+    """Return True when a new robot clean command can be sent now."""
+    if has_blocking_error(state) or state.working_status == WorkingStatus.UNKNOWN:
+        return False
+    return (
+        state.is_docked
+        and not is_clean_session_context(state)
+        and not state.blocks_robot_start_for_dock_task
+    )
 
 
 class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
@@ -117,6 +244,22 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
             supports_broadcasts=supports_broadcasts,
         )
         self.clean_settings = CleanSettings()
+        self.room_clean_settings: dict[tuple[str | None, int], RoomCleanSettings] = {}
+        self.room_clean_settings_customized: dict[tuple[str | None, int], set[str]] = {}
+        self.selected_clean_rooms: dict[str | None, set[int]] = {}
+        self._room_selection_store = Store(
+            hass,
+            ROOM_SELECTION_STORE_VERSION,
+            f"{DOMAIN}_room_selection_{entry.entry_id}",
+        )
+        self._room_selection_save_lock = asyncio.Lock()
+        self._room_selection_store_loaded = False
+        self._room_profile_store_loaded = False
+        self._room_selection_dirty_maps: set[str | None] = set()
+        self._room_profile_pending_resolution: set[int] = set()
+        self.active_clean_work_mode: WorkMode | None = None
+        self.active_room_clean_settings: dict[int, RoomCleanSettings] = {}
+        self.active_clean_setting_overrides: dict[str, object] = {}
         self._listen_task: asyncio.Task[None] | None = None
         self._fast_poll_remaining = 0
         self._prev_working_status = WorkingStatus.UNKNOWN
@@ -142,6 +285,581 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         """Record that dock-control state came from a current base-status payload."""
         self._dock_status_refresh_failed = False
 
+    def default_room_clean_settings(self) -> RoomCleanSettings:
+        """Return a room-clean profile copied from the current global defaults."""
+        return RoomCleanSettings(
+            work_mode=self.clean_settings.work_mode,
+            fan=self.clean_settings.fan,
+            water=self.clean_settings.water,
+            mop_strength=self.clean_settings.mop_strength,
+            passes=self.clean_settings.passes,
+            route=self.clean_settings.route,
+        )
+
+    @staticmethod
+    def shared_room_clean_work_mode(
+        room_settings: Mapping[int, RoomCleanSettings],
+    ) -> WorkMode | None:
+        """Return the shared work mode, or None for a mixed-room task."""
+        modes = {settings.work_mode for settings in room_settings.values()}
+        if len(modes) == 1:
+            return next(iter(modes))
+        return None
+
+    def record_accepted_clean_start(
+        self,
+        room_settings: Mapping[int, RoomCleanSettings],
+    ) -> None:
+        """Record effective room profiles for the accepted robot task."""
+        self.active_clean_setting_overrides = {}
+        self.active_clean_work_mode = self.shared_room_clean_work_mode(
+            room_settings
+        )
+        self.active_room_clean_settings = {
+            room_id: replace(settings)
+            for room_id, settings in room_settings.items()
+        }
+
+    def active_clean_setting(self, attr: str) -> object | None:
+        """Return the effective live value for the current clean, if known."""
+        state = self.data or self.client.state
+        if not is_clean_session_context(state):
+            return None
+        overrides = getattr(self, "active_clean_setting_overrides", {})
+        if attr in overrides:
+            return overrides[attr]
+        if (
+            state.current_room_id is not None
+            and state.current_room_id in self.active_room_clean_settings
+        ):
+            return getattr(
+                self.active_room_clean_settings[state.current_room_id], attr
+            )
+        values = {
+            getattr(settings, attr)
+            for settings in self.active_room_clean_settings.values()
+        }
+        return next(iter(values)) if len(values) == 1 else None
+
+    def set_active_clean_setting(self, attr: str, value: object) -> None:
+        """Update the displayed live value after an accepted runtime command."""
+        if not hasattr(self, "active_clean_setting_overrides"):
+            self.active_clean_setting_overrides = {}
+        self.active_clean_setting_overrides[attr] = value
+        for settings in self.active_room_clean_settings.values():
+            setattr(settings, attr, value)
+
+    def clean_setting_applicability_mode(
+        self, *, live: bool = False
+    ) -> WorkMode | None:
+        """Return the mode used to decide whether fan/water controls apply."""
+        if live:
+            state = self.data or self.client.state
+            if is_clean_session_context(state):
+                if (
+                    state.current_room_id is not None
+                    and state.current_room_id in self.active_room_clean_settings
+                ):
+                    return self.active_room_clean_settings[
+                        state.current_room_id
+                    ].work_mode
+                return self.active_clean_work_mode
+        return self.clean_settings.work_mode
+
+    def _sync_active_clean_context(self, state: NarwalState) -> None:
+        """Clear accepted-task metadata once the robot is no longer in a clean context."""
+        if not is_clean_session_context(state):
+            self.active_clean_work_mode = None
+            self.active_room_clean_settings.clear()
+            if hasattr(self, "active_clean_setting_overrides"):
+                self.active_clean_setting_overrides.clear()
+
+    @staticmethod
+    def _normalise_room_settings_map_id(map_id: object) -> str | None:
+        """Return a stable map id for room profiles."""
+        if map_id in (None, "", 0, "0"):
+            return None
+        return str(map_id)
+
+    def room_settings_map_id(self, map_data: object | None = None) -> str | None:
+        """Return the active map id used to scope room profiles."""
+        if map_data is None:
+            state = self.data or self.client.state
+            map_data = getattr(state, "map_data", None) if state is not None else None
+        return self._normalise_room_settings_map_id(getattr(map_data, "map_id", None))
+
+    def _room_clean_settings_key(
+        self,
+        room_id: int,
+        map_id: str | None = None,
+    ) -> tuple[str | None, int]:
+        """Return the storage key for a room profile."""
+        map_key = map_id if map_id is not None else self.room_settings_map_id()
+        if map_key is not None:
+            self._resolve_identified_room_state(map_key)
+        return (map_key, room_id)
+
+    def room_clean_settings_for(
+        self,
+        room_id: int,
+        *,
+        map_id: str | None = None,
+    ) -> RoomCleanSettings:
+        """Return the configured room-clean profile for a room."""
+        key = self._room_clean_settings_key(room_id, map_id)
+        if key not in self.room_clean_settings:
+            self.room_clean_settings[key] = self.default_room_clean_settings()
+        return self.room_clean_settings[key]
+
+    def effective_room_clean_settings_for(
+        self,
+        room_id: int,
+        *,
+        map_id: str | None = None,
+    ) -> RoomCleanSettings:
+        """Return the room profile after applying current global fallbacks."""
+        return self.room_clean_settings_for_rooms([room_id], map_id=map_id)[room_id]
+
+    def room_clean_settings_for_rooms(
+        self,
+        room_ids: list[int],
+        *,
+        default: RoomCleanSettings | None = None,
+        map_id: str | None = None,
+        use_room_profiles: bool = True,
+    ) -> dict[int, RoomCleanSettings]:
+        """Return stored room-clean profiles for a set of rooms.
+
+        Missing rooms use the supplied default without creating profile entries.
+        """
+        map_key = map_id if map_id is not None else self.room_settings_map_id()
+        if map_key is not None:
+            self._resolve_identified_room_state(map_key)
+        fallback = default or self.default_room_clean_settings()
+        if not use_room_profiles:
+            return {room_id: fallback for room_id in room_ids}
+        customized = getattr(self, "room_clean_settings_customized", {})
+        settings: dict[int, RoomCleanSettings] = {}
+        for room_id in room_ids:
+            key = (map_key, room_id)
+            profile = self.room_clean_settings.get(key)
+            custom_fields = customized.get(key, set())
+            if profile is None or not custom_fields:
+                settings[room_id] = fallback
+                continue
+            merged = RoomCleanSettings(
+                work_mode=fallback.work_mode,
+                fan=fallback.fan,
+                water=fallback.water,
+                mop_strength=fallback.mop_strength,
+                passes=fallback.passes,
+                route=fallback.route,
+            )
+            for attr in custom_fields:
+                if attr in ROOM_CLEAN_SETTING_ATTRS:
+                    setattr(merged, attr, getattr(profile, attr))
+            settings[room_id] = merged
+        return settings
+
+    def selected_clean_room_ids_for(
+        self,
+        room_ids: list[int],
+        *,
+        map_id: str | None = None,
+    ) -> list[int]:
+        """Return selected rooms without broadening a stale explicit selection."""
+        if not getattr(self, "_room_selection_store_loaded", True):
+            return []
+        map_key = map_id if map_id is not None else self.room_settings_map_id()
+        if map_key is not None:
+            self._resolve_identified_room_state(map_key)
+        selected = self.selected_clean_rooms.get(map_key, set())
+        if not selected and map_key is not None:
+            selected = self.selected_clean_rooms.get(None, set())
+        if not selected:
+            return list(room_ids)
+        return [room_id for room_id in room_ids if room_id in selected]
+
+    def has_selected_clean_rooms(self, *, map_id: str | None = None) -> bool:
+        """Return whether the current map has an explicit next-clean selection."""
+        map_key = map_id if map_id is not None else self.room_settings_map_id()
+        if map_key is not None:
+            self._resolve_identified_room_state(map_key)
+        return bool(
+            self.selected_clean_rooms.get(map_key)
+            or (map_key is not None and self.selected_clean_rooms.get(None))
+        )
+
+    def is_room_selected_for_clean(
+        self,
+        room_id: int,
+        *,
+        map_id: str | None = None,
+    ) -> bool:
+        """Return True when a room is selected for the next vacuum start."""
+        map_key = map_id if map_id is not None else self.room_settings_map_id()
+        if map_key is not None:
+            self._resolve_identified_room_state(map_key)
+        selected = self.selected_clean_rooms.get(map_key, set())
+        if not selected and map_key is not None:
+            selected = self.selected_clean_rooms.get(None, set())
+        return room_id in selected
+
+    def set_room_selected_for_clean(
+        self,
+        room_id: int,
+        selected: bool,
+        *,
+        map_id: str | None = None,
+    ) -> None:
+        """Set whether a room is included in the next vacuum start."""
+        map_key = map_id if map_id is not None else self.room_settings_map_id()
+        if map_key is not None:
+            self._resolve_identified_room_state(map_key)
+        selected_rooms = self.selected_clean_rooms.setdefault(map_key, set())
+        if selected:
+            selected_rooms.add(room_id)
+        else:
+            selected_rooms.discard(room_id)
+            if not selected_rooms:
+                self.selected_clean_rooms.pop(map_key, None)
+        if not hasattr(self, "_room_selection_dirty_maps"):
+            self._room_selection_dirty_maps = set()
+        self._room_selection_dirty_maps.add(map_key)
+        self._schedule_room_selection_save()
+
+    def _resolve_identified_room_state(self, map_id: str) -> None:
+        """Resolve unidentified state and persist the newly known map key."""
+        if not self._migrate_unidentified_room_state(map_id):
+            return
+        if not hasattr(self, "_room_selection_dirty_maps"):
+            self._room_selection_dirty_maps = set()
+        if None in self._room_selection_dirty_maps:
+            self._room_selection_dirty_maps.remove(None)
+        self._room_selection_dirty_maps.add(map_id)
+        self._schedule_room_selection_save()
+
+    def _migrate_unidentified_room_state(self, map_id: str) -> bool:
+        """Move unresolved selection and profile state to an identified map."""
+        changed = False
+        if None in self.selected_clean_rooms:
+            unresolved = self.selected_clean_rooms.pop(None)
+            dirty_maps = getattr(self, "_room_selection_dirty_maps", set())
+            if map_id not in self.selected_clean_rooms or None in dirty_maps:
+                self.selected_clean_rooms[map_id] = unresolved
+            changed = True
+        customized = getattr(self, "room_clean_settings_customized", {})
+        settings = getattr(self, "room_clean_settings", {})
+        pending_profiles = getattr(self, "_room_profile_pending_resolution", set())
+        for source_key in [key for key in settings if key[0] is None]:
+            target_key = (map_id, source_key[1])
+            source_profile = settings.pop(source_key)
+            source_fields = customized.get(source_key, set())
+            if target_key not in settings:
+                settings[target_key] = source_profile
+                if source_fields:
+                    customized[target_key] = set(source_fields)
+            elif source_key[1] in pending_profiles:
+                target_profile = settings[target_key]
+                for attr in source_fields:
+                    setattr(target_profile, attr, getattr(source_profile, attr))
+                customized.setdefault(target_key, set()).update(source_fields)
+            customized.pop(source_key, None)
+            pending_profiles.discard(source_key[1])
+            changed = True
+        return changed
+
+    def _room_selection_store_payload(
+        self,
+        *,
+        preserved_profiles: list[object] | None = None,
+    ) -> dict[str, object]:
+        """Return durable room selections and customized profile fields."""
+        profiles: list[dict[str, object]] = []
+        customized = getattr(self, "room_clean_settings_customized", {})
+        room_settings = getattr(self, "room_clean_settings", {})
+        for (map_id, room_id), custom_fields in sorted(
+            customized.items(),
+            key=lambda item: (item[0][0] or "", item[0][1]),
+        ):
+            profile = room_settings.get((map_id, room_id))
+            if profile is None or not custom_fields:
+                continue
+            profiles.append(
+                {
+                    "map_id": map_id,
+                    "room_id": room_id,
+                    "values": {
+                        attr: int(getattr(profile, attr))
+                        for attr in sorted(custom_fields)
+                        if attr in ROOM_CLEAN_SETTING_ATTRS
+                    },
+                    **(
+                        {"pending_map_resolution": True}
+                        if map_id is None
+                        and room_id
+                        in getattr(self, "_room_profile_pending_resolution", set())
+                        else {}
+                    ),
+                }
+            )
+        return {
+            "maps": [
+                {
+                    "map_id": map_id,
+                    "room_ids": sorted(room_ids),
+                    **(
+                        {"pending_map_resolution": True}
+                        if map_id is None
+                        and None
+                        in getattr(self, "_room_selection_dirty_maps", set())
+                        else {}
+                    ),
+                }
+                for map_id, room_ids in sorted(
+                    self.selected_clean_rooms.items(),
+                    key=lambda item: item[0] or "",
+                )
+                if room_ids
+            ],
+            "profiles": profiles if preserved_profiles is None else preserved_profiles,
+        }
+
+    @staticmethod
+    def _deserialize_room_selection_maps(
+        maps: object,
+    ) -> tuple[dict[str | None, set[int]], set[str | None]] | None:
+        """Validate and deserialize the maps portion of stored room state."""
+        if not isinstance(maps, list):
+            return None
+        restored: dict[str | None, set[int]] = {}
+        pending_resolution: set[str | None] = set()
+        for item in maps:
+            if not isinstance(item, Mapping):
+                return None
+            map_id = item.get("map_id")
+            room_ids = item.get("room_ids")
+            pending = item.get("pending_map_resolution", False)
+            if (map_id is not None and not isinstance(map_id, str)) or not isinstance(
+                room_ids, list
+            ):
+                return None
+            if not isinstance(pending, bool) or (pending and map_id is not None):
+                return None
+            if not room_ids or any(
+                not isinstance(room_id, int)
+                or isinstance(room_id, bool)
+                or room_id <= 0
+                for room_id in room_ids
+            ):
+                return None
+            if map_id in restored:
+                return None
+            restored[map_id] = set(room_ids)
+            if pending:
+                pending_resolution.add(map_id)
+        return restored, pending_resolution
+
+    async def _async_restore_room_selections(self) -> None:
+        """Restore explicit room selections independently of dynamic entities."""
+        try:
+            payload = await self._room_selection_store.async_load()
+        except Exception:
+            _LOGGER.debug("Could not restore room selections")
+            return
+        if payload is None:
+            self._room_selection_store_loaded = True
+            self._room_profile_store_loaded = True
+            return
+        if not isinstance(payload, Mapping):
+            return
+        parsed_maps = self._deserialize_room_selection_maps(payload.get("maps"))
+        if parsed_maps is None:
+            return
+        restored, stored_dirty_maps = parsed_maps
+        profiles = payload.get("profiles", [])
+        if not isinstance(profiles, list):
+            return
+        restored_profiles: dict[tuple[str | None, int], RoomCleanSettings] = {}
+        restored_customized: dict[tuple[str | None, int], set[str]] = {}
+        restored_pending_profiles: set[int] = set()
+        for item in profiles:
+            if not isinstance(item, Mapping):
+                return
+            map_id = item.get("map_id")
+            room_id = item.get("room_id")
+            values = item.get("values")
+            pending = item.get("pending_map_resolution", False)
+            if (
+                (map_id is not None and not isinstance(map_id, str))
+                or not isinstance(room_id, int)
+                or isinstance(room_id, bool)
+                or room_id <= 0
+                or not isinstance(values, Mapping)
+                or not values
+                or not isinstance(pending, bool)
+                or (pending and map_id is not None)
+            ):
+                return
+            key = (map_id, room_id)
+            if key in restored_profiles:
+                return
+            profile = RoomCleanSettings()
+            custom_fields: set[str] = set()
+            for attr, raw_value in values.items():
+                if (
+                    attr not in ROOM_CLEAN_SETTING_ATTRS
+                    or not isinstance(raw_value, int)
+                    or isinstance(raw_value, bool)
+                ):
+                    return
+                if attr == "passes":
+                    if raw_value not in (1, 2, 3):
+                        return
+                    value = raw_value
+                else:
+                    value_type = ROOM_CLEAN_SETTING_VALUE_TYPES.get(attr)
+                    if value_type is None:
+                        return
+                    try:
+                        value = value_type(raw_value)
+                    except ValueError:
+                        return
+                setattr(profile, attr, value)
+                custom_fields.add(attr)
+            restored_profiles[key] = profile
+            restored_customized[key] = custom_fields
+            if pending:
+                restored_pending_profiles.add(room_id)
+        dirty_maps = getattr(self, "_room_selection_dirty_maps", set())
+        for map_id in dirty_maps:
+            if selected := self.selected_clean_rooms.get(map_id):
+                restored[map_id] = set(selected)
+            else:
+                restored.pop(map_id, None)
+        self.selected_clean_rooms = restored
+        self.room_clean_settings = restored_profiles
+        self.room_clean_settings_customized = restored_customized
+        self._room_profile_pending_resolution = restored_pending_profiles
+        self._room_selection_dirty_maps = stored_dirty_maps | dirty_maps
+        self._room_selection_store_loaded = True
+        self._room_profile_store_loaded = True
+
+    def _schedule_room_selection_save(self) -> None:
+        """Persist explicit room selections after a switch changes."""
+        if not hasattr(self, "_room_selection_store"):
+            return
+        self.config_entry.async_create_background_task(
+            self.hass,
+            self._async_save_room_selections(),
+            f"{DOMAIN}_room_selection_save",
+        )
+
+    async def _async_save_room_selections(self) -> None:
+        """Serialize room-selection writes so the newest state wins."""
+        async with self._room_selection_save_lock:
+            preserved_profiles: list[object] | None = None
+            if not self._room_selection_store_loaded:
+                local_dirty_maps = getattr(
+                    self, "_room_selection_dirty_maps", set()
+                )
+                stored_dirty_maps: set[str | None] = set()
+                try:
+                    stored = await self._room_selection_store.async_load()
+                except Exception:
+                    _LOGGER.debug("Could not reconcile room selections before save")
+                    return
+                if stored is None:
+                    restored: dict[str | None, set[int]] = {}
+                    self._room_profile_store_loaded = True
+                elif not isinstance(stored, Mapping):
+                    return
+                else:
+                    parsed = self._deserialize_room_selection_maps(stored.get("maps"))
+                    profiles = stored.get("profiles", [])
+                    if parsed is None or not isinstance(profiles, list):
+                        return
+                    restored, stored_dirty_maps = parsed
+                    if not getattr(self, "_room_profile_store_loaded", True):
+                        preserved_profiles = list(profiles)
+                for map_id in local_dirty_maps:
+                    if selected := self.selected_clean_rooms.get(map_id):
+                        restored[map_id] = set(selected)
+                    else:
+                        restored.pop(map_id, None)
+                self._room_selection_dirty_maps = (
+                    stored_dirty_maps | local_dirty_maps
+                )
+                self.selected_clean_rooms = restored
+                self._room_selection_store_loaded = True
+            if not getattr(self, "_room_profile_store_loaded", True):
+                if preserved_profiles is None:
+                    try:
+                        stored = await self._room_selection_store.async_load()
+                    except Exception:
+                        _LOGGER.debug("Could not reconcile room profiles before save")
+                        return
+                    if stored is None:
+                        self._room_profile_store_loaded = True
+                    elif isinstance(stored, Mapping) and isinstance(
+                        stored.get("profiles", []), list
+                    ):
+                        preserved_profiles = list(stored.get("profiles", []))
+                    else:
+                        return
+            payload = self._room_selection_store_payload(
+                preserved_profiles=preserved_profiles
+            )
+            save_task = asyncio.create_task(
+                self._room_selection_store.async_save(payload)
+            )
+            cancelled = False
+            while not save_task.done():
+                try:
+                    await asyncio.shield(save_task)
+                except asyncio.CancelledError:
+                    cancelled = True
+                except Exception:
+                    break
+            saved = False
+            try:
+                await save_task
+            except Exception:
+                _LOGGER.debug("Could not save room selections")
+            else:
+                saved = True
+            if saved:
+                dirty_maps = getattr(self, "_room_selection_dirty_maps", set())
+                self._room_selection_dirty_maps = (
+                    {None}
+                    if None in dirty_maps and None in self.selected_clean_rooms
+                    else set()
+                )
+            if cancelled:
+                raise asyncio.CancelledError
+
+    def set_room_clean_setting(
+        self,
+        room_id: int,
+        attr: str,
+        value,
+        *,
+        map_id: str | None = None,
+    ) -> None:
+        """Store one room-clean profile value."""
+        if attr not in ROOM_CLEAN_SETTING_ATTRS:
+            raise AttributeError(f"Unsupported room clean setting: {attr}")
+        key = self._room_clean_settings_key(room_id, map_id)
+        setattr(self.room_clean_settings_for(room_id, map_id=map_id), attr, value)
+        if not hasattr(self, "room_clean_settings_customized"):
+            self.room_clean_settings_customized = {}
+        self.room_clean_settings_customized.setdefault(key, set()).add(attr)
+        if key[0] is None:
+            if not hasattr(self, "_room_profile_pending_resolution"):
+                self._room_profile_pending_resolution = set()
+            self._room_profile_pending_resolution.add(room_id)
+        self._schedule_room_selection_save()
+
     async def async_setup(self) -> None:
         """Connect to the vacuum and start the WebSocket listener.
 
@@ -150,6 +868,7 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         try/except so setup never crashes if the robot is asleep.
         The listener's keepalive loop handles waking independently.
         """
+        await self._async_restore_room_selections()
         await self.client.connect()
 
         # Fetch initial state BEFORE starting listener (no concurrent recv)
@@ -279,6 +998,7 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
                     f"{DOMAIN}_resub",
                 )
 
+        self._sync_active_clean_context(state)
         self.async_set_updated_data(state)
 
         # Broadcast arrived — switch back to normal polling if in fast mode
@@ -332,10 +1052,12 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
                     "Status refresh returned no dock-status payload"
                 )
             self._mark_dock_status_refresh_succeeded()
+            self._sync_active_clean_context(self.client.state)
             self.async_set_updated_data(self.client.state)
         except Exception:
             self._mark_dock_status_refresh_failed()
             _LOGGER.debug("Failed to refresh dock status after transition")
+            self._sync_active_clean_context(self.client.state)
             self.async_set_updated_data(self.client.state)
 
     async def async_refresh_dock_status(self) -> bool:
@@ -346,6 +1068,7 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         except Exception:
             self._mark_dock_status_refresh_failed()
             _LOGGER.debug("Failed to refresh dock status")
+            self._sync_active_clean_context(self.client.state)
             self.async_set_updated_data(self.client.state)
             return False
         if not response.accepted:
@@ -354,15 +1077,18 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
                 "Dock status refresh was rejected with code %s",
                 response.result_code,
             )
+            self._sync_active_clean_context(self.client.state)
             self.async_set_updated_data(self.client.state)
             return False
         if full_update and not _has_dock_status_payload(response):
             self._mark_dock_status_refresh_failed()
             _LOGGER.debug("Dock status refresh returned no dock-status payload")
+            self._sync_active_clean_context(self.client.state)
             self.async_set_updated_data(self.client.state)
             return False
         if full_update:
             self._mark_dock_status_refresh_succeeded()
+        self._sync_active_clean_context(self.client.state)
         self.async_set_updated_data(self.client.state)
         return True
 
@@ -376,6 +1102,17 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         On poll failure, returns stale data for up to _max_failures consecutive
         failures (~5 minutes) before raising UpdateFailed.
         """
+        if (
+            not getattr(self, "_room_selection_store_loaded", True)
+            or not getattr(self, "_room_profile_store_loaded", True)
+        ):
+            async with self._room_selection_save_lock:
+                if (
+                    not self._room_selection_store_loaded
+                    or not self._room_profile_store_loaded
+                ):
+                    await self._async_restore_room_selections()
+
         try:
             if not self.client.connected:
                 raise NarwalConnectionError("Not connected")
@@ -448,6 +1185,7 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
                 if self._fast_poll_remaining <= 0:
                     self.update_interval = POLL_INTERVAL
 
+        self._sync_active_clean_context(self.client.state)
         return self.client.state
 
     async def async_shutdown(self) -> None:
@@ -455,4 +1193,5 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         await self.client.disconnect()
         if self._listen_task and not self._listen_task.done():
             self._listen_task.cancel()
+        await self._async_save_room_selections()
         await super().async_shutdown()

--- a/custom_components/narwal/narwal_client/__init__.py
+++ b/custom_components/narwal/narwal_client/__init__.py
@@ -1,14 +1,20 @@
 """Narwal robot vacuum client library — local WebSocket API."""
 
-from .client import NarwalClient, NarwalCommandError, NarwalConnectionError
+from .client import (
+    NarwalClient,
+    NarwalCommandError,
+    NarwalConnectionError,
+    RoomCleanSettings,
+)
 from .const import (
     AmbientLightCtrlType,
+    CleaningRoute,
     CommandResult,
     FanLevel,
     MopHumidity,
     MopStrengthLevel,
-    WorkMode,
     WorkingStatus,
+    WorkMode,
 )
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState, RoomInfo
 from .protocol import build_frame, parse_frame
@@ -17,9 +23,11 @@ __all__ = [
     "NarwalClient",
     "NarwalCommandError",
     "NarwalConnectionError",
+    "RoomCleanSettings",
     "NarwalState",
     "CommandResponse",
     "CommandResult",
+    "CleaningRoute",
     "DeviceInfo",
     "AmbientLightCtrlType",
     "FanLevel",

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -7,7 +7,8 @@ import contextlib
 import logging
 import random
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from typing import Any
 
 import websockets
@@ -46,7 +47,6 @@ from .const import (
     TOPIC_CMD_GET_MAP,
     TOPIC_CMD_NOTIFY_APP_EVENT,
     TOPIC_CMD_PAUSE,
-    TOPIC_CMD_PLAN_START,
     TOPIC_CMD_RECALL,
     TOPIC_CMD_RESUME,
     TOPIC_CMD_SET_FAN_LEVEL,
@@ -58,6 +58,7 @@ from .const import (
     TOPIC_CMD_YELL,
     WAKE_TIMEOUT,
     AmbientLightCtrlType,
+    CleaningRoute,
     CommandResult,
     FanLevel,
     MopHumidity,
@@ -149,6 +150,18 @@ def _can_force_end_scoped_dock_task(state: NarwalState, task: str | None) -> boo
 def _has_generic_dock_stop_proof(state: NarwalState) -> bool:
     """Return true when generic force-end can only target dock-side work."""
     return state.is_docked and state.has_dock_presence_signal
+
+
+@dataclass
+class RoomCleanSettings:
+    """Clean parameters for a single room in a custom clean task."""
+
+    work_mode: WorkMode = WorkMode.VACUUM_AND_MOP
+    fan: FanLevel = FanLevel.NORMAL
+    water: MopHumidity = MopHumidity.NORMAL
+    mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL
+    passes: int = 1
+    route: CleaningRoute | None = None
 
 
 def _base_status_working_status(decoded: dict[str, Any] | object) -> WorkingStatus | None:
@@ -1181,16 +1194,6 @@ class NarwalClient:
         """Trigger locate sound — robot says 'Robot is here'."""
         return await self.send_command(TOPIC_CMD_YELL)
 
-    # Legacy clean task payload — the minimal CleanTask the app sent on Flow
-    # firmware < v01.07.22. Only used by the saved-plan fallback below, which
-    # goes to clean/plan/start — a topic that discards payloads entirely (#66),
-    # so these bytes are effectively a no-op marker on current firmware.
-    # Structure: {1: {2: {}, 5: {1: {1: 3, 2: 2, 3: 1}, 5: {}}}}
-    #   field 5.1.1 = suction level (3=max)
-    #   field 5.1.2 = mop humidity (2=wet)
-    #   field 5.1.3 = passes (1=single)
-    _DEFAULT_CLEAN_PAYLOAD = bytes.fromhex("0a0e12002a0a0a060803100218012a00")
-
     async def _all_room_ids(self) -> list[int]:
         """Every cleanable room id on the active map, fetching the map if needed."""
         map_data = self.state.map_data
@@ -1204,34 +1207,6 @@ class NarwalClient:
             return []
         return [r.room_id for r in map_data.rooms if r.room_id > 0]
 
-    async def _start_saved_plan(self) -> CommandResponse:
-        """Last-resort start: re-run the plan stored on the robot.
-
-        clean/plan/start is StartWithPlan{planId, mapId} — it ignores the
-        payload and re-runs whatever plan the robot already holds, which is
-        usually the last room selection rather than the whole house. Only
-        reachable when no map rooms are known.
-        """
-        _LOGGER.warning(
-            "start(): no map rooms available; falling back to clean/plan/start, "
-            "which re-runs the robot's saved plan rather than cleaning every room"
-        )
-        async with self._robot_start_lock:
-            if _robot_start_blocked(self.state):
-                _LOGGER.warning(
-                    "start(): robot or dock guard active (%s); not starting saved plan",
-                    self.state.active_dock_task_keys or "private",
-                )
-                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
-            response = await self.send_command(
-                TOPIC_CMD_PLAN_START,
-                payload=self._DEFAULT_CLEAN_PAYLOAD,
-                timeout=10.0,
-            )
-            if _accepted_response(response):
-                self.state.assume_robot_clean()
-            return response
-
     async def start(
         self,
         *,
@@ -1240,18 +1215,16 @@ class NarwalClient:
         water: MopHumidity = MopHumidity.NORMAL,
         mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL,
         passes: int = 1,
+        route: CleaningRoute | None = None,
     ) -> CommandResponse:
         """Start a whole-house clean.
 
         Enumerates every room on the active map and issues clean/start_clean,
         matching the app's allRoomIds() path.
 
-        The old implementation sent a minimal payload to clean/plan/start and
-        returned as soon as the result was anything but NOT_APPLICABLE. Newer
-        firmware answers SUCCESS there and does nothing, so the caller saw a
-        successful start that never happened (#69). clean/plan/start is a
-        plan-runner that discards payloads (#66), so it survives only as a
-        last-resort fallback when no map rooms are known.
+        The old implementation sent a minimal payload to clean/plan/start.
+        Newer firmware answers SUCCESS there and does nothing, so this path
+        fails clearly when no room list is available instead (#69).
         """
         if _robot_start_blocked(self.state):
             _LOGGER.warning(
@@ -1259,9 +1232,12 @@ class NarwalClient:
                 self.state.active_dock_task_keys or "unmapped",
             )
             return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        if not self.connected:
+            raise NarwalConnectionError("Not connected to vacuum")
         room_ids = await self._all_room_ids()
         if not room_ids:
-            return await self._start_saved_plan()
+            _LOGGER.warning("start(): no map rooms available")
+            return CommandResponse(result_code=CommandResult.NOT_READY)
         _LOGGER.info("start(): whole-house clean over %d rooms", len(room_ids))
         return await self.start_rooms(
             room_ids,
@@ -1270,6 +1246,7 @@ class NarwalClient:
             water=water,
             mop_strength=mop_strength,
             passes=passes,
+            route=route,
         )
 
     def _build_clean_payload_v2(
@@ -1306,7 +1283,7 @@ class NarwalClient:
             clean_mode: v2 schema cleanMode (3 observed for sweep+mop).
 
         Returns:
-            Encoded protobuf bytes for clean/plan/start.
+            Encoded protobuf bytes for clean/start_clean.
         """
         import blackboxprotobuf
 
@@ -1379,6 +1356,36 @@ class NarwalClient:
         WorkMode.VACUUM_THEN_MOP: (5, ("5", "6")),  # sweep + mop pass counts
         WorkMode.VACUUM_AND_MOP: (4, ("7",)),      # sweepMopSyncTime
     }
+    # The app uses taskType 6 for a custom task whose CleanItems carry the
+    # effective mode independently.  Captured in upstream issue #36 and
+    # runtime-validated on Flow firmware v01.07.23.00.
+    _CUSTOM_CLEAN_TASK_TYPE = 6
+
+    def _clean_param_for_settings(self, settings: RoomCleanSettings) -> dict[str, int]:
+        """Return a CleanParam protobuf dict for one room."""
+        param_mode, pass_tags = self._WORK_MODE_PARAM[settings.work_mode]
+        param: dict[str, int] = {
+            "1": int(param_mode),
+            "2": int(settings.fan),
+            "3": int(settings.mop_strength),
+            "4": int(settings.water),
+        }
+        if settings.route is not None:
+            param["8"] = int(settings.route)
+        for tag in pass_tags:
+            param[tag] = int(settings.passes)
+        return param
+
+    @classmethod
+    def _task_type_for_settings(
+        cls,
+        room_settings: list[RoomCleanSettings],
+    ) -> int:
+        """Return the outer CleanTask type for a room-clean payload."""
+        modes = {settings.work_mode for settings in room_settings}
+        if len(modes) == 1:
+            return int(next(iter(modes)))
+        return cls._CUSTOM_CLEAN_TASK_TYPE
 
     def _build_start_clean_payload(
         self,
@@ -1390,13 +1397,16 @@ class NarwalClient:
         water: MopHumidity = MopHumidity.NORMAL,
         mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL,
         passes: int = 1,
+        route: CleaningRoute | None = None,
+        room_settings: Mapping[int, RoomCleanSettings] | None = None,
     ) -> bytes:
         """Build a clean/start_clean request for the given rooms.
 
         StartClean_Request{1: CleanTask{1: map_id, 2: [CleanItem...], 3: {} (TaskOption),
         5: taskType}}; CleanItem{1: ZoneOption{1: 1 (room zone), 2: room_id}, 2: CleanParam,
-        3: order}. taskType (the execution-mode carrier) and CleanParam.mode/pass-tag are
-        derived from work_mode. overlapLevel is omitted — live-validated as ignored here.
+        3: order}. Uniform tasks use the WorkMode as taskType. Mixed-mode tasks use
+        the app's custom taskType (6), with each CleanParam carrying its own mode.
+        overlapLevel is CleanParam tag 8 when supplied.
 
         Args:
             room_ids: Robot room IDs (RoomInfo.room_id).
@@ -1406,28 +1416,42 @@ class NarwalClient:
             water: Mop water volume (tag 4).
             mop_strength: Mop scrub intensity (tag 3).
             passes: Clean count, routed to the pass tag(s) for the mode.
+            route: Optional route overlap level (tag 8).
+            room_settings: Optional per-room settings keyed by robot room ID.
         """
         import blackboxprotobuf
 
-        param_mode, pass_tags = self._WORK_MODE_PARAM[work_mode]
-        param: dict[str, int] = {
-            "1": int(param_mode),
-            "2": int(fan),
-            "3": int(mop_strength),
-            "4": int(water),
-        }
-        for tag in pass_tags:
-            param[tag] = int(passes)
+        default_settings = RoomCleanSettings(
+            work_mode=work_mode,
+            fan=fan,
+            water=water,
+            mop_strength=mop_strength,
+            passes=passes,
+            route=route,
+        )
+        settings_by_room = (
+            {rid: room_settings.get(rid, default_settings) for rid in room_ids}
+            if room_settings
+            else {rid: default_settings for rid in room_ids}
+        )
+        task_type = self._task_type_for_settings(
+            list(settings_by_room.values()),
+        )
+        param_keys: set[str] = set()
+        params_by_room: dict[int, dict[str, int]] = {}
+        for rid, settings in settings_by_room.items():
+            params_by_room[rid] = self._clean_param_for_settings(settings)
+            param_keys.update(params_by_room[rid])
 
         items = [
-            {"1": {"1": 1, "2": rid}, "2": dict(param), "3": idx + 1}
+            {"1": {"1": 1, "2": rid}, "2": params_by_room[rid], "3": idx + 1}
             for idx, rid in enumerate(room_ids)
         ]
         task = {
             "1": map_id,
             "2": items if len(items) > 1 else items[0],
             "3": {},
-            "5": int(work_mode),  # CleanTask.taskType
+            "5": int(task_type),  # CleanTask.taskType
         }
         item_typedef = {
             "type": "message",
@@ -1439,7 +1463,7 @@ class NarwalClient:
                 # Derive the CleanParam typedef from the emitted dict — bbpb silently
                 # drops any tag absent from the typedef.
                 "2": {"type": "message", "message_typedef": {
-                    k: {"type": "int"} for k in param
+                    k: {"type": "int"} for k in sorted(param_keys, key=int)
                 }},
                 "3": {"type": "int"},
             },
@@ -1461,6 +1485,8 @@ class NarwalClient:
         water: MopHumidity = MopHumidity.NORMAL,
         mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL,
         passes: int = 1,
+        route: CleaningRoute | None = None,
+        room_settings: Mapping[int, RoomCleanSettings] | None = None,
     ) -> CommandResponse:
         """Start cleaning the given rooms via clean/start_clean.
 
@@ -1476,13 +1502,12 @@ class NarwalClient:
 
         Args:
             room_ids: Robot room IDs (RoomInfo.room_id), mapped from HA areas.
-            work_mode, fan, water, mop_strength, passes: CleanParam settings —
+            work_mode, fan, water, mop_strength, passes, route: CleanParam settings —
                 see _build_start_clean_payload.
+            room_settings: Optional per-room settings keyed by robot room ID.
         """
         if not room_ids:
-            # No rooms selected — do not call start(), which would resolve the
-            # full room list and come straight back here.
-            return await self._start_saved_plan()
+            return CommandResponse(result_code=CommandResult.NOT_READY)
         async with self._robot_start_lock:
             if _robot_start_blocked(self.state):
                 _LOGGER.warning(
@@ -1501,10 +1526,21 @@ class NarwalClient:
                 )
                 return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
 
-            payload = self._build_start_clean_payload(
-                room_ids, map_id, work_mode=work_mode, fan=fan, water=water,
-                mop_strength=mop_strength, passes=passes,
-            )
+            try:
+                payload = self._build_start_clean_payload(
+                    room_ids,
+                    map_id,
+                    work_mode=work_mode,
+                    fan=fan,
+                    water=water,
+                    mop_strength=mop_strength,
+                    passes=passes,
+                    route=route,
+                    room_settings=room_settings,
+                )
+            except ValueError as err:
+                _LOGGER.warning("start_rooms: %s", err)
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
             resp = await self.send_command(
                 TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
             )
@@ -1863,7 +1899,13 @@ class NarwalClient:
     async def get_map(self) -> MapData:
         """Download the full map data."""
         resp = await self.send_command(TOPIC_CMD_GET_MAP, timeout=15.0)
+        if not resp.accepted:
+            raise NarwalCommandError(
+                f"get_map failed with code {resp.result_code}"
+            )
         map_data = MapData.from_response(resp.data)
+        if not map_data.map_id:
+            raise NarwalCommandError("get_map response did not contain an active map")
         self.state.map_data = map_data
         return map_data
 

--- a/custom_components/narwal/narwal_client/const.py
+++ b/custom_components/narwal/narwal_client/const.py
@@ -188,6 +188,7 @@ class WorkingStatus(IntEnum):
            active — developer/take_picture is accepted in this state)
       10 = DOCKED (on dock, charging)
       14 = CHARGED (on dock, fully charged)
+      17 = CUSTOM_CLEANING (custom per-room clean; live-validated on Flow 2)
       19 = TASK_COMPLETED (transitional: scheduled task finished, returning to base)
 
     Field 3 sub-fields (confirmed live):
@@ -209,10 +210,11 @@ class WorkingStatus(IntEnum):
     # revisit if a capture shows 3 means something else (e.g. a self-test state).
     CLEANING_V2 = 3   # active cleaning on newer Flow 2 firmware
     CLEANING = 4      # active cleaning (stays 4 even while returning to dock)
-    CLEANING_ALT = 5  # cleaning — observed when robot was physically stuck; may indicate error/stuck state
+    CLEANING_ALT = 5  # cleaning - seen when stuck; may indicate error/stuck state
     REMAPPING = 7     # mapping/exploration (live 2026-07-09); camera active, take_picture accepted
     DOCKED = 10       # on dock (does NOT reliably indicate charging vs charged)
     CHARGED = 14      # on dock (reported before 100% — use battery_level for charge state)
+    CUSTOM_CLEANING = 17  # active custom per-room clean on Flow 2
     TASK_COMPLETED = 19  # transitional: task finished, robot returning to base (#41)
     # PLACEHOLDER: error state value not yet observed live.
     # Trigger a real error (e.g., pick up robot mid-clean) to discover the value.
@@ -224,13 +226,18 @@ ACTIVE_CLEANING_STATUSES = frozenset(
         WorkingStatus.CLEANING_V2,
         WorkingStatus.CLEANING,
         WorkingStatus.CLEANING_ALT,
+        WorkingStatus.CUSTOM_CLEANING,
         WorkingStatus.REMAPPING,
     }
 )
 
 
 class FanLevel(IntEnum):
-    """CleanParam suction level (CleanTask.pbenum FanLevel). Live clean/set_fan_level carries a SweepFanLevel instead — identical ints 0-4, but it has no SUPER, so the app maps SUPER->STRONG on that path."""
+    """CleanParam suction level.
+
+    Live clean/set_fan_level carries a SweepFanLevel instead: identical ints
+    0-4, but it has no SUPER, so the app maps SUPER->STRONG on that path.
+    """
 
     UNSPECIFIED = 0
     MUTE = 1
@@ -241,7 +248,7 @@ class FanLevel(IntEnum):
 
 
 class MopHumidity(IntEnum):
-    """Water volume. CleanParam tag 4 and the live clean/set_mop_humidity command share these ints."""
+    """Water volume shared by CleanParam tag 4 and live set_mop_humidity."""
 
     UNSPECIFIED = 0
     DRY = 1
@@ -257,8 +264,19 @@ class MopStrengthLevel(IntEnum):
     HIGH = 2
 
 
+class CleaningRoute(IntEnum):
+    """Cleaning route overlap level (CleanParam tag 8)."""
+
+    STANDARD = 1
+    METICULOUS = 2
+
+
 class WorkMode(IntEnum):
-    """Clean work mode — the app's robot_work_mode_* selector (Vacuum / Mop / Vacuum then mop / Vacuum and mop). Its value IS the CleanTask.taskType the robot executes; the per-item CleanParam.mode (the proto's own CleanMode enum) is derived separately in client._WORK_MODE_PARAM."""
+    """Clean work mode selected by the app's robot_work_mode_* setting.
+
+    Uniform jobs also use this value as CleanTask.taskType. Custom mixed-mode
+    jobs use taskType 6 while each item's CleanParam.mode carries its work mode.
+    """
 
     VACUUM = 1
     MOP = 2

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -753,6 +753,19 @@ class NarwalState:
         )
 
     @property
+    def has_paused_clean_task_context(self) -> bool:
+        """True when a paused overlay still has retained robot clean details."""
+        if not self.is_paused or self.is_docked:
+            return False
+        return (
+            getattr(self, "task_progress_percent", None) is not None
+            or getattr(self, "task_elapsed_time", self.cleaning_time) > 0
+            or getattr(self, "task_remaining_time", 0) > 0
+            or self.current_room_id is not None
+            or bool(getattr(self, "current_room_aux_name", ""))
+        )
+
+    @property
     def is_cleaning(self) -> bool:
         """True when actively cleaning (not paused, not returning to dock)."""
         if self.has_recent_active_working_status:
@@ -1113,7 +1126,8 @@ class NarwalState:
             except (ValueError, TypeError):
                 pass
         if active_payload:
-            self.working_status = WorkingStatus.CLEANING
+            if self.working_status != WorkingStatus.CUSTOM_CLEANING:
+                self.working_status = WorkingStatus.CLEANING
             self.last_active_working_status_time = time.monotonic()
             self.clear_assumed_robot_clean()
             self.is_paused = False

--- a/custom_components/narwal/number.py
+++ b/custom_components/narwal/number.py
@@ -6,14 +6,16 @@ CleanParam tag for the current mode (sweep->5, mop->6, sweep_then_mop->5+6, sync
 
 from __future__ import annotations
 
+import voluptuous as vol
 from homeassistant.components.number import NumberMode, RestoreNumber
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import NarwalConfigEntry
+from . import NarwalConfigEntry, _validate_pass_count
 from .const import PASSES_MAX, PASSES_MIN
-from .coordinator import NarwalCoordinator
+from .coordinator import NarwalCoordinator, can_edit_pending_clean_settings
 from .entity import NarwalEntity
 
 
@@ -50,8 +52,11 @@ class NarwalPassesNumber(NarwalEntity, RestoreNumber):
 
     @property
     def available(self) -> bool:
-        """Editable even while the robot sleeps — this is a pending setting."""
-        return True
+        """Return True when the pass count can be changed now."""
+        return (
+            can_edit_pending_clean_settings(self.coordinator.data)
+            and not self.coordinator.has_selected_clean_rooms()
+        )
 
     @property
     def native_value(self) -> float:
@@ -60,5 +65,15 @@ class NarwalPassesNumber(NarwalEntity, RestoreNumber):
 
     async def async_set_native_value(self, value: float) -> None:
         """Store the pass count."""
-        self.coordinator.clean_settings.passes = int(value)
+        if (
+            not can_edit_pending_clean_settings(self.coordinator.data)
+            or self.coordinator.has_selected_clean_rooms()
+        ):
+            raise HomeAssistantError("Narwal pass count cannot be changed right now")
+        try:
+            passes = _validate_pass_count(value)
+        except vol.Invalid as err:
+            raise HomeAssistantError(str(err)) from err
+        self.coordinator.clean_settings.passes = passes
         self.async_write_ha_state()
+        self.coordinator.async_update_listeners()

--- a/custom_components/narwal/select.py
+++ b/custom_components/narwal/select.py
@@ -1,7 +1,7 @@
 """Clean-parameter select entities for Narwal vacuum.
 
-These hold pending values applied at the next room clean (CleanParam is only sent in the
-start payload). water additionally writes live via clean/set_mop_humidity while cleaning.
+These hold pending values applied at the next room clean. Water additionally writes
+live via clean/set_mop_humidity while cleaning.
 """
 
 from __future__ import annotations
@@ -10,14 +10,49 @@ from dataclasses import dataclass
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
+from homeassistant.util import slugify
 
 from . import NarwalConfigEntry
-from .const import WORK_MODE_MAP, MOP_STRENGTH_MAP, WATER_MAP
-from .coordinator import NarwalCoordinator
+from .const import (
+    FAN_SPEED_LIST,
+    FAN_SPEED_MAP,
+    MOP_STRENGTH_MAP,
+    UNVERSIONED_FAN_SPEED_MAP,
+    WATER_MAP,
+    WORK_MODE_MAP,
+    fan_speed_list_for,
+    normalize_fan_level_for_model,
+)
+from .coordinator import (
+    NarwalCoordinator,
+    can_edit_pending_clean_settings,
+    clean_setting_applies_to_mode,
+    is_live_clean_setting_available,
+)
 from .entity import NarwalEntity
+from .narwal_client import (
+    CleaningRoute,
+    CommandResult,
+    FanLevel,
+    MopHumidity,
+    MopStrengthLevel,
+    WorkMode,
+)
+
+
+def _raise_if_command_failed(response, action: str) -> None:
+    """Raise a Home Assistant service error for rejected robot commands."""
+    if response.accepted:
+        return
+    try:
+        result_name = CommandResult(response.result_code).name
+    except ValueError:
+        result_name = f"UNKNOWN({response.result_code})"
+    raise HomeAssistantError(f"Narwal {action} failed: {result_name}")
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -27,6 +62,35 @@ class NarwalSelectEntityDescription(SelectEntityDescription):
     attr: str  # CleanSettings field this select reads/writes
     mapping: dict[str, int]  # option label -> robot enum value
     live_setter: str | None = None  # NarwalClient coroutine applied live while cleaning
+
+
+@dataclass(frozen=True)
+class SettingRestoreData(ExtraStoredData):
+    """Persist a clean setting by its stable robot value."""
+
+    value: int
+    version: int = 1
+
+    def as_dict(self) -> dict[str, int]:
+        """Return a JSON-serializable representation."""
+        return {"version": self.version, "value": self.value}
+
+
+@dataclass(frozen=True)
+class RoomSettingRestoreData(ExtraStoredData):
+    """Persist a room setting independently of entity availability."""
+
+    value: int
+    customized: bool
+    version: int = 1
+
+    def as_dict(self) -> dict[str, int | bool]:
+        """Return a JSON-serializable representation."""
+        return {
+            "version": self.version,
+            "value": self.value,
+            "customized": self.customized,
+        }
 
 
 SELECT_DESCRIPTIONS: tuple[NarwalSelectEntityDescription, ...] = (
@@ -57,6 +121,175 @@ SELECT_DESCRIPTIONS: tuple[NarwalSelectEntityDescription, ...] = (
     ),
 )
 
+LEGACY_MODE_OPTIONS = ("Vacuum", "Mop", "Vacuum then mop", "Vacuum and mop")
+LEGACY_SUCTION_OPTIONS = ("AI", *FAN_SPEED_LIST)
+LEGACY_WATER_OPTIONS = ("Dry", "Normal", "Wet")
+LEGACY_SCRUB_OPTIONS = ("Normal", "High")
+LEGACY_ROUTE_OPTIONS = ("Standard", "Meticulous")
+LEGACY_PASSES_OPTIONS = ("1", "2", "3")
+
+LEGACY_MODE_MAP: dict[str, WorkMode] = {
+    "Vacuum": WorkMode.VACUUM,
+    "Mop": WorkMode.MOP,
+    "Vacuum then mop": WorkMode.VACUUM_THEN_MOP,
+    "Vacuum and mop": WorkMode.VACUUM_AND_MOP,
+}
+LEGACY_MODE_LABELS: dict[WorkMode, str] = {
+    value: label for label, value in LEGACY_MODE_MAP.items()
+}
+LEGACY_SUCTION_MAP: dict[str, FanLevel] = {
+    "AI": FanLevel.UNSPECIFIED,
+    "Super": FanLevel.DEEP,
+    "Super powerful": FanLevel.DEEP,
+    "Ultra powerful": FanLevel.SUPER,
+    **{option: FAN_SPEED_MAP[option] for option in FAN_SPEED_LIST},
+}
+LEGACY_SUCTION_LABELS: dict[FanLevel, str] = {
+    FanLevel.UNSPECIFIED: "AI",
+    **{FAN_SPEED_MAP[option]: option for option in FAN_SPEED_LIST},
+}
+LEGACY_WATER_MAP: dict[str, MopHumidity] = {
+    "Dry": MopHumidity.DRY,
+    "Normal": MopHumidity.NORMAL,
+    "Wet": MopHumidity.WET,
+}
+LEGACY_SCRUB_MAP: dict[str, MopStrengthLevel] = {
+    "Normal": MopStrengthLevel.NORMAL,
+    "High": MopStrengthLevel.HIGH,
+}
+LEGACY_ROUTE_MAP: dict[str, CleaningRoute] = {
+    "Standard": CleaningRoute.STANDARD,
+    "Meticulous": CleaningRoute.METICULOUS,
+}
+LEGACY_MOP_MODES = {"Mop", "Vacuum then mop", "Vacuum and mop"}
+LEGACY_VACUUM_MODES = {"Vacuum", "Vacuum then mop", "Vacuum and mop"}
+LEGACY_START_ONLY_SETTINGS = {"mode", "passes", "route", "scrub"}
+START_ONLY_CLEAN_SETTING_ATTRS = {"work_mode", "mop_strength"}
+
+
+@dataclass(frozen=True, kw_only=True)
+class LegacyNarwalSelectEntityDescription(SelectEntityDescription):
+    """Describes a backwards-compatible Narwal setting select."""
+
+    setting_key: str
+    setting_options: tuple[str, ...]
+    default_option: str
+    icon: str
+
+
+LEGACY_SELECT_DESCRIPTIONS: tuple[LegacyNarwalSelectEntityDescription, ...] = (
+    LegacyNarwalSelectEntityDescription(
+        key="mode",
+        setting_key="mode",
+        name="Mode",
+        setting_options=LEGACY_MODE_OPTIONS,
+        default_option="Vacuum and mop",
+        icon="mdi:robot-vacuum",
+    ),
+    LegacyNarwalSelectEntityDescription(
+        key="runtime_suction",
+        setting_key="suction",
+        name="Suction",
+        setting_options=LEGACY_SUCTION_OPTIONS,
+        default_option="Super Powerful",
+        icon="mdi:fan",
+    ),
+    LegacyNarwalSelectEntityDescription(
+        key="runtime_water",
+        setting_key="water",
+        name="Water",
+        setting_options=LEGACY_WATER_OPTIONS,
+        default_option="Wet",
+        icon="mdi:water",
+    ),
+    LegacyNarwalSelectEntityDescription(
+        key="scrub",
+        setting_key="scrub",
+        name="Scrub",
+        setting_options=LEGACY_SCRUB_OPTIONS,
+        default_option="High",
+        icon="mdi:brush",
+    ),
+    LegacyNarwalSelectEntityDescription(
+        key="route",
+        setting_key="route",
+        name="Route",
+        setting_options=LEGACY_ROUTE_OPTIONS,
+        default_option="Meticulous",
+        icon="mdi:routes",
+    ),
+    LegacyNarwalSelectEntityDescription(
+        key="passes",
+        setting_key="passes",
+        name="Passes",
+        setting_options=LEGACY_PASSES_OPTIONS,
+        default_option="2",
+        icon="mdi:counter",
+    ),
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class RoomNarwalSelectEntityDescription(SelectEntityDescription):
+    """Describes a per-room Narwal clean profile select."""
+
+    setting_key: str
+    attr: str
+    default_option: str
+    icon: str
+
+
+ROOM_SELECT_DESCRIPTIONS: tuple[RoomNarwalSelectEntityDescription, ...] = (
+    RoomNarwalSelectEntityDescription(
+        key="room_mode",
+        setting_key="mode",
+        attr="work_mode",
+        name="mode",
+        default_option="Vacuum and mop",
+        icon="mdi:robot-vacuum",
+    ),
+    RoomNarwalSelectEntityDescription(
+        key="room_suction",
+        setting_key="suction",
+        attr="fan",
+        name="suction",
+        default_option="Super Powerful",
+        icon="mdi:fan",
+    ),
+    RoomNarwalSelectEntityDescription(
+        key="room_water",
+        setting_key="water",
+        attr="water",
+        name="water",
+        default_option="Wet",
+        icon="mdi:water",
+    ),
+    RoomNarwalSelectEntityDescription(
+        key="room_scrub",
+        setting_key="scrub",
+        attr="mop_strength",
+        name="scrub",
+        default_option="High",
+        icon="mdi:brush",
+    ),
+    RoomNarwalSelectEntityDescription(
+        key="room_route",
+        setting_key="route",
+        attr="route",
+        name="route",
+        default_option="Meticulous",
+        icon="mdi:routes",
+    ),
+    RoomNarwalSelectEntityDescription(
+        key="room_passes",
+        setting_key="passes",
+        attr="passes",
+        name="passes",
+        default_option="2",
+        icon="mdi:counter",
+    ),
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -65,13 +298,53 @@ async def async_setup_entry(
 ) -> None:
     """Set up Narwal clean-param select entities."""
     coordinator = entry.runtime_data
+    known_room_settings: dict[tuple[str | None, int, str], RoomNarwalSettingSelect] = {}
+
+    @callback
+    def async_add_room_setting_entities() -> None:
+        map_data = coordinator.client.state.map_data
+        if map_data is None:
+            return
+        map_id = coordinator.room_settings_map_id(map_data)
+        entities: list[RoomNarwalSettingSelect] = []
+        for room in sorted(map_data.rooms, key=lambda item: item.display_name.lower()):
+            if room.room_id <= 0:
+                continue
+            for description in ROOM_SELECT_DESCRIPTIONS:
+                key = (map_id, room.room_id, description.key)
+                if key in known_room_settings:
+                    known_room_settings[key].async_update_room_name(room.display_name)
+                    continue
+                entity = RoomNarwalSettingSelect(
+                    coordinator,
+                    room.room_id,
+                    room.display_name,
+                    description,
+                    map_id=map_id,
+                )
+                known_room_settings[key] = entity
+                entities.append(entity)
+        if entities:
+            async_add_entities(entities)
+
     async_add_entities(
-        NarwalSelect(coordinator, description) for description in SELECT_DESCRIPTIONS
+        [
+            *(
+                NarwalSelect(coordinator, description)
+                for description in SELECT_DESCRIPTIONS
+            ),
+            *(
+                LegacyNarwalSettingSelect(coordinator, description)
+                for description in LEGACY_SELECT_DESCRIPTIONS
+            ),
+        ]
     )
+    async_add_room_setting_entities()
+    entry.async_on_unload(coordinator.async_add_listener(async_add_room_setting_entities))
 
 
 class NarwalSelect(NarwalEntity, RestoreEntity, SelectEntity):
-    """A clean-parameter select backed by coordinator.clean_settings; restored across restarts."""
+    """Clean-parameter select backed by coordinator.clean_settings."""
 
     entity_description: NarwalSelectEntityDescription
 
@@ -90,6 +363,26 @@ class NarwalSelect(NarwalEntity, RestoreEntity, SelectEntity):
     async def async_added_to_hass(self) -> None:
         """Restore the last selection into clean_settings (persists across restarts)."""
         await super().async_added_to_hass()
+        extra = await self.async_get_last_extra_data()
+        if extra is not None:
+            data = extra.as_dict()
+            raw_value = data.get("value")
+            values = {
+                int(value): value for value in self.entity_description.mapping.values()
+            }
+            if (
+                data.get("version") == 1
+                and isinstance(raw_value, int)
+                and not isinstance(raw_value, bool)
+                and raw_value in values
+            ):
+                setattr(
+                    self.coordinator.clean_settings,
+                    self.entity_description.attr,
+                    values[raw_value],
+                )
+                self.coordinator.async_update_listeners()
+                return
         last = await self.async_get_last_state()
         if last is not None and last.state in self.entity_description.mapping:
             setattr(
@@ -97,23 +390,744 @@ class NarwalSelect(NarwalEntity, RestoreEntity, SelectEntity):
                 self.entity_description.attr,
                 self.entity_description.mapping[last.state],
             )
+            self.coordinator.async_update_listeners()
+
+    @property
+    def extra_restore_state_data(self) -> ExtraStoredData:
+        """Return the pending value even when this select is unavailable."""
+        value = getattr(
+            self.coordinator.clean_settings,
+            self.entity_description.attr,
+        )
+        return SettingRestoreData(value=int(value))
 
     @property
     def available(self) -> bool:
-        """Editable even while the robot sleeps — these are pending settings."""
-        return True
+        """Return True when this clean parameter can be changed now."""
+        state = self.coordinator.data
+        setup_available = (
+            can_edit_pending_clean_settings(state)
+            and not self.coordinator.has_selected_clean_rooms()
+        )
+        setup_applies = clean_setting_applies_to_mode(
+            self.entity_description.attr,
+            self.coordinator.clean_settings.work_mode,
+        )
+        if self.entity_description.attr in START_ONLY_CLEAN_SETTING_ATTRS:
+            return setup_available and setup_applies
+        live_available = super().available and is_live_clean_setting_available(state)
+        live_mode = self.coordinator.clean_setting_applicability_mode(live=True)
+        live_applies = (
+            live_mode is not None
+            and clean_setting_applies_to_mode(
+                self.entity_description.attr,
+                live_mode,
+            )
+        )
+        return (
+            (setup_available and setup_applies)
+            or (live_available and live_applies)
+        )
 
     @property
     def current_option(self) -> str | None:
         """Return the stored option label."""
-        value = getattr(self.coordinator.clean_settings, self.entity_description.attr)
+        value = self.coordinator.active_clean_setting(self.entity_description.attr)
+        if value is None:
+            value = getattr(
+                self.coordinator.clean_settings,
+                self.entity_description.attr,
+            )
         return self._labels.get(int(value))
 
     async def async_select_option(self, option: str) -> None:
-        """Store the selection and, for live controls, apply it if cleaning."""
-        value = self.entity_description.mapping[option]
-        setattr(self.coordinator.clean_settings, self.entity_description.attr, value)
-        self.async_write_ha_state()
+        """Store an editable pending selection or apply it to a live clean."""
+        if option not in self.entity_description.mapping:
+            raise HomeAssistantError(f"Unsupported Narwal option: {option}")
         state = self.coordinator.data
-        if self.entity_description.live_setter and state is not None and state.is_cleaning:
-            await getattr(self.coordinator.client, self.entity_description.live_setter)(value)
+        has_selected_rooms = self.coordinator.has_selected_clean_rooms()
+        setup_available = (
+            can_edit_pending_clean_settings(state)
+            and not has_selected_rooms
+        )
+        live_available = super().available and is_live_clean_setting_available(state)
+        setup_applies = clean_setting_applies_to_mode(
+            self.entity_description.attr,
+            self.coordinator.clean_settings.work_mode,
+        )
+        live_mode = self.coordinator.clean_setting_applicability_mode(live=True)
+        live_applies = (
+            live_mode is not None
+            and clean_setting_applies_to_mode(
+                self.entity_description.attr,
+                live_mode,
+            )
+        )
+        if not (
+            (setup_available and setup_applies)
+            or (
+                self.entity_description.attr not in START_ONLY_CLEAN_SETTING_ATTRS
+                and live_available
+                and live_applies
+            )
+        ):
+            if not setup_applies and not live_applies:
+                raise HomeAssistantError(
+                    "This Narwal setting is not available for the selected mode"
+                )
+            raise HomeAssistantError(
+                "This Narwal setting cannot be changed right now"
+            )
+        if (
+            self.entity_description.attr in START_ONLY_CLEAN_SETTING_ATTRS
+            and not setup_available
+        ):
+            raise HomeAssistantError("This Narwal setting cannot be changed right now")
+        if (
+            self.entity_description.attr not in START_ONLY_CLEAN_SETTING_ATTRS
+            and not setup_available
+            and not live_available
+        ):
+            raise HomeAssistantError("This Narwal setting cannot be changed right now")
+
+        value = self.entity_description.mapping[option]
+        if (
+            self.entity_description.live_setter
+            and state is not None
+            and live_available
+            and live_applies
+        ):
+            response = await getattr(
+                self.coordinator.client, self.entity_description.live_setter
+            )(
+                value
+            )
+            _raise_if_command_failed(response, f"set {self.entity_description.name}")
+            self.coordinator.set_active_clean_setting(
+                self.entity_description.attr,
+                value,
+            )
+        if not has_selected_rooms:
+            setattr(self.coordinator.clean_settings, self.entity_description.attr, value)
+        self.async_write_ha_state()
+        self.coordinator.async_update_listeners()
+
+
+class RoomNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
+    """Per-room clean profile select backed by coordinator room settings."""
+
+    entity_description: RoomNarwalSelectEntityDescription
+
+    def __init__(
+        self,
+        coordinator: NarwalCoordinator,
+        room_id: int,
+        room_name: str,
+        description: RoomNarwalSelectEntityDescription,
+        *,
+        map_id: str | None = None,
+    ) -> None:
+        """Initialize the per-room select."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._map_id = map_id
+        self._room_id = room_id
+        self._room_name = room_name
+        device_id = coordinator.config_entry.data["device_id"]
+        map_prefix = f"map_{slugify(map_id)}_" if map_id is not None else ""
+        self._attr_unique_id = (
+            f"{device_id}_{map_prefix}room_{room_id}_{description.setting_key}"
+        )
+        self._attr_name = f"{room_name} {description.name}"
+        self._attr_icon = description.icon
+        self._attr_options = self._options_for_description(description)
+        self._attr_entity_category = EntityCategory.CONFIG
+
+    @callback
+    def async_update_room_name(self, room_name: str) -> None:
+        """Update display metadata when the map renames this room."""
+        if room_name == self._room_name:
+            return
+        self._room_name = room_name
+        self._attr_name = f"{room_name} {self.entity_description.name}"
+        if getattr(self, "hass", None) is not None:
+            self.async_write_ha_state()
+
+    def _options_for_description(
+        self,
+        description: RoomNarwalSelectEntityDescription,
+    ) -> list[str]:
+        """Return selectable options for this room setting."""
+        if description.setting_key == "suction":
+            return ["AI", *fan_speed_list_for(self.coordinator.config_entry.data)]
+        if description.setting_key == "mode":
+            return list(LEGACY_MODE_OPTIONS)
+        if description.setting_key == "water":
+            return list(LEGACY_WATER_OPTIONS)
+        if description.setting_key == "scrub":
+            return list(LEGACY_SCRUB_OPTIONS)
+        if description.setting_key == "route":
+            return list(LEGACY_ROUTE_OPTIONS)
+        if description.setting_key == "passes":
+            return list(LEGACY_PASSES_OPTIONS)
+        return []
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the room profile option."""
+        await super().async_added_to_hass()
+        if getattr(self.coordinator, "_room_profile_store_loaded", True) is False:
+            return
+        if self._is_customized:
+            return
+        extra = await self.async_get_last_extra_data()
+        if extra is not None:
+            data = extra.as_dict()
+            if data.get("customized") is False:
+                return
+            if data.get("customized") is True:
+                raw_value = data.get("value")
+                if (
+                    data.get("version") == 1
+                    and isinstance(raw_value, int)
+                    and not isinstance(raw_value, bool)
+                    and self._apply_raw_value(raw_value)
+                ):
+                    return
+                option = data.get("option")
+                if isinstance(option, str) and self._apply_unversioned_option(option):
+                    return
+        last = await self.async_get_last_state()
+        if last is not None and self._restore_state_is_customized(last):
+            self._apply_unversioned_option(last.state)
+
+    @property
+    def extra_restore_state_data(self) -> ExtraStoredData:
+        """Return the room profile even when its entity is unavailable."""
+        return RoomSettingRestoreData(
+            value=self._raw_value,
+            customized=self._is_customized,
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True when this room profile can be changed now."""
+        if (
+            getattr(self.coordinator, "_room_profile_store_loaded", True) is False
+            or not can_edit_pending_clean_settings(self.coordinator.data)
+            or not self._room_exists
+        ):
+            return False
+        key = self.entity_description.setting_key
+        mode = self._selected_mode
+        if key == "water" and mode not in LEGACY_MOP_MODES:
+            return False
+        if key == "scrub" and mode not in LEGACY_MOP_MODES:
+            return False
+        return key != "suction" or mode in LEGACY_VACUUM_MODES
+
+    @property
+    def options(self) -> list[str]:
+        """Return the selectable room profile options."""
+        return list(self._attr_options or [])
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the currently selected profile option."""
+        settings = self.coordinator.effective_room_clean_settings_for(
+            self._room_id,
+            map_id=self._map_id,
+        )
+        return self._label_for_value(getattr(settings, self.entity_description.attr))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | int | bool]:
+        """Return room metadata for dashboards and automations."""
+        return {
+            "room_id": self._room_id,
+            "room_name": self._room_name,
+            "setting": self.entity_description.setting_key,
+            "map_id": self._map_id or "",
+            "customized": self._is_customized,
+        }
+
+    @property
+    def _is_customized(self) -> bool:
+        """Return True when this room field was explicitly customized."""
+        customized = getattr(self.coordinator, "room_clean_settings_customized", {})
+        key = (self._map_id, self._room_id)
+        return self.entity_description.attr in customized.get(key, set())
+
+    @property
+    def _room_exists(self) -> bool:
+        """Return True when the room still exists in the current map."""
+        state = self.coordinator.data
+        map_data = getattr(state, "map_data", None) if state is not None else None
+        if self.coordinator.room_settings_map_id(map_data) != self._map_id:
+            return False
+        rooms = getattr(map_data, "rooms", None)
+        if not isinstance(rooms, (list, tuple)):
+            return True
+        return any(room.room_id == self._room_id for room in rooms)
+
+    @property
+    def _selected_mode(self) -> str:
+        """Return the selected room clean mode."""
+        settings = self.coordinator.effective_room_clean_settings_for(
+            self._room_id,
+            map_id=self._map_id,
+        )
+        return LEGACY_MODE_LABELS.get(settings.work_mode) or "Vacuum and mop"
+
+    def _label_for_value(self, value) -> str | None:
+        """Return the UI option label for a profile value."""
+        key = self.entity_description.setting_key
+        if key == "mode":
+            return LEGACY_MODE_LABELS.get(value)
+        if key == "suction":
+            return LEGACY_SUCTION_LABELS.get(value)
+        if key == "water":
+            labels = {value: label for label, value in LEGACY_WATER_MAP.items()}
+            return labels.get(value)
+        if key == "scrub":
+            labels = {value: label for label, value in LEGACY_SCRUB_MAP.items()}
+            return labels.get(value)
+        if key == "route":
+            labels = {value: label for label, value in LEGACY_ROUTE_MAP.items()}
+            return labels.get(value)
+        if key == "passes":
+            return str(value)
+        return None
+
+    def _normalise_option(self, option: str) -> str | None:
+        """Return a current option, accepting old hidden suction aliases."""
+        if option in self.options:
+            return option
+        if self.entity_description.setting_key != "suction":
+            return None
+        label = LEGACY_SUCTION_LABELS.get(LEGACY_SUCTION_MAP.get(option))
+        return label if label in self.options else None
+
+    @staticmethod
+    def _restore_state_is_customized(state: State) -> bool:
+        """Return True when restored state represents an explicit room override."""
+        attributes = getattr(state, "attributes", None)
+        return isinstance(attributes, dict) and attributes.get("customized") is True
+
+    @property
+    def _raw_value(self) -> int:
+        """Return the stable robot value for this room setting."""
+        settings = self.coordinator.effective_room_clean_settings_for(
+            self._room_id,
+            map_id=self._map_id,
+        )
+        return int(getattr(settings, self.entity_description.attr))
+
+    def _value_for_option(self, option: str, *, unversioned: bool = False):
+        """Return the robot value represented by an option."""
+        key = self.entity_description.setting_key
+        if key == "mode":
+            return LEGACY_MODE_MAP.get(option)
+        elif key == "suction":
+            mapping = (
+                UNVERSIONED_FAN_SPEED_MAP
+                if unversioned
+                else LEGACY_SUCTION_MAP
+            )
+            return mapping.get(option)
+        elif key == "water":
+            return LEGACY_WATER_MAP.get(option)
+        elif key == "scrub":
+            return LEGACY_SCRUB_MAP.get(option)
+        elif key == "route":
+            return LEGACY_ROUTE_MAP.get(option)
+        elif key == "passes":
+            return int(option) if option in LEGACY_PASSES_OPTIONS else None
+        return None
+
+    def _allowed_values(self) -> dict[int, object]:
+        """Return valid robot values for this room field."""
+        options = self.options
+        values = [self._value_for_option(option) for option in options]
+        return {int(value): value for value in values if value is not None}
+
+    def _apply_raw_value(self, raw_value: int) -> bool:
+        """Store a validated stable robot value."""
+        value = self._allowed_values().get(raw_value)
+        if value is None:
+            return False
+        self.coordinator.set_room_clean_setting(
+            self._room_id,
+            self.entity_description.attr,
+            value,
+            map_id=self._map_id,
+        )
+        self.coordinator.async_update_listeners()
+        return True
+
+    def _apply_unversioned_option(self, option: str) -> bool:
+        """Restore a pre-schema label using its historical meaning."""
+        value = self._value_for_option(option, unversioned=True)
+        if value is None:
+            return False
+        if self.entity_description.setting_key == "suction":
+            value = normalize_fan_level_for_model(
+                self.coordinator.config_entry.data,
+                value,
+            )
+        self.coordinator.set_room_clean_setting(
+            self._room_id,
+            self.entity_description.attr,
+            value,
+            map_id=self._map_id,
+        )
+        self.coordinator.async_update_listeners()
+        return True
+
+    def _apply_option(self, option: str) -> None:
+        """Store a room profile option."""
+        value = self._value_for_option(option)
+        if value is None:
+            raise HomeAssistantError(f"Unsupported Narwal room option: {option}")
+        self.coordinator.set_room_clean_setting(
+            self._room_id,
+            self.entity_description.attr,
+            value,
+            map_id=self._map_id,
+        )
+
+    async def async_select_option(self, option: str) -> None:
+        """Apply a room profile option."""
+        if getattr(self.coordinator, "_room_profile_store_loaded", True) is False:
+            raise HomeAssistantError("Narwal room profiles are not restored yet")
+        requested_option = option
+        option = self._normalise_option(option) or ""
+        if not option:
+            raise HomeAssistantError(f"Unsupported Narwal room option: {requested_option}")
+        if not self._room_exists:
+            raise HomeAssistantError("Narwal room is not available")
+        if not can_edit_pending_clean_settings(self.coordinator.data):
+            raise HomeAssistantError("Narwal room profiles cannot be changed right now")
+
+        key = self.entity_description.setting_key
+        mode = self._selected_mode
+        if key == "water" and mode not in LEGACY_MOP_MODES:
+            raise HomeAssistantError("Water level is not available in vacuum-only mode")
+        if key == "scrub" and mode not in LEGACY_MOP_MODES:
+            raise HomeAssistantError("Scrub level is not available in vacuum-only mode")
+        if key == "suction" and mode not in LEGACY_VACUUM_MODES:
+            raise HomeAssistantError("Suction is not available in mop-only mode")
+
+        self._apply_option(option)
+        self.async_write_ha_state()
+        self.coordinator.async_update_listeners()
+
+
+class LegacyNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
+    """Backwards-compatible selects for existing dashboards and scripts."""
+
+    entity_description: LegacyNarwalSelectEntityDescription
+
+    def __init__(
+        self,
+        coordinator: NarwalCoordinator,
+        description: LegacyNarwalSelectEntityDescription,
+    ) -> None:
+        """Initialize the legacy select."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        device_id = coordinator.config_entry.data["device_id"]
+        self._attr_unique_id = f"{device_id}_{description.key}"
+        self._attr_icon = description.icon
+        self._attr_entity_category = EntityCategory.CONFIG
+        if description.setting_key == "suction":
+            self._attr_options = [
+                "AI",
+                *fan_speed_list_for(coordinator.config_entry.data),
+            ]
+        else:
+            self._attr_options = list(description.setting_options)
+        self._option = description.default_option
+
+    async def async_added_to_hass(self) -> None:
+        """Restore legacy-only settings without competing with primary entities."""
+        await super().async_added_to_hass()
+        key = self.entity_description.setting_key
+        if key in {"route", "suction"}:
+            extra = await self.async_get_last_extra_data()
+            if extra is not None:
+                data = extra.as_dict()
+                raw_value = data.get("value")
+                if (
+                    data.get("version") == 1
+                    and isinstance(raw_value, int)
+                    and not isinstance(raw_value, bool)
+                    and self._apply_restored_raw_value(raw_value)
+                ):
+                    return
+            last = await self.async_get_last_state()
+            if last is not None and self._apply_unversioned_restore(last.state):
+                return
+        self._option = self._option_from_settings()
+
+    @property
+    def extra_restore_state_data(self) -> ExtraStoredData:
+        """Return the pending value even when this select is unavailable."""
+        return SettingRestoreData(value=self._raw_setting_value)
+
+    @property
+    def available(self) -> bool:
+        """Return True when this legacy setting can be changed now."""
+        return self._setting_available()
+
+    @property
+    def options(self) -> list[str]:
+        """Return the static option list for Home Assistant capabilities."""
+        return list(self._attr_options or [])
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current selected option."""
+        return self._option_from_settings()
+
+    @property
+    def _selected_mode(self) -> str:
+        """Return the selected legacy clean mode."""
+        return (
+            LEGACY_MODE_LABELS.get(self.coordinator.clean_settings.work_mode)
+            or "Vacuum and mop"
+        )
+
+    def _mode_for_applicability(self, *, live: bool = False) -> str | None:
+        """Return the mode label used for pending or live setting applicability."""
+        if not live:
+            return self._selected_mode
+        mode = self.coordinator.clean_setting_applicability_mode(live=True)
+        if mode is None:
+            return None
+        return LEGACY_MODE_LABELS.get(mode) or self._selected_mode
+
+    def _setting_applies_to_mode(self, key: str, *, live: bool = False) -> bool:
+        """Return whether the legacy setting applies to the selected mode."""
+        mode = self._mode_for_applicability(live=live)
+        if mode is None:
+            return not live
+        if key == "water" and mode not in LEGACY_MOP_MODES:
+            return False
+        if key == "scrub" and mode not in LEGACY_MOP_MODES:
+            return False
+        return not (key == "suction" and mode not in LEGACY_VACUUM_MODES)
+
+    @property
+    def _is_cleaning_or_paused(self) -> bool:
+        """Return True while the robot is in an active clean session."""
+        return is_live_clean_setting_available(self.coordinator.data)
+
+    def _setting_available(self) -> bool:
+        """Return whether this setting is currently meaningful and actionable."""
+        key = self.entity_description.setting_key
+        state = self.coordinator.data
+        setup_available = (
+            can_edit_pending_clean_settings(state)
+            and not self.coordinator.has_selected_clean_rooms()
+        )
+        live_available = super().available and is_live_clean_setting_available(state)
+        setup_applies = self._setting_applies_to_mode(key)
+        if key in LEGACY_START_ONLY_SETTINGS:
+            return setup_available and setup_applies
+        live_applies = self._setting_applies_to_mode(key, live=True)
+        return (
+            (setup_available and setup_applies)
+            or (live_available and live_applies)
+        )
+
+    def _apply_option(self, option: str) -> None:
+        """Store a legacy option and mirror it into clean settings."""
+        self._option = option
+        key = self.entity_description.setting_key
+        settings = self.coordinator.clean_settings
+        if key == "mode":
+            settings.work_mode = LEGACY_MODE_MAP[option]
+            self.coordinator._legacy_mode_option = option
+        elif key == "suction":
+            settings.fan = LEGACY_SUCTION_MAP[option]
+        elif key == "water":
+            settings.water = LEGACY_WATER_MAP[option]
+        elif key == "scrub":
+            settings.mop_strength = LEGACY_SCRUB_MAP[option]
+        elif key == "route":
+            settings.route = LEGACY_ROUTE_MAP[option]
+        elif key == "passes":
+            settings.passes = int(option)
+
+    @property
+    def _raw_setting_value(self) -> int:
+        """Return the stable robot value for this setting."""
+        key = self.entity_description.setting_key
+        settings = self.coordinator.clean_settings
+        if key == "mode":
+            return int(settings.work_mode)
+        if key == "suction":
+            return int(settings.fan)
+        if key == "water":
+            return int(settings.water)
+        if key == "scrub":
+            return int(settings.mop_strength)
+        if key == "route":
+            return int(settings.route)
+        return settings.passes
+
+    def _apply_restored_raw_value(self, raw_value: int) -> bool:
+        """Restore the legacy-owned global settings from a stable value."""
+        key = self.entity_description.setting_key
+        if key == "suction":
+            values = {int(value): value for value in FanLevel}
+            if (value := values.get(raw_value)) is None:
+                return False
+            self.coordinator.clean_settings.fan = normalize_fan_level_for_model(
+                self.coordinator.config_entry.data,
+                value,
+            )
+        elif key == "route":
+            values = {int(value): value for value in CleaningRoute}
+            if (value := values.get(raw_value)) is None:
+                return False
+            self.coordinator.clean_settings.route = value
+        else:
+            return False
+        self._option = self._option_from_settings()
+        self.coordinator.async_update_listeners()
+        return True
+
+    def _apply_unversioned_restore(self, option: str) -> bool:
+        """Restore labels using their v1.0.5 meanings."""
+        key = self.entity_description.setting_key
+        if key == "suction":
+            value = UNVERSIONED_FAN_SPEED_MAP.get(option)
+            if value is None:
+                return False
+            self.coordinator.clean_settings.fan = normalize_fan_level_for_model(
+                self.coordinator.config_entry.data,
+                value,
+            )
+        elif key == "route":
+            value = LEGACY_ROUTE_MAP.get(option)
+            if value is None:
+                return False
+            self.coordinator.clean_settings.route = value
+        else:
+            return False
+        self._option = self._option_from_settings()
+        self.coordinator.async_update_listeners()
+        return True
+
+    def _option_from_settings(self) -> str:
+        """Return this legacy option from the shared clean settings."""
+        key = self.entity_description.setting_key
+        settings = self.coordinator.clean_settings
+        if key == "mode":
+            option = LEGACY_MODE_LABELS.get(settings.work_mode)
+        elif key == "suction":
+            value = self.coordinator.active_clean_setting("fan")
+            option = LEGACY_SUCTION_LABELS.get(
+                value if value is not None else settings.fan
+            )
+        elif key == "water":
+            value = self.coordinator.active_clean_setting("water")
+            option = {value: label for label, value in LEGACY_WATER_MAP.items()}.get(
+                value if value is not None else settings.water
+            )
+        elif key == "scrub":
+            option = {value: label for label, value in LEGACY_SCRUB_MAP.items()}.get(
+                settings.mop_strength
+            )
+        elif key == "route":
+            option = {value: label for label, value in LEGACY_ROUTE_MAP.items()}.get(
+                settings.route
+            )
+        elif key == "passes":
+            option = str(settings.passes)
+        else:
+            option = None
+        return self._normalise_option(option or "") or self.entity_description.default_option
+
+    def _normalise_option(self, option: str) -> str | None:
+        """Return a current option, accepting old hidden suction aliases."""
+        if option in self.options:
+            return option
+        if self.entity_description.setting_key != "suction":
+            return None
+        label = LEGACY_SUCTION_LABELS.get(LEGACY_SUCTION_MAP.get(option))
+        return label if label in self.options else None
+
+    async def async_select_option(self, option: str) -> None:
+        """Apply a legacy setting option."""
+        requested_option = option
+        option = self._normalise_option(option) or ""
+        if not option:
+            raise HomeAssistantError(f"Unsupported Narwal option: {requested_option}")
+
+        key = self.entity_description.setting_key
+        state = self.coordinator.data
+        has_selected_rooms = self.coordinator.has_selected_clean_rooms()
+        setup_available = (
+            can_edit_pending_clean_settings(state)
+            and not has_selected_rooms
+        )
+        live_available = super().available and is_live_clean_setting_available(state)
+        setup_applies = self._setting_applies_to_mode(key)
+        live_applies = self._setting_applies_to_mode(key, live=True)
+        if not (
+            (setup_available and setup_applies)
+            or (
+                key not in LEGACY_START_ONLY_SETTINGS
+                and live_available
+                and live_applies
+            )
+        ):
+            if key in {"water", "scrub"} and not setup_applies and not live_applies:
+                raise HomeAssistantError(
+                    f"{self.entity_description.name} is not available in vacuum-only mode"
+                )
+            if key == "suction" and not setup_applies and not live_applies:
+                raise HomeAssistantError("Suction is not available in mop-only mode")
+            raise HomeAssistantError("This Narwal setting cannot be changed right now")
+        if key in LEGACY_START_ONLY_SETTINGS and not setup_available:
+            raise HomeAssistantError("This Narwal setting cannot be changed right now")
+        if key not in LEGACY_START_ONLY_SETTINGS and not setup_available and not live_available:
+            raise HomeAssistantError("This Narwal setting cannot be changed right now")
+        if key == "suction" and option == "AI" and live_available and not setup_available:
+            raise HomeAssistantError("AI suction cannot be selected mid-clean")
+
+        response = None
+        if live_available and live_applies and not setup_available:
+            if key == "suction":
+                response = await self.coordinator.client.set_fan_speed(
+                    LEGACY_SUCTION_MAP[option]
+                )
+            elif key == "water":
+                response = await self.coordinator.client.set_mop_humidity(
+                    LEGACY_WATER_MAP[option]
+                )
+
+        if response is not None and not response.accepted:
+            try:
+                result_name = CommandResult(response.result_code).name
+            except ValueError:
+                result_name = f"UNKNOWN({response.result_code})"
+            raise HomeAssistantError(
+                f"Narwal setting command failed: {result_name}"
+            )
+
+        if response is not None:
+            attr = "fan" if key == "suction" else "water"
+            value = (
+                LEGACY_SUCTION_MAP[option]
+                if key == "suction"
+                else LEGACY_WATER_MAP[option]
+            )
+            self.coordinator.set_active_clean_setting(attr, value)
+
+        if not has_selected_rooms:
+            self._apply_option(option)
+        self.async_write_ha_state()
+        self.coordinator.async_update_listeners()

--- a/custom_components/narwal/services.yaml
+++ b/custom_components/narwal/services.yaml
@@ -1,0 +1,68 @@
+clean_rooms:
+  name: Clean rooms
+  description: Start a room clean using Narwal's local clean/start_clean command.
+  target:
+    entity:
+      integration: narwal
+      domain: vacuum
+  fields:
+    rooms:
+      name: Rooms
+      description: Narwal room IDs to clean, in order, or "all" for all current map rooms.
+      required: true
+      selector:
+        object:
+    mode:
+      name: Mode
+      default: vacuum_and_mop
+      selector:
+        select:
+          options:
+            - vacuum
+            - mop
+            - vacuum_then_mop
+            - vacuum_and_mop
+    suction:
+      name: Suction
+      default: standard
+      selector:
+        select:
+          options:
+            - ai
+            - quiet
+            - standard
+            - strong
+            - super
+            - ultra
+    water:
+      name: Water
+      default: normal
+      selector:
+        select:
+          options:
+            - dry
+            - normal
+            - wet
+    mop_strength:
+      name: Mop strength
+      default: normal
+      selector:
+        select:
+          options:
+            - normal
+            - high
+    passes:
+      name: Passes
+      default: 1
+      selector:
+        number:
+          min: 1
+          max: 3
+          mode: box
+    route:
+      name: Route
+      selector:
+        select:
+          options:
+            - standard
+            - meticulous

--- a/custom_components/narwal/switch.py
+++ b/custom_components/narwal/switch.py
@@ -1,4 +1,4 @@
-"""Switch entities for Narwal dock tasks and map display options."""
+"""Switch entities for Narwal dock tasks, room selection, and map display options."""
 
 from __future__ import annotations
 
@@ -7,9 +7,10 @@ from dataclasses import dataclass
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import slugify
 
 from . import NarwalConfigEntry
 from .const import (
@@ -18,7 +19,7 @@ from .const import (
     CONF_SHOW_ROOM_LABELS,
     MAP_OPTION_DEFAULTS,
 )
-from .coordinator import NarwalCoordinator
+from .coordinator import NarwalCoordinator, can_edit_pending_clean_settings
 from .dock_tasks import (
     DOCK_TASKS,
     can_start_dock_task,
@@ -81,6 +82,49 @@ async def async_setup_entry(
 ) -> None:
     """Set up Narwal switch entities."""
     coordinator = entry.runtime_data
+    known_room_selections: dict[tuple[str | None, int], NarwalRoomSelectionSwitch] = {}
+
+    @callback
+    def async_add_room_selection_entities() -> None:
+        map_data = coordinator.client.state.map_data
+        if map_data is None:
+            return
+        map_id = coordinator.room_settings_map_id(map_data)
+        entities: list[NarwalRoomSelectionSwitch] = []
+        current_room_ids: set[int] = set()
+        for room in sorted(map_data.rooms, key=lambda item: item.display_name.lower()):
+            if room.room_id <= 0:
+                continue
+            current_room_ids.add(room.room_id)
+            key = (map_id, room.room_id)
+            if key in known_room_selections:
+                known_room_selections[key].async_update_room_name(room.display_name)
+                continue
+            entity = NarwalRoomSelectionSwitch(
+                coordinator,
+                room.room_id,
+                room.display_name,
+                map_id=map_id,
+            )
+            known_room_selections[key] = entity
+            entities.append(entity)
+        for room_id in sorted(
+            coordinator.selected_clean_rooms.get(map_id, set()) - current_room_ids
+        ):
+            key = (map_id, room_id)
+            if key in known_room_selections:
+                continue
+            entity = NarwalRoomSelectionSwitch(
+                coordinator,
+                room_id,
+                f"Room {room_id}",
+                map_id=map_id,
+            )
+            known_room_selections[key] = entity
+            entities.append(entity)
+        if entities:
+            async_add_entities(entities)
+
     async_add_entities(
         NarwalDockTaskSwitch(coordinator, description)
         for description in DOCK_TASK_SWITCHES
@@ -89,6 +133,8 @@ async def async_setup_entry(
         NarwalMapOptionSwitch(coordinator, description)
         for description in MAP_SWITCHES
     )
+    async_add_room_selection_entities()
+    entry.async_on_unload(coordinator.async_add_listener(async_add_room_selection_entities))
 
 
 def _format_duration(seconds: int) -> str:
@@ -220,6 +266,117 @@ class NarwalDockTaskSwitch(NarwalDockEntity, SwitchEntity):
         raise HomeAssistantError(
             f"Narwal {action} {self.entity_description.key} failed: {result_name}"
         )
+
+
+class NarwalRoomSelectionSwitch(NarwalEntity, SwitchEntity):
+    """Room inclusion switch for the next native vacuum start command."""
+
+    _attr_icon = "mdi:floor-plan"
+
+    def __init__(
+        self,
+        coordinator: NarwalCoordinator,
+        room_id: int,
+        room_name: str,
+        *,
+        map_id: str | None = None,
+    ) -> None:
+        """Initialize a room selection switch."""
+        super().__init__(coordinator)
+        self._map_id = map_id
+        self._room_id = room_id
+        self._room_name = room_name
+        device_id = coordinator.config_entry.data["device_id"]
+        map_prefix = f"map_{slugify(map_id)}_" if map_id is not None else ""
+        self._attr_unique_id = f"{device_id}_{map_prefix}room_{room_id}_selected"
+        self._attr_suggested_object_id = (
+            f"{slugify(coordinator.config_entry.title)}_room_{slugify(room_name)}"
+        )
+        self._attr_name = f"{room_name} selected"
+
+    @callback
+    def async_update_room_name(self, room_name: str) -> None:
+        """Update display metadata when the map renames this room."""
+        if room_name == self._room_name:
+            return
+        self._room_name = room_name
+        self._attr_name = f"{room_name} selected"
+        self._attr_suggested_object_id = (
+            f"{slugify(self.coordinator.config_entry.title)}_room_{slugify(room_name)}"
+        )
+        if getattr(self, "hass", None) is not None:
+            self.async_write_ha_state()
+
+    @property
+    def is_on(self) -> bool:
+        """Return whether this room is selected for the next vacuum start."""
+        return self.coordinator.is_room_selected_for_clean(
+            self._room_id,
+            map_id=self._map_id,
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True when next-clean room selection can be changed."""
+        return (
+            can_edit_pending_clean_settings(self.coordinator.data)
+            and (self._room_exists or (self._is_current_map and self.is_on))
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | int]:
+        """Return room metadata for dashboards and automations."""
+        return {
+            "room_id": self._room_id,
+            "room_name": self._room_name,
+            "map_id": self._map_id or "",
+        }
+
+    @property
+    def _room_exists(self) -> bool:
+        """Return True when the room still exists in the current map."""
+        state = self.coordinator.data
+        map_data = getattr(state, "map_data", None) if state is not None else None
+        if not self._is_current_map:
+            return False
+        rooms = getattr(map_data, "rooms", None)
+        if not isinstance(rooms, (list, tuple)):
+            return True
+        return any(room.room_id == self._room_id for room in rooms)
+
+    @property
+    def _is_current_map(self) -> bool:
+        """Return True when this switch belongs to the currently loaded map."""
+        state = self.coordinator.data
+        map_data = getattr(state, "map_data", None) if state is not None else None
+        return (
+            map_data is not None
+            and self.coordinator.room_settings_map_id(map_data) == self._map_id
+        )
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Select this room for the next native vacuum start."""
+        if not self.available or not self._room_exists:
+            raise HomeAssistantError("Narwal room selection cannot be changed right now")
+        self.coordinator.set_room_selected_for_clean(
+            self._room_id,
+            True,
+            map_id=self._map_id,
+        )
+        self.async_write_ha_state()
+        self.coordinator.async_update_listeners()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Remove this room from the next native vacuum start."""
+        if not self.available:
+            raise HomeAssistantError("Narwal room selection cannot be changed right now")
+        self.coordinator.set_room_selected_for_clean(
+            self._room_id,
+            False,
+            map_id=self._map_id,
+        )
+        self.async_write_ha_state()
+        self.coordinator.async_update_listeners()
 
 
 class NarwalMapOptionSwitch(NarwalEntity, SwitchEntity):

--- a/custom_components/narwal/vacuum.py
+++ b/custom_components/narwal/vacuum.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.components.vacuum import (
@@ -18,19 +19,30 @@ except ImportError:
     Segment = None  # HA < 2026.3 — room cleaning unavailable
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 
 from . import NarwalConfigEntry
-from .const import FAN_SPEED_LIST, FAN_SPEED_MAP, fan_speed_list_for
-from .coordinator import NarwalCoordinator
+from .const import (
+    FAN_SPEED_LIST,
+    FAN_SPEED_MAP,
+    fan_speed_list_for,
+    normalize_fan_level_for_model,
+)
+from .coordinator import (
+    NarwalCoordinator,
+    can_edit_pending_clean_settings,
+    clean_setting_applies_to_mode,
+    has_blocking_error,
+    is_clean_session_context,
+    is_live_clean_setting_available,
+)
 from .dock_tasks import (
     can_start_robot_clean,
     can_stop_dock_task,
     has_active_dock_work,
-    is_clean_session_context,
 )
 from .entity import NarwalEntity
-from .narwal_client import CommandResult, WorkingStatus
+from .narwal_client import CommandResult, FanLevel, WorkingStatus
 from .narwal_client.const import ACTIVE_CLEANING_STATUSES
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,6 +50,18 @@ _LOGGER = logging.getLogger(__name__)
 # working_status values already reported as unmapped. Activity is recomputed on
 # every state broadcast, so warn once per distinct value instead of flooding.
 _WARNED_UNMAPPED_ACTIVITY: set[int] = set()
+
+
+@dataclass(frozen=True)
+class FanSettingRestoreData(ExtraStoredData):
+    """Persist pending suction by its stable robot value."""
+
+    value: int
+    version: int = 1
+
+    def as_dict(self) -> dict[str, int]:
+        """Return a JSON-serializable representation."""
+        return {"version": self.version, "value": self.value}
 
 WORKING_STATUS_TO_ACTIVITY: dict[WorkingStatus, VacuumActivity] = {
     WorkingStatus.DOCKED: VacuumActivity.DOCKED,
@@ -47,6 +71,7 @@ WORKING_STATUS_TO_ACTIVITY: dict[WorkingStatus, VacuumActivity] = {
     WorkingStatus.CLEANING_V2: VacuumActivity.CLEANING,
     WorkingStatus.CLEANING: VacuumActivity.CLEANING,
     WorkingStatus.CLEANING_ALT: VacuumActivity.CLEANING,
+    WorkingStatus.CUSTOM_CLEANING: VacuumActivity.CLEANING,
     # Mapping/exploration is active robot work.
     WorkingStatus.REMAPPING: VacuumActivity.CLEANING,
     WorkingStatus.TASK_COMPLETED: VacuumActivity.RETURNING,
@@ -66,6 +91,15 @@ def _result_name(result_code: int | CommandResult) -> str:
 
 # FanLevel value -> fan_speed label. FAN_SPEED_MAP also holds back-compat aliases.
 _FAN_LABELS: dict[int, str] = {int(FAN_SPEED_MAP[label]): label for label in FAN_SPEED_LIST}
+
+
+def _raise_if_command_failed(response: Any, action: str) -> None:
+    """Raise a Home Assistant service error for rejected robot commands."""
+    if response.accepted:
+        return
+    raise HomeAssistantError(
+        f"Narwal {action} failed: {_result_name(response.result_code)}"
+    )
 
 
 async def async_setup_entry(
@@ -97,6 +131,25 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         """Hide robot actions while dock work makes them unsafe or ambiguous."""
         features = self._BASE_SUPPORTED_FEATURES
         state = self.coordinator.data
+        setup_fan = (
+            can_edit_pending_clean_settings(state)
+            and not self.coordinator.has_selected_clean_rooms()
+            and clean_setting_applies_to_mode(
+                "fan", self.coordinator.clean_settings.work_mode
+            )
+        )
+        live_fan = False
+        if is_live_clean_setting_available(state):
+            live_mode = self.coordinator.clean_setting_applicability_mode(live=True)
+            live_fan = live_mode is not None and clean_setting_applies_to_mode(
+                "fan", live_mode
+            )
+        if not setup_fan and not live_fan:
+            features &= ~VacuumEntityFeature.FAN_SPEED
+        if not getattr(self.coordinator, "_room_profile_store_loaded", True):
+            features &= ~VacuumEntityFeature.CLEAN_AREA
+            if not (state and state.is_paused and is_clean_session_context(state)):
+                features &= ~VacuumEntityFeature.START
         if not has_active_dock_work(state):
             return features
         features &= ~(
@@ -121,8 +174,37 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         """Restore the pending fan speed into clean_settings (persists across restarts)."""
         await super().async_added_to_hass()
         last = await self.async_get_last_state()
-        if last is not None and (fan := last.attributes.get("fan_speed")) in FAN_SPEED_MAP:
-            self.coordinator.clean_settings.fan = FAN_SPEED_MAP[fan]
+        extra = await self.async_get_last_extra_data()
+        if extra is not None:
+            data = extra.as_dict()
+            raw_value = data.get("value")
+            values = {int(value): value for value in FanLevel}
+            if (
+                data.get("version") == 1
+                and isinstance(raw_value, int)
+                and not isinstance(raw_value, bool)
+                and raw_value in values
+            ):
+                self.coordinator.clean_settings.fan = normalize_fan_level_for_model(
+                    self.coordinator.config_entry.data,
+                    values[raw_value],
+                )
+                return
+        if last is None or "fan_speed" not in last.attributes:
+            return
+        fan = last.attributes.get("fan_speed")
+        if fan is None:
+            self.coordinator.clean_settings.fan = FanLevel.UNSPECIFIED
+        elif fan in FAN_SPEED_MAP:
+            self.coordinator.clean_settings.fan = normalize_fan_level_for_model(
+                self.coordinator.config_entry.data,
+                FAN_SPEED_MAP[fan],
+            )
+
+    @property
+    def extra_restore_state_data(self) -> ExtraStoredData:
+        """Return pending suction independently of its displayed active value."""
+        return FanSettingRestoreData(value=int(self.coordinator.clean_settings.fan))
 
     @property
     def activity(self) -> VacuumActivity:
@@ -173,7 +255,10 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         pending value held in coordinator.clean_settings (applied at the next clean
         and, while cleaning, written live via set_fan_speed).
         """
-        return _FAN_LABELS.get(int(self.coordinator.clean_settings.fan))
+        fan = self.coordinator.active_clean_setting("fan")
+        if fan is None:
+            fan = self.coordinator.clean_settings.fan
+        return _FAN_LABELS.get(int(fan))
 
     # Timeout for action commands (start/stop/return) — robot may need
     # time to load map, plan route, etc., especially after waking.
@@ -202,38 +287,62 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         """Start or resume cleaning."""
         await self._ensure_awake()
         state = self.coordinator.data
-        # is_paused stays stale after docking — only trust it during cleaning
-        is_cleaning = state and state.working_status in ACTIVE_CLEANING_STATUSES
-        if is_cleaning and state.is_paused:
-            await self.coordinator.client.resume(timeout=self._ACTION_TIMEOUT)
+        if (
+            state
+            and not has_blocking_error(state)
+            and state.working_status != WorkingStatus.TASK_COMPLETED
+            and state.is_paused
+            and is_clean_session_context(state)
+        ):
+            response = await self.coordinator.client.resume(
+                timeout=self._ACTION_TIMEOUT
+            )
+            _raise_if_command_failed(response, "resume")
             return
+        if getattr(self.coordinator, "_room_profile_store_loaded", True) is False:
+            raise HomeAssistantError("Narwal room profiles are not restored yet")
         room_ids: list[int] = []
         async with self.coordinator.dock_action_lock:
             await self._validate_clean_start()
 
-            # Whole-house clean enumerates every room via clean/start_clean, matching the
-            # app's allRoomIds() path. clean/plan/start (StartWithPlan) would instead re-run
-            # the saved current plan — i.e. the last room selection — not the whole house.
-            room_ids = await self._all_room_ids()
-            if room_ids:
-                settings = self.coordinator.clean_settings
-                resp = await self.coordinator.client.start_rooms(
-                    room_ids,
-                    work_mode=settings.work_mode,
-                    fan=settings.fan,
-                    water=settings.water,
-                    mop_strength=settings.mop_strength,
-                    passes=settings.passes,
-                )
-            else:
-                # No map rooms known — best-effort fall back to the saved-plan start.
-                resp = await self.coordinator.client.start()
+            # The HA vacuum start command uses integration-owned room selections:
+            # selected rooms when any are on, otherwise all rooms.
+            all_room_ids = await self._all_room_ids()
+            if not all_room_ids:
+                raise HomeAssistantError("Narwal room map is not available")
+            map_id = self.coordinator.room_settings_map_id(
+                self.coordinator.client.state.map_data
+            )
+            if map_id is None and self.coordinator.selected_clean_rooms:
+                raise HomeAssistantError("Narwal room selection is not available")
+            room_ids = self.coordinator.selected_clean_room_ids_for(
+                all_room_ids,
+                map_id=map_id,
+            )
+            if not room_ids:
+                raise HomeAssistantError("Narwal room selection is not available")
+            settings = self.coordinator.clean_settings
+            room_settings = self.coordinator.room_clean_settings_for_rooms(
+                room_ids,
+                map_id=map_id,
+            )
+            resp = await self.coordinator.client.start_rooms(
+                room_ids,
+                work_mode=settings.work_mode,
+                fan=settings.fan,
+                water=settings.water,
+                mop_strength=settings.mop_strength,
+                passes=settings.passes,
+                route=settings.route,
+                room_settings=room_settings,
+            )
             if resp.accepted:
+                self.coordinator.record_accepted_clean_start(room_settings)
                 self.coordinator.client.state.assume_robot_clean()
                 self.coordinator.async_set_updated_data(self.coordinator.client.state)
         _LOGGER.info(
-            "Whole-house start: code=%s, success=%s, rooms=%s",
-            resp.result_code, resp.success, room_ids or "(saved plan)",
+            "Room-aware start: code=%s, success=%s, rooms=%s",
+            resp.result_code, resp.success, room_ids,
         )
         if not resp.accepted:
             _LOGGER.warning(
@@ -244,27 +353,18 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
             raise HomeAssistantError(
                 f"Narwal start command failed: {_result_name(resp.result_code)}"
             )
+        self.async_write_ha_state()
 
     async def _all_room_ids(self) -> list[int]:
-        """Every cleanable room id for a whole-house clean; fetches the map if not cached."""
-        state = self.coordinator.data
-        if state is None or state.map_data is None:
-            try:
-                await self.coordinator.client.get_map()
-            except Exception:  # noqa: BLE001 — best-effort prefetch; fall through to fallback
-                _LOGGER.debug("get_map for whole-house clean failed")
-            state = self.coordinator.data
+        """Return room ids from an authoritative static map."""
+        try:
+            await self.coordinator.client.get_map()
+        except Exception as err:
+            raise HomeAssistantError("Narwal map could not be refreshed") from err
+        state = self.coordinator.client.state
         if state and state.map_data:
             return [r.room_id for r in state.map_data.rooms if r.room_id > 0]
-        # Map still unavailable — reuse the HA segment cache (Segment.id == str(room_id)).
-        cached = getattr(self, "last_seen_segments", None) or []
-        ids: list[int] = []
-        for seg in cached:
-            try:
-                ids.append(int(seg.id))
-            except (ValueError, AttributeError, TypeError):
-                continue
-        return ids
+        return []
 
     async def async_stop(self, **kwargs) -> None:
         """Stop cleaning."""
@@ -338,17 +438,49 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
     async def async_set_fan_speed(self, fan_speed: str, **kwargs) -> None:
         """Set the fan speed.
 
-        Stores it as the pending suction for the next clean; if the robot is
-        currently cleaning, also writes it live via set_fan_speed.
+        Stores it as whole-floor pending suction when no rooms are selected;
+        while cleaning, it also writes the active task live.
         """
         level = FAN_SPEED_MAP.get(fan_speed)
         if level is None:
             return
-        self.coordinator.clean_settings.fan = level
-        self.async_write_ha_state()
         state = self.coordinator.data
-        if state is not None and state.is_cleaning:
-            await self.coordinator.client.set_fan_speed(level)
+        has_selected_rooms = self.coordinator.has_selected_clean_rooms()
+        setup_available = (
+            can_edit_pending_clean_settings(state)
+            and not has_selected_rooms
+        )
+        live_available = super().available and is_live_clean_setting_available(state)
+        setup_applies = clean_setting_applies_to_mode(
+            "fan",
+            self.coordinator.clean_settings.work_mode,
+        )
+        live_mode = self.coordinator.clean_setting_applicability_mode(live=True)
+        live_applies = (
+            live_mode is not None
+            and clean_setting_applies_to_mode("fan", live_mode)
+        )
+        if not (
+            (setup_available and setup_applies)
+            or (live_available and live_applies)
+        ):
+            if not setup_applies and not live_applies:
+                raise HomeAssistantError(
+                    "Narwal fan speed is not available in mop-only mode"
+                )
+            raise HomeAssistantError("Narwal fan speed cannot be changed right now")
+        if live_available and not live_applies:
+            raise HomeAssistantError(
+                "Narwal fan speed is not available in mop-only mode"
+            )
+        if live_available:
+            resp = await self.coordinator.client.set_fan_speed(level)
+            _raise_if_command_failed(resp, "set fan speed")
+            self.coordinator.set_active_clean_setting("fan", level)
+        if not has_selected_rooms:
+            self.coordinator.clean_settings.fan = level
+        self.async_write_ha_state()
+        self.coordinator.async_update_listeners()
 
     # --- Segment API (HA 2026.3 room-specific cleaning) ---
 
@@ -387,38 +519,48 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         Converts string segment IDs back to integer room IDs and sends
         a room-specific clean command to the robot.
         """
+        if getattr(self.coordinator, "_room_profile_store_loaded", True) is False:
+            raise HomeAssistantError("Narwal room profiles are not restored yet")
         await self._ensure_awake()
         try:
-            room_ids = [int(sid) for sid in segment_ids]
+            room_ids = list(dict.fromkeys(int(sid) for sid in segment_ids))
         except (TypeError, ValueError) as err:
             raise HomeAssistantError("Narwal segment IDs must be numeric") from err
+        if not room_ids:
+            raise HomeAssistantError("Narwal segment IDs must not be empty")
+        if any(room_id <= 0 for room_id in room_ids):
+            raise HomeAssistantError("Narwal segment IDs must be positive")
 
         async with self.coordinator.dock_action_lock:
             await self._validate_clean_start()
             try:
                 await self.coordinator.client.get_map()
-            except Exception:
-                _LOGGER.debug("Could not refresh Narwal map before segment clean")
+            except Exception as err:
+                raise HomeAssistantError(
+                    "Narwal map could not be refreshed"
+                ) from err
             state = self.coordinator.client.state
-            known_room_ids = {
+            known_ids = {
                 room.room_id
                 for room in getattr(getattr(state, "map_data", None), "rooms", ())
                 if room.room_id > 0
             }
-            if known_room_ids:
-                unknown_room_ids = [
-                    room_id for room_id in room_ids if room_id not in known_room_ids
-                ]
-                if unknown_room_ids:
-                    raise HomeAssistantError(
-                        f"Unknown Narwal room ID: {', '.join(map(str, unknown_room_ids))}"
-                    )
+            if not known_ids:
+                raise HomeAssistantError("Narwal map is not available")
+            unknown_ids = [room_id for room_id in room_ids if room_id not in known_ids]
+            if unknown_ids:
+                raise HomeAssistantError(
+                    "Unknown Narwal room ID: "
+                    f"{', '.join(str(room_id) for room_id in unknown_ids)}"
+                )
             settings = self.coordinator.clean_settings
+            room_settings = self.coordinator.room_clean_settings_for_rooms(room_ids)
             _LOGGER.info(
                 "Starting room-specific clean: rooms=%s mode=%s fan=%s water=%s "
-                "mop_strength=%s passes=%s",
+                "mop_strength=%s passes=%s route=%s",
                 room_ids, settings.work_mode.name, settings.fan.name,
                 settings.water.name, settings.mop_strength.name, settings.passes,
+                settings.route.name,
             )
             resp = await self.coordinator.client.start_rooms(
                 room_ids,
@@ -427,8 +569,11 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
                 water=settings.water,
                 mop_strength=settings.mop_strength,
                 passes=settings.passes,
+                route=settings.route,
+                room_settings=room_settings,
             )
             if resp.accepted:
+                self.coordinator.record_accepted_clean_start(room_settings)
                 self.coordinator.client.state.assume_robot_clean()
                 self.coordinator.async_set_updated_data(self.coordinator.client.state)
         result_name = _result_name(resp.result_code)
@@ -447,6 +592,7 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
             raise HomeAssistantError(
                 f"Narwal room clean failed: {result_name}"
             )
+        self.async_write_ha_state()
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/narwal_client/__init__.py
+++ b/narwal_client/__init__.py
@@ -1,14 +1,20 @@
 """Narwal robot vacuum client library — local WebSocket API."""
 
-from .client import NarwalClient, NarwalCommandError, NarwalConnectionError
+from .client import (
+    NarwalClient,
+    NarwalCommandError,
+    NarwalConnectionError,
+    RoomCleanSettings,
+)
 from .const import (
     AmbientLightCtrlType,
+    CleaningRoute,
     CommandResult,
     FanLevel,
     MopHumidity,
     MopStrengthLevel,
-    WorkMode,
     WorkingStatus,
+    WorkMode,
 )
 from .models import CommandResponse, DeviceInfo, MapData, MapDisplayData, NarwalState, RoomInfo
 from .protocol import build_frame, parse_frame
@@ -17,9 +23,11 @@ __all__ = [
     "NarwalClient",
     "NarwalCommandError",
     "NarwalConnectionError",
+    "RoomCleanSettings",
     "NarwalState",
     "CommandResponse",
     "CommandResult",
+    "CleaningRoute",
     "DeviceInfo",
     "AmbientLightCtrlType",
     "FanLevel",

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -7,7 +7,8 @@ import contextlib
 import logging
 import random
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from typing import Any
 
 import websockets
@@ -46,7 +47,6 @@ from .const import (
     TOPIC_CMD_GET_MAP,
     TOPIC_CMD_NOTIFY_APP_EVENT,
     TOPIC_CMD_PAUSE,
-    TOPIC_CMD_PLAN_START,
     TOPIC_CMD_RECALL,
     TOPIC_CMD_RESUME,
     TOPIC_CMD_SET_FAN_LEVEL,
@@ -58,6 +58,7 @@ from .const import (
     TOPIC_CMD_YELL,
     WAKE_TIMEOUT,
     AmbientLightCtrlType,
+    CleaningRoute,
     CommandResult,
     FanLevel,
     MopHumidity,
@@ -149,6 +150,18 @@ def _can_force_end_scoped_dock_task(state: NarwalState, task: str | None) -> boo
 def _has_generic_dock_stop_proof(state: NarwalState) -> bool:
     """Return true when generic force-end can only target dock-side work."""
     return state.is_docked and state.has_dock_presence_signal
+
+
+@dataclass
+class RoomCleanSettings:
+    """Clean parameters for a single room in a custom clean task."""
+
+    work_mode: WorkMode = WorkMode.VACUUM_AND_MOP
+    fan: FanLevel = FanLevel.NORMAL
+    water: MopHumidity = MopHumidity.NORMAL
+    mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL
+    passes: int = 1
+    route: CleaningRoute | None = None
 
 
 def _base_status_working_status(decoded: dict[str, Any] | object) -> WorkingStatus | None:
@@ -1181,16 +1194,6 @@ class NarwalClient:
         """Trigger locate sound — robot says 'Robot is here'."""
         return await self.send_command(TOPIC_CMD_YELL)
 
-    # Legacy clean task payload — the minimal CleanTask the app sent on Flow
-    # firmware < v01.07.22. Only used by the saved-plan fallback below, which
-    # goes to clean/plan/start — a topic that discards payloads entirely (#66),
-    # so these bytes are effectively a no-op marker on current firmware.
-    # Structure: {1: {2: {}, 5: {1: {1: 3, 2: 2, 3: 1}, 5: {}}}}
-    #   field 5.1.1 = suction level (3=max)
-    #   field 5.1.2 = mop humidity (2=wet)
-    #   field 5.1.3 = passes (1=single)
-    _DEFAULT_CLEAN_PAYLOAD = bytes.fromhex("0a0e12002a0a0a060803100218012a00")
-
     async def _all_room_ids(self) -> list[int]:
         """Every cleanable room id on the active map, fetching the map if needed."""
         map_data = self.state.map_data
@@ -1204,34 +1207,6 @@ class NarwalClient:
             return []
         return [r.room_id for r in map_data.rooms if r.room_id > 0]
 
-    async def _start_saved_plan(self) -> CommandResponse:
-        """Last-resort start: re-run the plan stored on the robot.
-
-        clean/plan/start is StartWithPlan{planId, mapId} — it ignores the
-        payload and re-runs whatever plan the robot already holds, which is
-        usually the last room selection rather than the whole house. Only
-        reachable when no map rooms are known.
-        """
-        _LOGGER.warning(
-            "start(): no map rooms available; falling back to clean/plan/start, "
-            "which re-runs the robot's saved plan rather than cleaning every room"
-        )
-        async with self._robot_start_lock:
-            if _robot_start_blocked(self.state):
-                _LOGGER.warning(
-                    "start(): robot or dock guard active (%s); not starting saved plan",
-                    self.state.active_dock_task_keys or "private",
-                )
-                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
-            response = await self.send_command(
-                TOPIC_CMD_PLAN_START,
-                payload=self._DEFAULT_CLEAN_PAYLOAD,
-                timeout=10.0,
-            )
-            if _accepted_response(response):
-                self.state.assume_robot_clean()
-            return response
-
     async def start(
         self,
         *,
@@ -1240,18 +1215,16 @@ class NarwalClient:
         water: MopHumidity = MopHumidity.NORMAL,
         mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL,
         passes: int = 1,
+        route: CleaningRoute | None = None,
     ) -> CommandResponse:
         """Start a whole-house clean.
 
         Enumerates every room on the active map and issues clean/start_clean,
         matching the app's allRoomIds() path.
 
-        The old implementation sent a minimal payload to clean/plan/start and
-        returned as soon as the result was anything but NOT_APPLICABLE. Newer
-        firmware answers SUCCESS there and does nothing, so the caller saw a
-        successful start that never happened (#69). clean/plan/start is a
-        plan-runner that discards payloads (#66), so it survives only as a
-        last-resort fallback when no map rooms are known.
+        The old implementation sent a minimal payload to clean/plan/start.
+        Newer firmware answers SUCCESS there and does nothing, so this path
+        fails clearly when no room list is available instead (#69).
         """
         if _robot_start_blocked(self.state):
             _LOGGER.warning(
@@ -1259,9 +1232,12 @@ class NarwalClient:
                 self.state.active_dock_task_keys or "unmapped",
             )
             return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        if not self.connected:
+            raise NarwalConnectionError("Not connected to vacuum")
         room_ids = await self._all_room_ids()
         if not room_ids:
-            return await self._start_saved_plan()
+            _LOGGER.warning("start(): no map rooms available")
+            return CommandResponse(result_code=CommandResult.NOT_READY)
         _LOGGER.info("start(): whole-house clean over %d rooms", len(room_ids))
         return await self.start_rooms(
             room_ids,
@@ -1270,6 +1246,7 @@ class NarwalClient:
             water=water,
             mop_strength=mop_strength,
             passes=passes,
+            route=route,
         )
 
     def _build_clean_payload_v2(
@@ -1306,7 +1283,7 @@ class NarwalClient:
             clean_mode: v2 schema cleanMode (3 observed for sweep+mop).
 
         Returns:
-            Encoded protobuf bytes for clean/plan/start.
+            Encoded protobuf bytes for clean/start_clean.
         """
         import blackboxprotobuf
 
@@ -1379,6 +1356,36 @@ class NarwalClient:
         WorkMode.VACUUM_THEN_MOP: (5, ("5", "6")),  # sweep + mop pass counts
         WorkMode.VACUUM_AND_MOP: (4, ("7",)),      # sweepMopSyncTime
     }
+    # The app uses taskType 6 for a custom task whose CleanItems carry the
+    # effective mode independently.  Captured in upstream issue #36 and
+    # runtime-validated on Flow firmware v01.07.23.00.
+    _CUSTOM_CLEAN_TASK_TYPE = 6
+
+    def _clean_param_for_settings(self, settings: RoomCleanSettings) -> dict[str, int]:
+        """Return a CleanParam protobuf dict for one room."""
+        param_mode, pass_tags = self._WORK_MODE_PARAM[settings.work_mode]
+        param: dict[str, int] = {
+            "1": int(param_mode),
+            "2": int(settings.fan),
+            "3": int(settings.mop_strength),
+            "4": int(settings.water),
+        }
+        if settings.route is not None:
+            param["8"] = int(settings.route)
+        for tag in pass_tags:
+            param[tag] = int(settings.passes)
+        return param
+
+    @classmethod
+    def _task_type_for_settings(
+        cls,
+        room_settings: list[RoomCleanSettings],
+    ) -> int:
+        """Return the outer CleanTask type for a room-clean payload."""
+        modes = {settings.work_mode for settings in room_settings}
+        if len(modes) == 1:
+            return int(next(iter(modes)))
+        return cls._CUSTOM_CLEAN_TASK_TYPE
 
     def _build_start_clean_payload(
         self,
@@ -1390,13 +1397,16 @@ class NarwalClient:
         water: MopHumidity = MopHumidity.NORMAL,
         mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL,
         passes: int = 1,
+        route: CleaningRoute | None = None,
+        room_settings: Mapping[int, RoomCleanSettings] | None = None,
     ) -> bytes:
         """Build a clean/start_clean request for the given rooms.
 
         StartClean_Request{1: CleanTask{1: map_id, 2: [CleanItem...], 3: {} (TaskOption),
         5: taskType}}; CleanItem{1: ZoneOption{1: 1 (room zone), 2: room_id}, 2: CleanParam,
-        3: order}. taskType (the execution-mode carrier) and CleanParam.mode/pass-tag are
-        derived from work_mode. overlapLevel is omitted — live-validated as ignored here.
+        3: order}. Uniform tasks use the WorkMode as taskType. Mixed-mode tasks use
+        the app's custom taskType (6), with each CleanParam carrying its own mode.
+        overlapLevel is CleanParam tag 8 when supplied.
 
         Args:
             room_ids: Robot room IDs (RoomInfo.room_id).
@@ -1406,28 +1416,42 @@ class NarwalClient:
             water: Mop water volume (tag 4).
             mop_strength: Mop scrub intensity (tag 3).
             passes: Clean count, routed to the pass tag(s) for the mode.
+            route: Optional route overlap level (tag 8).
+            room_settings: Optional per-room settings keyed by robot room ID.
         """
         import blackboxprotobuf
 
-        param_mode, pass_tags = self._WORK_MODE_PARAM[work_mode]
-        param: dict[str, int] = {
-            "1": int(param_mode),
-            "2": int(fan),
-            "3": int(mop_strength),
-            "4": int(water),
-        }
-        for tag in pass_tags:
-            param[tag] = int(passes)
+        default_settings = RoomCleanSettings(
+            work_mode=work_mode,
+            fan=fan,
+            water=water,
+            mop_strength=mop_strength,
+            passes=passes,
+            route=route,
+        )
+        settings_by_room = (
+            {rid: room_settings.get(rid, default_settings) for rid in room_ids}
+            if room_settings
+            else {rid: default_settings for rid in room_ids}
+        )
+        task_type = self._task_type_for_settings(
+            list(settings_by_room.values()),
+        )
+        param_keys: set[str] = set()
+        params_by_room: dict[int, dict[str, int]] = {}
+        for rid, settings in settings_by_room.items():
+            params_by_room[rid] = self._clean_param_for_settings(settings)
+            param_keys.update(params_by_room[rid])
 
         items = [
-            {"1": {"1": 1, "2": rid}, "2": dict(param), "3": idx + 1}
+            {"1": {"1": 1, "2": rid}, "2": params_by_room[rid], "3": idx + 1}
             for idx, rid in enumerate(room_ids)
         ]
         task = {
             "1": map_id,
             "2": items if len(items) > 1 else items[0],
             "3": {},
-            "5": int(work_mode),  # CleanTask.taskType
+            "5": int(task_type),  # CleanTask.taskType
         }
         item_typedef = {
             "type": "message",
@@ -1439,7 +1463,7 @@ class NarwalClient:
                 # Derive the CleanParam typedef from the emitted dict — bbpb silently
                 # drops any tag absent from the typedef.
                 "2": {"type": "message", "message_typedef": {
-                    k: {"type": "int"} for k in param
+                    k: {"type": "int"} for k in sorted(param_keys, key=int)
                 }},
                 "3": {"type": "int"},
             },
@@ -1461,6 +1485,8 @@ class NarwalClient:
         water: MopHumidity = MopHumidity.NORMAL,
         mop_strength: MopStrengthLevel = MopStrengthLevel.NORMAL,
         passes: int = 1,
+        route: CleaningRoute | None = None,
+        room_settings: Mapping[int, RoomCleanSettings] | None = None,
     ) -> CommandResponse:
         """Start cleaning the given rooms via clean/start_clean.
 
@@ -1476,13 +1502,12 @@ class NarwalClient:
 
         Args:
             room_ids: Robot room IDs (RoomInfo.room_id), mapped from HA areas.
-            work_mode, fan, water, mop_strength, passes: CleanParam settings —
+            work_mode, fan, water, mop_strength, passes, route: CleanParam settings —
                 see _build_start_clean_payload.
+            room_settings: Optional per-room settings keyed by robot room ID.
         """
         if not room_ids:
-            # No rooms selected — do not call start(), which would resolve the
-            # full room list and come straight back here.
-            return await self._start_saved_plan()
+            return CommandResponse(result_code=CommandResult.NOT_READY)
         async with self._robot_start_lock:
             if _robot_start_blocked(self.state):
                 _LOGGER.warning(
@@ -1501,10 +1526,21 @@ class NarwalClient:
                 )
                 return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
 
-            payload = self._build_start_clean_payload(
-                room_ids, map_id, work_mode=work_mode, fan=fan, water=water,
-                mop_strength=mop_strength, passes=passes,
-            )
+            try:
+                payload = self._build_start_clean_payload(
+                    room_ids,
+                    map_id,
+                    work_mode=work_mode,
+                    fan=fan,
+                    water=water,
+                    mop_strength=mop_strength,
+                    passes=passes,
+                    route=route,
+                    room_settings=room_settings,
+                )
+            except ValueError as err:
+                _LOGGER.warning("start_rooms: %s", err)
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
             resp = await self.send_command(
                 TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
             )
@@ -1863,7 +1899,13 @@ class NarwalClient:
     async def get_map(self) -> MapData:
         """Download the full map data."""
         resp = await self.send_command(TOPIC_CMD_GET_MAP, timeout=15.0)
+        if not resp.accepted:
+            raise NarwalCommandError(
+                f"get_map failed with code {resp.result_code}"
+            )
         map_data = MapData.from_response(resp.data)
+        if not map_data.map_id:
+            raise NarwalCommandError("get_map response did not contain an active map")
         self.state.map_data = map_data
         return map_data
 

--- a/narwal_client/const.py
+++ b/narwal_client/const.py
@@ -188,6 +188,7 @@ class WorkingStatus(IntEnum):
            active — developer/take_picture is accepted in this state)
       10 = DOCKED (on dock, charging)
       14 = CHARGED (on dock, fully charged)
+      17 = CUSTOM_CLEANING (custom per-room clean; live-validated on Flow 2)
       19 = TASK_COMPLETED (transitional: scheduled task finished, returning to base)
 
     Field 3 sub-fields (confirmed live):
@@ -209,10 +210,11 @@ class WorkingStatus(IntEnum):
     # revisit if a capture shows 3 means something else (e.g. a self-test state).
     CLEANING_V2 = 3   # active cleaning on newer Flow 2 firmware
     CLEANING = 4      # active cleaning (stays 4 even while returning to dock)
-    CLEANING_ALT = 5  # cleaning — observed when robot was physically stuck; may indicate error/stuck state
+    CLEANING_ALT = 5  # cleaning - seen when stuck; may indicate error/stuck state
     REMAPPING = 7     # mapping/exploration (live 2026-07-09); camera active, take_picture accepted
     DOCKED = 10       # on dock (does NOT reliably indicate charging vs charged)
     CHARGED = 14      # on dock (reported before 100% — use battery_level for charge state)
+    CUSTOM_CLEANING = 17  # active custom per-room clean on Flow 2
     TASK_COMPLETED = 19  # transitional: task finished, robot returning to base (#41)
     # PLACEHOLDER: error state value not yet observed live.
     # Trigger a real error (e.g., pick up robot mid-clean) to discover the value.
@@ -224,13 +226,18 @@ ACTIVE_CLEANING_STATUSES = frozenset(
         WorkingStatus.CLEANING_V2,
         WorkingStatus.CLEANING,
         WorkingStatus.CLEANING_ALT,
+        WorkingStatus.CUSTOM_CLEANING,
         WorkingStatus.REMAPPING,
     }
 )
 
 
 class FanLevel(IntEnum):
-    """CleanParam suction level (CleanTask.pbenum FanLevel). Live clean/set_fan_level carries a SweepFanLevel instead — identical ints 0-4, but it has no SUPER, so the app maps SUPER->STRONG on that path."""
+    """CleanParam suction level.
+
+    Live clean/set_fan_level carries a SweepFanLevel instead: identical ints
+    0-4, but it has no SUPER, so the app maps SUPER->STRONG on that path.
+    """
 
     UNSPECIFIED = 0
     MUTE = 1
@@ -241,7 +248,7 @@ class FanLevel(IntEnum):
 
 
 class MopHumidity(IntEnum):
-    """Water volume. CleanParam tag 4 and the live clean/set_mop_humidity command share these ints."""
+    """Water volume shared by CleanParam tag 4 and live set_mop_humidity."""
 
     UNSPECIFIED = 0
     DRY = 1
@@ -257,8 +264,19 @@ class MopStrengthLevel(IntEnum):
     HIGH = 2
 
 
+class CleaningRoute(IntEnum):
+    """Cleaning route overlap level (CleanParam tag 8)."""
+
+    STANDARD = 1
+    METICULOUS = 2
+
+
 class WorkMode(IntEnum):
-    """Clean work mode — the app's robot_work_mode_* selector (Vacuum / Mop / Vacuum then mop / Vacuum and mop). Its value IS the CleanTask.taskType the robot executes; the per-item CleanParam.mode (the proto's own CleanMode enum) is derived separately in client._WORK_MODE_PARAM."""
+    """Clean work mode selected by the app's robot_work_mode_* setting.
+
+    Uniform jobs also use this value as CleanTask.taskType. Custom mixed-mode
+    jobs use taskType 6 while each item's CleanParam.mode carries its work mode.
+    """
 
     VACUUM = 1
     MOP = 2

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -753,6 +753,19 @@ class NarwalState:
         )
 
     @property
+    def has_paused_clean_task_context(self) -> bool:
+        """True when a paused overlay still has retained robot clean details."""
+        if not self.is_paused or self.is_docked:
+            return False
+        return (
+            getattr(self, "task_progress_percent", None) is not None
+            or getattr(self, "task_elapsed_time", self.cleaning_time) > 0
+            or getattr(self, "task_remaining_time", 0) > 0
+            or self.current_room_id is not None
+            or bool(getattr(self, "current_room_aux_name", ""))
+        )
+
+    @property
     def is_cleaning(self) -> bool:
         """True when actively cleaning (not paused, not returning to dock)."""
         if self.has_recent_active_working_status:
@@ -1113,7 +1126,8 @@ class NarwalState:
             except (ValueError, TypeError):
                 pass
         if active_payload:
-            self.working_status = WorkingStatus.CLEANING
+            if self.working_status != WorkingStatus.CUSTOM_CLEANING:
+                self.working_status = WorkingStatus.CLEANING
             self.last_active_working_status_time = time.monotonic()
             self.clear_assumed_robot_clean()
             self.is_paused = False

--- a/tests/ha_stubs.py
+++ b/tests/ha_stubs.py
@@ -137,6 +137,25 @@ def install() -> None:
 
     ha_uc.CoordinatorEntity = _CoordinatorEntity  # type: ignore[attr-defined]
 
+    ha_storage = _mod("homeassistant.helpers.storage", ha_helpers)
+
+    class _Store:
+        """Stub for Home Assistant Store helper."""
+
+        def __init__(self, hass: object, version: int, key: str) -> None:
+            self.hass = hass
+            self.version = version
+            self.key = key
+            self.data: object | None = None
+
+        async def async_load(self) -> object | None:
+            return self.data
+
+        async def async_save(self, data: object) -> None:
+            self.data = data
+
+    ha_storage.Store = _Store  # type: ignore[attr-defined]
+
     ha_dr = _mod("homeassistant.helpers.device_registry", ha_helpers)
     ha_dr.DeviceInfo = dict  # type: ignore[attr-defined]
 

--- a/tests/ha_stubs.py
+++ b/tests/ha_stubs.py
@@ -36,13 +36,25 @@ def install() -> None:
     vol.Required = MagicMock(side_effect=lambda *a, **kw: a[0] if a else "key")  # type: ignore[attr-defined]
     vol.Optional = MagicMock(side_effect=lambda *a, **kw: a[0] if a else "key")  # type: ignore[attr-defined]
     vol.In = MagicMock()  # type: ignore[attr-defined]
+    vol.Invalid = type("Invalid", (Exception,), {})  # type: ignore[attr-defined]
 
     # --- homeassistant ---
     ha = _mod("homeassistant")
 
+    ha_auth = _mod("homeassistant.auth", ha)
+    ha_auth_permissions = _mod("homeassistant.auth.permissions", ha_auth)
+    ha_auth_permissions_const = _mod(
+        "homeassistant.auth.permissions.const",
+        ha_auth_permissions,
+    )
+    ha_auth_permissions_const.POLICY_CONTROL = "control"  # type: ignore[attr-defined]
+
     # homeassistant.const
     ha_const = _mod("homeassistant.const", ha)
     ha_const.Platform = MagicMock()  # type: ignore[attr-defined]
+    ha_const.ATTR_AREA_ID = "area_id"  # type: ignore[attr-defined]
+    ha_const.ATTR_DEVICE_ID = "device_id"  # type: ignore[attr-defined]
+    ha_const.ATTR_ENTITY_ID = "entity_id"  # type: ignore[attr-defined]
     ha_const.PERCENTAGE = "%"  # type: ignore[attr-defined]
     ha_const.STATE_ON = "on"  # type: ignore[attr-defined]
     ha_const.UnitOfArea = MagicMock()  # type: ignore[attr-defined]
@@ -57,7 +69,12 @@ def install() -> None:
     # homeassistant.core
     ha_core = _mod("homeassistant.core", ha)
     ha_core.HomeAssistant = MagicMock  # type: ignore[attr-defined]
+    ha_core.ServiceCall = MagicMock  # type: ignore[attr-defined]
+    ha_core.State = MagicMock  # type: ignore[attr-defined]
     ha_core.callback = lambda f: f  # type: ignore[attr-defined]
+
+    ha_util = _mod("homeassistant.util", ha)
+    ha_util.slugify = lambda value: str(value).lower().replace(" ", "_")  # type: ignore[attr-defined]
 
     # homeassistant.exceptions
     ha_exc = _mod("homeassistant.exceptions", ha)
@@ -65,6 +82,8 @@ def install() -> None:
     ha_exc.HomeAssistantError = type(  # type: ignore[attr-defined]
         "HomeAssistantError", (Exception,), {}
     )
+    ha_exc.Unauthorized = type("Unauthorized", (Exception,), {})  # type: ignore[attr-defined]
+    ha_exc.UnknownUser = type("UnknownUser", (Exception,), {})  # type: ignore[attr-defined]
 
     # homeassistant.config_entries
     ha_ce = _mod("homeassistant.config_entries", ha)
@@ -98,6 +117,10 @@ def install() -> None:
 
     # homeassistant.helpers (and sub-modules)
     ha_helpers = _mod("homeassistant.helpers", ha)
+    ha_cv = _mod("homeassistant.helpers.config_validation", ha_helpers)
+    ha_cv.comp_entity_ids = MagicMock()  # type: ignore[attr-defined]
+    ha_cv.entity_ids = MagicMock()  # type: ignore[attr-defined]
+    ha_cv.ensure_list = MagicMock()  # type: ignore[attr-defined]
 
     # NOTE: deliberately does NOT expose EntityCategory. Real HA removed
     # homeassistant.helpers.entity.EntityCategory; it lives in homeassistant.const.
@@ -159,6 +182,12 @@ def install() -> None:
     ha_dr = _mod("homeassistant.helpers.device_registry", ha_helpers)
     ha_dr.DeviceInfo = dict  # type: ignore[attr-defined]
 
+    ha_er = _mod("homeassistant.helpers.entity_registry", ha_helpers)
+    ha_er.async_get = MagicMock()  # type: ignore[attr-defined]
+
+    ha_service = _mod("homeassistant.helpers.service", ha_helpers)
+    ha_service.async_extract_entity_ids = MagicMock()  # type: ignore[attr-defined]
+
     ha_ep = _mod("homeassistant.helpers.entity_platform", ha_helpers)
     ha_ep.AddConfigEntryEntitiesCallback = MagicMock  # type: ignore[attr-defined]
 
@@ -189,6 +218,12 @@ def install() -> None:
 
     ha_rs = _mod("homeassistant.helpers.restore_state", ha_helpers)
 
+    class _ExtraStoredData:
+        """Stub for ExtraStoredData."""
+
+        def as_dict(self) -> dict[str, object]:
+            raise NotImplementedError
+
     class _RestoreEntity:
         """Stub for RestoreEntity."""
 
@@ -198,6 +233,10 @@ def install() -> None:
         async def async_get_last_state(self) -> None:
             return None
 
+        async def async_get_last_extra_data(self) -> None:
+            return None
+
+    ha_rs.ExtraStoredData = _ExtraStoredData  # type: ignore[attr-defined]
     ha_rs.RestoreEntity = _RestoreEntity  # type: ignore[attr-defined]
 
     # homeassistant.components.*
@@ -227,8 +266,11 @@ def install() -> None:
     ha_diag.REDACTED = REDACTED  # type: ignore[attr-defined]
 
     ha_vac = _mod("homeassistant.components.vacuum", ha_comp)
+    ha_vac.DOMAIN = "vacuum"  # type: ignore[attr-defined]
+
     class _Segment:
         """Stub for homeassistant.components.vacuum.Segment."""
+
         def __init__(self, *, id: str, name: str, group: str | None = None) -> None:
             self.id = id
             self.name = name

--- a/tests/test_clean_settings_entities.py
+++ b/tests/test_clean_settings_entities.py
@@ -9,33 +9,166 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 import tests.ha_stubs  # noqa: E402
 
 tests.ha_stubs.install()
 
 from homeassistant.components.select import SelectEntity  # noqa: E402
+from homeassistant.exceptions import HomeAssistantError  # noqa: E402
 from homeassistant.helpers.restore_state import RestoreEntity  # noqa: E402
 
-from narwal_client.const import MopHumidity, MopStrengthLevel, WorkMode  # noqa: E402
-from custom_components.narwal.coordinator import CleanSettings  # noqa: E402
+from custom_components.narwal.coordinator import (  # noqa: E402
+    CleanSettings,
+    can_edit_pending_clean_settings,
+)
 from custom_components.narwal.number import NarwalPassesNumber  # noqa: E402
-from custom_components.narwal.select import NarwalSelect, SELECT_DESCRIPTIONS  # noqa: E402
+from custom_components.narwal.select import (  # noqa: E402
+    LEGACY_SELECT_DESCRIPTIONS,
+    ROOM_SELECT_DESCRIPTIONS,
+    SELECT_DESCRIPTIONS,
+    LegacyNarwalSettingSelect,
+    NarwalSelect,
+    RoomNarwalSettingSelect,
+    RoomSettingRestoreData,
+    SettingRestoreData,
+    async_setup_entry,
+)
+from narwal_client import NarwalState, RoomCleanSettings  # noqa: E402
+from narwal_client.const import (  # noqa: E402
+    CleaningRoute,
+    CommandResult,
+    FanLevel,
+    MopHumidity,
+    MopStrengthLevel,
+    WorkingStatus,
+    WorkMode,
+)
+from narwal_client.models import (  # noqa: E402
+    DOCK_TASK_DRY_DOCK_BAG,
+    CommandResponse,  # noqa: E402
+    MapData,
+    RoomInfo,
+)
 
 _DESCS = {d.key: d for d in SELECT_DESCRIPTIONS}
+_LEGACY_DESCS = {d.setting_key: d for d in LEGACY_SELECT_DESCRIPTIONS}
+_ROOM_DESCS = {d.setting_key: d for d in ROOM_SELECT_DESCRIPTIONS}
 
 
-def _coordinator(*, settings: CleanSettings | None = None, state: object | None = None) -> MagicMock:
+def _coordinator(
+    *,
+    settings: CleanSettings | None = None,
+    state: object | None = None,
+    product_key: str = "QoEsI5qYXO",
+) -> MagicMock:
     coord = MagicMock()
     coord.config_entry = MagicMock()
-    coord.config_entry.data = {"device_id": "dev1"}
+    coord.config_entry.data = {"device_id": "dev1", "product_key": product_key}
     coord.config_entry.title = "Narwal Test"
     coord.client = MagicMock()
     coord.client.state = MagicMock()
     coord.client.state.firmware_version = "1.0.0"
     coord.last_update_success = True
     coord.clean_settings = settings or CleanSettings()
+    coord.room_clean_settings = {}
+    coord.room_clean_settings_customized = {}
+    coord.active_clean_work_mode = None
+    coord.has_selected_clean_rooms.return_value = False
+    coord.active_clean_setting.return_value = None
     coord.data = state
+    coord._legacy_mode_option = "Vacuum and mop"
+
+    def room_settings_map_id(map_data=None) -> str | None:
+        if map_data is None:
+            map_data = getattr(coord.data, "map_data", None) if coord.data else None
+        map_id = getattr(map_data, "map_id", None)
+        if map_id in (None, "", 0, "0"):
+            return None
+        return str(map_id)
+
+    def room_clean_settings_for(
+        room_id: int,
+        *,
+        map_id: str | None = None,
+    ) -> RoomCleanSettings:
+        key = (map_id if map_id is not None else room_settings_map_id(), room_id)
+        if key not in coord.room_clean_settings:
+            coord.room_clean_settings[key] = RoomCleanSettings(
+                work_mode=coord.clean_settings.work_mode,
+                fan=coord.clean_settings.fan,
+                water=coord.clean_settings.water,
+                mop_strength=coord.clean_settings.mop_strength,
+                passes=coord.clean_settings.passes,
+                route=coord.clean_settings.route,
+            )
+        return coord.room_clean_settings[key]
+
+    def effective_room_clean_settings_for(
+        room_id: int,
+        *,
+        map_id: str | None = None,
+    ) -> RoomCleanSettings:
+        key = (map_id if map_id is not None else room_settings_map_id(), room_id)
+        fallback = RoomCleanSettings(
+            work_mode=coord.clean_settings.work_mode,
+            fan=coord.clean_settings.fan,
+            water=coord.clean_settings.water,
+            mop_strength=coord.clean_settings.mop_strength,
+            passes=coord.clean_settings.passes,
+            route=coord.clean_settings.route,
+        )
+        profile = coord.room_clean_settings.get(key)
+        for attr in coord.room_clean_settings_customized.get(key, set()):
+            setattr(fallback, attr, getattr(profile, attr))
+        return fallback
+
+    def set_room_clean_setting(
+        room_id: int,
+        attr: str,
+        value,
+        *,
+        map_id: str | None = None,
+    ) -> None:
+        key = (map_id if map_id is not None else room_settings_map_id(), room_id)
+        setattr(room_clean_settings_for(room_id, map_id=map_id), attr, value)
+        coord.room_clean_settings_customized.setdefault(key, set()).add(attr)
+
+    coord.room_settings_map_id.side_effect = room_settings_map_id
+    coord.room_clean_settings_for.side_effect = room_clean_settings_for
+    coord.effective_room_clean_settings_for.side_effect = effective_room_clean_settings_for
+    coord.set_room_clean_setting.side_effect = set_room_clean_setting
+    def clean_setting_applicability_mode(*, live: bool = False) -> WorkMode | None:
+        if not live:
+            return coord.clean_settings.work_mode
+        if (
+            getattr(coord.data, "is_cleaning", False) is True
+            or getattr(coord.data, "has_recent_active_working_status", False) is True
+            or getattr(coord.data, "has_paused_clean_task_context", False) is True
+        ):
+            return coord.active_clean_work_mode
+        return coord.clean_settings.work_mode
+
+    coord.clean_setting_applicability_mode.side_effect = clean_setting_applicability_mode
     return coord
+
+
+def _state(
+    working_status: WorkingStatus = WorkingStatus.DOCKED,
+    *,
+    recent: bool = False,
+    returning: bool = False,
+) -> MagicMock:
+    state = MagicMock()
+    state.working_status = working_status
+    state.has_recent_active_working_status = recent
+    state.is_returning = returning
+    state.is_cleaning = working_status == WorkingStatus.CLEANING and not returning
+    state.is_charging_to_resume = False
+    state.is_station_active = False
+    state.map_data = None
+    return state
 
 
 def test_select_bases_use_restore_entity() -> None:
@@ -51,19 +184,188 @@ class TestNarwalSelect:
         assert sel.current_option == "mop"
 
     async def test_select_option_stores_value(self) -> None:
-        coord = _coordinator()
+        coord = _coordinator(state=_state())
+        coord.async_update_listeners = MagicMock()
         sel = NarwalSelect(coord, _DESCS["mop_strength"])
         await sel.async_select_option("high")
         assert coord.clean_settings.mop_strength == MopStrengthLevel.HIGH
         assert sel.current_option == "high"
+        coord.async_update_listeners.assert_called_once()
+
+    async def test_select_option_stores_pending_value_when_entity_unavailable(self) -> None:
+        coord = _coordinator(state=_state())
+        coord.last_update_success = False
+        sel = NarwalSelect(coord, _DESCS["mop_strength"])
+
+        await sel.async_select_option("high")
+
+        assert coord.clean_settings.mop_strength == MopStrengthLevel.HIGH
+
+    async def test_extra_restore_data_survives_unavailable_entity_state(self) -> None:
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        sel = NarwalSelect(coord, _DESCS["work_mode"])
+        extra = SettingRestoreData(value=int(WorkMode.MOP))
+
+        with (
+            patch.object(
+                sel, "async_get_last_extra_data", AsyncMock(return_value=extra)
+            ),
+            patch.object(
+                sel,
+                "async_get_last_state",
+                AsyncMock(return_value=MagicMock(state="unavailable")),
+            ) as get_last_state,
+        ):
+            await sel.async_added_to_hass()
+
+        get_last_state.assert_not_awaited()
+        assert coord.clean_settings.work_mode == WorkMode.MOP
+
+    def test_extra_restore_data_records_stable_robot_value(self) -> None:
+        coord = _coordinator(settings=CleanSettings(water=MopHumidity.WET))
+        sel = NarwalSelect(coord, _DESCS["water"])
+
+        assert sel.extra_restore_state_data.as_dict() == {
+            "version": 1,
+            "value": int(MopHumidity.WET),
+        }
 
     async def test_water_applies_live_while_cleaning(self) -> None:
         coord = _coordinator(state=MagicMock(is_cleaning=True))
-        coord.client.set_mop_humidity = AsyncMock()
+        coord.active_clean_work_mode = WorkMode.VACUUM_AND_MOP
+        coord.client.set_mop_humidity = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
         sel = NarwalSelect(coord, _DESCS["water"])
         await sel.async_select_option("wet")
         assert coord.clean_settings.water == MopHumidity.WET
         coord.client.set_mop_humidity.assert_awaited_once_with(MopHumidity.WET)
+        coord.set_active_clean_setting.assert_called_once_with(
+            "water", MopHumidity.WET
+        )
+
+    def test_whole_floor_settings_hide_when_rooms_are_selected(self) -> None:
+        """An explicit room selection leaves only room-level setup controls."""
+        coord = _coordinator(state=_state())
+        coord.has_selected_clean_rooms.return_value = True
+
+        assert not NarwalSelect(coord, _DESCS["work_mode"]).available
+        assert not LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["mode"]).available
+        assert not NarwalPassesNumber(coord).available
+
+    def test_live_controls_report_active_room_values(self) -> None:
+        """Runtime suction and water reflect the dispatched room profile."""
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        coord.has_selected_clean_rooms.return_value = True
+        coord.active_clean_work_mode = WorkMode.VACUUM_AND_MOP
+        coord.active_clean_setting.side_effect = lambda attr: {
+            "fan": FanLevel.STRONG,
+            "water": MopHumidity.WET,
+        }.get(attr)
+
+        suction = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"])
+        water = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["water"])
+
+        assert suction.available
+        assert suction.current_option == "Strong"
+        assert water.available
+        assert water.current_option == "Wet"
+
+    async def test_water_accepts_live_accepted_response(self) -> None:
+        coord = _coordinator(state=MagicMock(is_cleaning=True))
+        coord.active_clean_work_mode = WorkMode.VACUUM_AND_MOP
+        coord.client.set_mop_humidity = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+        sel = NarwalSelect(coord, _DESCS["water"])
+
+        await sel.async_select_option("wet")
+
+        assert coord.clean_settings.water == MopHumidity.WET
+        coord.client.set_mop_humidity.assert_awaited_once_with(MopHumidity.WET)
+
+    async def test_live_water_uses_active_room_mode(self) -> None:
+        """Live water gating follows the accepted room mode, not pending globals."""
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        coord.clean_settings.work_mode = WorkMode.VACUUM
+        coord.active_clean_work_mode = WorkMode.MOP
+        coord.client.set_mop_humidity = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+        sel = NarwalSelect(coord, _DESCS["water"])
+
+        await sel.async_select_option("wet")
+
+        assert coord.clean_settings.water == MopHumidity.WET
+        coord.set_active_clean_setting.assert_called_once_with(
+            "water", MopHumidity.WET
+        )
+        coord.client.set_mop_humidity.assert_awaited_once_with(MopHumidity.WET)
+
+    async def test_live_water_rejects_active_vacuum_mode(self) -> None:
+        """Pending mop mode must not expose water for an active vacuum-only task."""
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        coord.clean_settings.work_mode = WorkMode.MOP
+        coord.active_clean_work_mode = WorkMode.VACUUM
+        coord.client.set_mop_humidity = AsyncMock()
+        sel = NarwalSelect(coord, _DESCS["water"])
+
+        with pytest.raises(HomeAssistantError, match="changed right now|selected mode"):
+            await sel.async_select_option("wet")
+
+        coord.client.set_mop_humidity.assert_not_awaited()
+
+    async def test_live_water_hides_unknown_active_mode(self) -> None:
+        """A reload cannot expose water before the accepted task mode is known."""
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        coord.clean_settings.work_mode = WorkMode.MOP
+        coord.active_clean_work_mode = None
+        coord.client.set_mop_humidity = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+        sel = NarwalSelect(coord, _DESCS["water"])
+
+        assert not sel.available
+        with pytest.raises(HomeAssistantError, match="changed right now|selected mode"):
+            await sel.async_select_option("wet")
+
+        coord.client.set_mop_humidity.assert_not_awaited()
+
+    async def test_water_applies_live_while_paused(self) -> None:
+        state = _state(WorkingStatus.CLEANING)
+        state.is_paused = True
+        state.is_cleaning = False
+        coord = _coordinator(state=state)
+        coord.client.set_mop_humidity = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        sel = NarwalSelect(coord, _DESCS["water"])
+        await sel.async_select_option("wet")
+
+        assert coord.clean_settings.water == MopHumidity.WET
+        coord.set_active_clean_setting.assert_called_once_with(
+            "water", MopHumidity.WET
+        )
+        coord.client.set_mop_humidity.assert_awaited_once_with(MopHumidity.WET)
+
+    async def test_rejected_live_water_change_does_not_update_settings(self) -> None:
+        coord = _coordinator(state=MagicMock(is_cleaning=True))
+        coord.active_clean_work_mode = WorkMode.VACUUM_AND_MOP
+        coord.clean_settings.water = MopHumidity.NORMAL
+        coord.client.set_mop_humidity = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        )
+        sel = NarwalSelect(coord, _DESCS["water"])
+
+        try:
+            await sel.async_select_option("wet")
+        except HomeAssistantError:
+            pass
+        else:
+            raise AssertionError("Rejected live water change should raise")
+
+        assert coord.clean_settings.water == MopHumidity.NORMAL
 
     async def test_no_live_setter_when_not_cleaning(self) -> None:
         coord = _coordinator(state=MagicMock(is_cleaning=False))
@@ -74,17 +376,567 @@ class TestNarwalSelect:
 
     async def test_restore_from_last_state(self) -> None:
         coord = _coordinator()
+        coord.async_update_listeners = MagicMock()
         sel = NarwalSelect(coord, _DESCS["work_mode"])
-        with patch.object(sel, "async_get_last_state", AsyncMock(return_value=MagicMock(state="mop"))):
+        with patch.object(
+            sel, "async_get_last_state", AsyncMock(return_value=MagicMock(state="mop"))
+        ):
             await sel.async_added_to_hass()
         assert coord.clean_settings.work_mode == WorkMode.MOP
+        coord.async_update_listeners.assert_called_once()
 
     async def test_restore_ignores_unknown_option(self) -> None:
         coord = _coordinator(settings=CleanSettings(work_mode=WorkMode.VACUUM))
         sel = NarwalSelect(coord, _DESCS["work_mode"])
-        with patch.object(sel, "async_get_last_state", AsyncMock(return_value=MagicMock(state="bogus"))):
+        with patch.object(
+            sel, "async_get_last_state", AsyncMock(return_value=MagicMock(state="bogus"))
+        ):
             await sel.async_added_to_hass()
         assert coord.clean_settings.work_mode == WorkMode.VACUUM
+
+    def test_start_only_selects_unavailable_during_active_clean(self) -> None:
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        coord.active_clean_work_mode = WorkMode.VACUUM_AND_MOP
+        assert not NarwalSelect(coord, _DESCS["work_mode"]).available
+        assert not NarwalSelect(coord, _DESCS["mop_strength"]).available
+        assert NarwalSelect(coord, _DESCS["water"]).available
+
+    def test_pending_settings_available_during_compatible_dock_bag_drying(self) -> None:
+        state = NarwalState(working_status=WorkingStatus.DOCKED)
+        state.dock_presence = 1
+        state.dock_field11 = 2
+        state.dock_field47 = 3
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=45,
+            target=180,
+            fields=("12", "13"),
+        )
+        coord = _coordinator(state=state)
+
+        assert state.is_station_active
+        assert can_edit_pending_clean_settings(state)
+        assert NarwalSelect(coord, _DESCS["work_mode"]).available
+
+    def test_primary_settings_unavailable_when_not_applicable_to_mode(self) -> None:
+        coord = _coordinator(state=_state())
+        coord.clean_settings.work_mode = WorkMode.VACUUM
+
+        assert not NarwalSelect(coord, _DESCS["water"]).available
+        assert not NarwalSelect(coord, _DESCS["mop_strength"]).available
+
+    async def test_primary_setting_rejects_option_when_not_applicable_to_mode(self) -> None:
+        coord = _coordinator(state=_state())
+        coord.clean_settings.work_mode = WorkMode.VACUUM
+        coord.client.set_mop_humidity = AsyncMock()
+        sel = NarwalSelect(coord, _DESCS["water"])
+
+        with pytest.raises(HomeAssistantError, match="selected mode"):
+            await sel.async_select_option("wet")
+
+        coord.client.set_mop_humidity.assert_not_awaited()
+
+
+class TestLegacyNarwalSettingSelect:
+    def test_start_only_settings_unavailable_during_active_clean(self) -> None:
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        for key in ("mode", "passes", "scrub"):
+            assert not LegacyNarwalSettingSelect(coord, _LEGACY_DESCS[key]).available
+
+    def test_live_settings_remain_available_during_active_clean(self) -> None:
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        coord.active_clean_work_mode = WorkMode.VACUUM_AND_MOP
+        assert LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"]).available
+        assert LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["water"]).available
+
+    def test_suction_options_stay_stable_while_cleaning(self) -> None:
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"])
+        assert "AI" in sel.options
+        assert "Standard" in sel.options
+
+    def test_ax26_legacy_suction_omits_ultra(self) -> None:
+        coord = _coordinator(product_key="qV6BujoYLz")
+        sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"])
+
+        assert "Super Powerful" in sel.options
+        assert sel._normalise_option("Super") == "Super Powerful"
+        assert "Ultra" not in sel.options
+        assert sel._normalise_option("Ultra powerful") is None
+
+    async def test_ai_suction_rejected_while_cleaning(self) -> None:
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        coord.client.set_fan_speed = AsyncMock()
+        sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"])
+        try:
+            await sel.async_select_option("AI")
+        except HomeAssistantError:
+            pass
+        else:
+            raise AssertionError("AI suction should not be selectable mid-clean")
+        coord.client.set_fan_speed.assert_not_awaited()
+
+    def test_route_is_available_when_idle(self) -> None:
+        coord = _coordinator(state=_state())
+        assert LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["route"]).available
+
+    def test_route_is_unavailable_during_active_clean(self) -> None:
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        assert not LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["route"]).available
+
+    def test_mode_specific_settings_unavailable_when_not_applicable(self) -> None:
+        coord = _coordinator(state=_state())
+        coord.clean_settings.work_mode = WorkMode.VACUUM
+        assert not LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["water"]).available
+        assert not LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["scrub"]).available
+
+        coord.clean_settings.work_mode = WorkMode.MOP
+        assert not LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"]).available
+
+    async def test_legacy_live_water_uses_active_room_mode(self) -> None:
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        coord.clean_settings.work_mode = WorkMode.VACUUM
+        coord.active_clean_work_mode = WorkMode.MOP
+        coord.client.set_mop_humidity = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+        sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["water"])
+
+        await sel.async_select_option("Wet")
+
+        assert coord.clean_settings.water == MopHumidity.WET
+        coord.set_active_clean_setting.assert_called_once_with(
+            "water", MopHumidity.WET
+        )
+        coord.client.set_mop_humidity.assert_awaited_once_with(MopHumidity.WET)
+
+    async def test_legacy_live_suction_rejects_active_mop_mode(self) -> None:
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        coord.clean_settings.work_mode = WorkMode.VACUUM
+        coord.active_clean_work_mode = WorkMode.MOP
+        coord.client.set_fan_speed = AsyncMock()
+        sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"])
+
+        with pytest.raises(HomeAssistantError, match="changed right now|mop-only"):
+            await sel.async_select_option("Strong")
+
+        coord.client.set_fan_speed.assert_not_awaited()
+
+    async def test_legacy_live_suction_hides_unknown_active_mode(self) -> None:
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        coord.clean_settings.work_mode = WorkMode.VACUUM
+        coord.active_clean_work_mode = None
+        coord.client.set_fan_speed = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+        sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"])
+
+        assert not sel.available
+        with pytest.raises(HomeAssistantError, match="changed right now|mop-only"):
+            await sel.async_select_option("Strong")
+
+        coord.client.set_fan_speed.assert_not_awaited()
+
+    def test_legacy_settings_are_config_entities(self) -> None:
+        coord = _coordinator(state=_state())
+        select = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["route"])
+
+        assert select._attr_entity_category == "config"
+
+    async def test_restore_does_not_overwrite_primary_settings(self) -> None:
+        coord = _coordinator(
+            settings=CleanSettings(
+                work_mode=WorkMode.MOP,
+                fan=FanLevel.STRONG,
+                water=MopHumidity.WET,
+                mop_strength=MopStrengthLevel.HIGH,
+                passes=3,
+            )
+        )
+        sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["mode"])
+        with patch.object(
+            sel,
+            "async_get_last_state",
+            AsyncMock(return_value=MagicMock(state="Vacuum")),
+        ):
+            await sel.async_added_to_hass()
+
+        assert coord.clean_settings.work_mode == WorkMode.MOP
+        assert sel.current_option == "Mop"
+
+    async def test_route_restore_stores_legacy_only_setting(self) -> None:
+        coord = _coordinator(settings=CleanSettings(route=CleaningRoute.METICULOUS))
+        sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["route"])
+        with patch.object(
+            sel,
+            "async_get_last_state",
+            AsyncMock(return_value=MagicMock(state="Standard")),
+        ):
+            await sel.async_added_to_hass()
+
+        assert coord.clean_settings.route == CleaningRoute.STANDARD
+        assert sel.current_option == "Standard"
+
+    async def test_ai_suction_restore_stores_legacy_only_setting(self) -> None:
+        coord = _coordinator(settings=CleanSettings(fan=FanLevel.NORMAL))
+        sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"])
+        with patch.object(
+            sel,
+            "async_get_last_state",
+            AsyncMock(return_value=MagicMock(state="AI")),
+        ):
+            await sel.async_added_to_hass()
+
+        assert coord.clean_settings.fan == FanLevel.UNSPECIFIED
+        assert sel.current_option == "AI"
+
+    async def test_suction_extra_restore_uses_stable_robot_value(self) -> None:
+        coord = _coordinator(settings=CleanSettings(fan=FanLevel.NORMAL))
+        sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"])
+        extra = SettingRestoreData(value=int(FanLevel.SUPER))
+
+        with (
+            patch.object(
+                sel, "async_get_last_extra_data", AsyncMock(return_value=extra)
+            ),
+            patch.object(
+                sel,
+                "async_get_last_state",
+                AsyncMock(return_value=MagicMock(state="unavailable")),
+            ) as get_last_state,
+        ):
+            await sel.async_added_to_hass()
+
+        get_last_state.assert_not_awaited()
+        assert coord.clean_settings.fan == FanLevel.SUPER
+
+    async def test_unversioned_suction_restore_keeps_v105_meaning(self) -> None:
+        coord = _coordinator(settings=CleanSettings(fan=FanLevel.NORMAL))
+        sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"])
+
+        with patch.object(
+            sel,
+            "async_get_last_state",
+            AsyncMock(return_value=MagicMock(state="Ultra")),
+        ):
+            await sel.async_added_to_hass()
+
+        assert coord.clean_settings.fan == FanLevel.SUPER
+
+    async def test_global_suction_restore_clamps_for_four_tier_model(self) -> None:
+        coord = _coordinator(
+            product_key="qV6BujoYLz",
+            settings=CleanSettings(fan=FanLevel.NORMAL),
+        )
+        sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"])
+        extra = SettingRestoreData(value=int(FanLevel.SUPER))
+
+        with patch.object(
+            sel, "async_get_last_extra_data", AsyncMock(return_value=extra)
+        ):
+            await sel.async_added_to_hass()
+
+        assert coord.clean_settings.fan == FanLevel.DEEP
+
+    async def test_select_option_refreshes_related_setting_entities(self) -> None:
+        coord = _coordinator(state=_state())
+        coord.async_update_listeners = MagicMock()
+        sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["mode"])
+        await sel.async_select_option("Vacuum")
+        coord.async_update_listeners.assert_called_once()
+
+    async def test_route_select_stores_clean_setting(self) -> None:
+        coord = _coordinator(state=_state())
+        sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["route"])
+        await sel.async_select_option("Standard")
+        assert coord.clean_settings.route == CleaningRoute.STANDARD
+
+    async def test_select_option_stores_pending_value_when_entity_unavailable(self) -> None:
+        coord = _coordinator(state=_state())
+        coord.last_update_success = False
+        sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["route"])
+
+        await sel.async_select_option("Standard")
+
+        assert coord.clean_settings.route == CleaningRoute.STANDARD
+
+
+class TestRoomNarwalSettingSelect:
+    def test_current_option_reflects_room_settings(self) -> None:
+        coord = _coordinator()
+        coord.room_clean_settings[(None, 4)] = RoomCleanSettings(
+            work_mode=WorkMode.MOP,
+            route=CleaningRoute.METICULOUS,
+        )
+        coord.room_clean_settings_customized[(None, 4)] = {"work_mode"}
+        assert (
+            RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["mode"]).current_option
+            == "Mop"
+        )
+
+    async def test_select_option_stores_room_setting(self) -> None:
+        coord = _coordinator(state=_state())
+        sel = RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["route"])
+        await sel.async_select_option("Standard")
+        assert coord.room_clean_settings[(None, 4)].route == CleaningRoute.STANDARD
+
+    async def test_failed_store_restore_blocks_room_profile_edits(self) -> None:
+        """An unread durable profile cannot be replaced by an entity edit."""
+        coord = _coordinator(state=_state())
+        coord._room_profile_store_loaded = False
+        sel = RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["route"])
+
+        assert not sel.available
+        with pytest.raises(HomeAssistantError, match="not restored"):
+            await sel.async_select_option("Standard")
+
+        assert coord.room_clean_settings == {}
+
+    async def test_select_option_stores_pending_value_when_entity_unavailable(self) -> None:
+        coord = _coordinator(state=_state())
+        coord.last_update_success = False
+        sel = RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["route"])
+
+        await sel.async_select_option("Standard")
+
+        assert coord.room_clean_settings[(None, 4)].route == CleaningRoute.STANDARD
+
+    async def test_select_passes_stores_room_setting(self) -> None:
+        coord = _coordinator(state=_state())
+        sel = RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["passes"])
+        await sel.async_select_option("3")
+        assert coord.room_clean_settings[(None, 4)].passes == 3
+
+    async def test_select_suction_stores_room_setting(self) -> None:
+        coord = _coordinator(state=_state())
+        sel = RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["suction"])
+        await sel.async_select_option("Strong")
+        assert coord.room_clean_settings[(None, 4)].fan == FanLevel.STRONG
+
+    async def test_added_without_restore_does_not_customize_room_defaults(self) -> None:
+        coord = _coordinator(state=_state())
+        sel = RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["route"])
+
+        with patch.object(sel, "async_get_last_state", AsyncMock(return_value=None)):
+            await sel.async_added_to_hass()
+
+        assert coord.room_clean_settings_customized == {}
+        coord.clean_settings.route = CleaningRoute.STANDARD
+        assert sel.current_option == "Standard"
+
+    async def test_restored_inherited_room_state_does_not_customize_room_defaults(
+        self,
+    ) -> None:
+        coord = _coordinator(state=_state())
+        sel = RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["route"])
+        restored = MagicMock(state="Meticulous", attributes={"customized": False})
+
+        with patch.object(sel, "async_get_last_state", AsyncMock(return_value=restored)):
+            await sel.async_added_to_hass()
+
+        assert coord.room_clean_settings_customized == {}
+        coord.clean_settings.route = CleaningRoute.STANDARD
+        assert sel.current_option == "Standard"
+
+    def test_inherited_room_state_follows_global_defaults(self) -> None:
+        coord = _coordinator(state=_state())
+        sel = RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["route"])
+
+        assert sel.current_option == "Meticulous"
+        coord.clean_settings.route = CleaningRoute.STANDARD
+
+        assert sel.current_option == "Standard"
+        assert coord.room_clean_settings_customized == {}
+
+    def test_customized_room_state_overrides_global_defaults(self) -> None:
+        coord = _coordinator(state=_state())
+        sel = RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["route"])
+
+        coord.set_room_clean_setting(4, "route", CleaningRoute.STANDARD)
+        coord.clean_settings.route = CleaningRoute.METICULOUS
+
+        assert sel.current_option == "Standard"
+        assert sel.extra_state_attributes["customized"] is True
+
+    async def test_restored_customized_room_state_is_applied(self) -> None:
+        coord = _coordinator(state=_state())
+        sel = RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["route"])
+        restored = MagicMock(state="Standard", attributes={"customized": True})
+
+        with patch.object(sel, "async_get_last_state", AsyncMock(return_value=restored)):
+            await sel.async_added_to_hass()
+
+        assert coord.room_clean_settings_customized == {(None, 4): {"route"}}
+        assert sel.current_option == "Standard"
+        assert sel.extra_state_attributes["customized"] is True
+        coord.async_update_listeners.assert_called_once_with()
+
+    async def test_coordinator_restore_wins_over_entity_restore_data(self) -> None:
+        """A disabled entity's old HA state cannot replace the durable profile."""
+        coord = _coordinator(state=_state())
+        coord.set_room_clean_setting(4, "route", CleaningRoute.STANDARD)
+        sel = RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["route"])
+        extra = RoomSettingRestoreData(
+            value=int(CleaningRoute.METICULOUS), customized=True
+        )
+
+        with patch.object(
+            sel, "async_get_last_extra_data", AsyncMock(return_value=extra)
+        ) as get_extra:
+            await sel.async_added_to_hass()
+
+        get_extra.assert_not_awaited()
+        assert sel.current_option == "Standard"
+
+    async def test_extra_restore_data_survives_unavailable_entity_state(self) -> None:
+        coord = _coordinator(state=_state())
+        sel = RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["route"])
+        extra = RoomSettingRestoreData(
+            value=int(CleaningRoute.STANDARD), customized=True
+        )
+
+        with (
+            patch.object(
+                sel, "async_get_last_extra_data", AsyncMock(return_value=extra)
+            ),
+            patch.object(
+                sel,
+                "async_get_last_state",
+                AsyncMock(return_value=MagicMock(state="unavailable")),
+            ) as get_last_state,
+        ):
+            await sel.async_added_to_hass()
+
+        get_last_state.assert_not_awaited()
+        assert coord.room_clean_settings_customized == {(None, 4): {"route"}}
+        assert sel.current_option == "Standard"
+        coord.async_update_listeners.assert_called_once_with()
+
+    def test_extra_restore_data_records_customized_room_setting(self) -> None:
+        coord = _coordinator(state=_state())
+        sel = RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["route"])
+        coord.set_room_clean_setting(4, "route", CleaningRoute.STANDARD)
+
+        assert sel.extra_restore_state_data.as_dict() == {
+            "version": 1,
+            "value": int(CleaningRoute.STANDARD),
+            "customized": True,
+        }
+
+    async def test_unversioned_room_suction_keeps_v105_meaning(self) -> None:
+        coord = _coordinator(state=_state())
+        sel = RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["suction"])
+        extra = MagicMock()
+        extra.as_dict.return_value = {"option": "Ultra", "customized": True}
+
+        with patch.object(
+            sel, "async_get_last_extra_data", AsyncMock(return_value=extra)
+        ):
+            await sel.async_added_to_hass()
+
+        assert coord.room_clean_settings[(None, 4)].fan == FanLevel.SUPER
+
+    async def test_unversioned_room_suction_clamps_for_four_tier_model(self) -> None:
+        coord = _coordinator(product_key="qV6BujoYLz", state=_state())
+        sel = RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["suction"])
+        extra = MagicMock()
+        extra.as_dict.return_value = {"option": "Ultra", "customized": True}
+
+        with patch.object(
+            sel, "async_get_last_extra_data", AsyncMock(return_value=extra)
+        ):
+            await sel.async_added_to_hass()
+
+        assert coord.room_clean_settings[(None, 4)].fan == FanLevel.DEEP
+
+    def test_mode_specific_settings_unavailable_when_not_applicable(self) -> None:
+        coord = _coordinator(state=_state())
+        coord.room_clean_settings[(None, 4)] = RoomCleanSettings(work_mode=WorkMode.VACUUM)
+        coord.room_clean_settings_customized[(None, 4)] = {"work_mode", "water"}
+        assert not RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["water"]).available
+        assert not RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["scrub"]).available
+
+        coord.room_clean_settings[(None, 4)].work_mode = WorkMode.MOP
+        coord.room_clean_settings_customized[(None, 4)].add("fan")
+        assert not RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["suction"]).available
+
+    def test_room_profile_entities_are_config_entities(self) -> None:
+        coord = _coordinator(state=_state())
+        select = RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["route"])
+
+        assert select._attr_entity_category == "config"
+
+    async def test_room_profiles_are_scoped_by_map_id(self) -> None:
+        state = _state()
+        state.map_data = MapData(map_id=100, rooms=[RoomInfo(room_id=4, name="Kitchen")])
+        coord = _coordinator(state=state)
+        kitchen = RoomNarwalSettingSelect(
+            coord,
+            4,
+            "Kitchen",
+            _ROOM_DESCS["route"],
+            map_id="100",
+        )
+
+        await kitchen.async_select_option("Standard")
+
+        state.map_data = MapData(map_id=200, rooms=[RoomInfo(room_id=4, name="Bedroom")])
+        bedroom = RoomNarwalSettingSelect(
+            coord,
+            4,
+            "Bedroom",
+            _ROOM_DESCS["route"],
+            map_id="200",
+        )
+
+        assert bedroom.current_option == "Meticulous"
+        assert coord.room_clean_settings[("100", 4)].route == CleaningRoute.STANDARD
+        assert ("200", 4) not in coord.room_clean_settings
+        assert not kitchen.available
+        with pytest.raises(HomeAssistantError, match="room is not available"):
+            await kitchen.async_select_option("Meticulous")
+        assert coord.room_clean_settings[("100", 4)].route == CleaningRoute.STANDARD
+
+    def test_room_profiles_unavailable_during_active_clean(self) -> None:
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        assert not RoomNarwalSettingSelect(coord, 4, "Kitchen", _ROOM_DESCS["mode"]).available
+
+    async def test_room_setting_entities_update_name_after_map_rename(self) -> None:
+        coord = _coordinator()
+        coord.client.state.map_data = MapData(
+            rooms=[RoomInfo(room_id=4, name="Kitchen")]
+        )
+        entry = MagicMock()
+        entry.runtime_data = coord
+        added_entities = []
+        listeners = []
+
+        def add_entities(entities) -> None:
+            added_entities.extend(entities)
+
+        coord.async_add_listener.side_effect = lambda listener: listeners.append(listener)
+
+        await async_setup_entry(MagicMock(), entry, add_entities)
+
+        room_mode = next(
+            entity
+            for entity in added_entities
+            if isinstance(entity, RoomNarwalSettingSelect)
+            and entity.entity_description.setting_key == "mode"
+        )
+        assert room_mode._attr_name == "Kitchen mode"
+        assert room_mode.extra_state_attributes["room_name"] == "Kitchen"
+
+        coord.client.state.map_data = MapData(
+            rooms=[RoomInfo(room_id=4, name="Pantry")]
+        )
+        listeners[0]()
+
+        assert len(added_entities) == len(SELECT_DESCRIPTIONS) + len(
+            LEGACY_SELECT_DESCRIPTIONS
+        ) + len(ROOM_SELECT_DESCRIPTIONS)
+        assert room_mode._attr_name == "Pantry mode"
+        assert room_mode.extra_state_attributes["room_name"] == "Pantry"
 
 
 class TestNarwalPassesNumber:
@@ -92,11 +944,43 @@ class TestNarwalPassesNumber:
         coord = _coordinator(settings=CleanSettings(passes=2))
         assert NarwalPassesNumber(coord).native_value == 2
 
+    def test_unavailable_during_active_clean(self) -> None:
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        assert not NarwalPassesNumber(coord).available
+
     async def test_set_native_value_stores_int(self) -> None:
         coord = _coordinator()
         num = NarwalPassesNumber(coord)
         await num.async_set_native_value(3.0)
         assert coord.clean_settings.passes == 3
+
+    async def test_set_native_value_rejects_fractional_values(self) -> None:
+        coord = _coordinator(settings=CleanSettings(passes=2))
+        num = NarwalPassesNumber(coord)
+
+        with pytest.raises(HomeAssistantError, match="integer"):
+            await num.async_set_native_value(2.5)
+
+        assert coord.clean_settings.passes == 2
+
+    async def test_set_native_value_stores_pending_value_when_entity_unavailable(self) -> None:
+        coord = _coordinator(state=_state())
+        coord.last_update_success = False
+        num = NarwalPassesNumber(coord)
+
+        await num.async_set_native_value(3.0)
+
+        assert coord.clean_settings.passes == 3
+
+    async def test_set_native_value_refreshes_related_setting_entities(self) -> None:
+        coord = _coordinator(state=_state())
+        coord.async_update_listeners = MagicMock()
+        number = NarwalPassesNumber(coord)
+
+        await number.async_set_native_value(3)
+
+        assert coord.clean_settings.passes == 3
+        coord.async_update_listeners.assert_called_once()
 
     async def test_restore_from_last_number_data(self) -> None:
         coord = _coordinator()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from narwal_client.client import NarwalClient, NarwalConnectionError
+from narwal_client.client import NarwalClient, NarwalCommandError, NarwalConnectionError
 from narwal_client.const import (
     TOPIC_CMD_CLEAN_TASK,
     TOPIC_CMD_DRY_DUST_BAG,
@@ -18,9 +18,10 @@ from narwal_client.const import (
     TOPIC_CMD_DUST_GATHERING,
     TOPIC_CMD_FORCE_END,
     TOPIC_CMD_GET_BASE_STATUS,
-    TOPIC_CMD_PLAN_START,
+    TOPIC_CMD_GET_MAP,
     TOPIC_CMD_WASH_MOP,
     AmbientLightCtrlType,
+    CleaningRoute,
     CommandResult,
     FanLevel,
     WorkingStatus,
@@ -277,13 +278,6 @@ class TestBuildCleanPayloadV2:
         assert params["7"] == 1
         assert params["3"] == 2
 
-    def test_v2_payload_differs_from_legacy_default(self) -> None:
-        """v2 schema must not collide with the legacy hardcoded default."""
-        client = NarwalClient("127.0.0.1")
-        v2 = client._build_clean_payload_v2([1])
-        assert v2 != client._DEFAULT_CLEAN_PAYLOAD
-
-
 class TestWholeHouseStart:
     """start() must route a whole-house clean through clean/start_clean (#69).
 
@@ -295,7 +289,7 @@ class TestWholeHouseStart:
     def _connected_client(self) -> NarwalClient:
         client = NarwalClient("127.0.0.1")
         client._ws = AsyncMock()
-        client._connected = True
+        client._connected.set()
         return client
 
     @pytest.mark.asyncio
@@ -316,11 +310,10 @@ class TestWholeHouseStart:
         assert result is success
         topic = mock_send.await_args_list[0].args[0]
         assert topic == TOPIC_CMD_CLEAN_TASK
-        assert topic != TOPIC_CMD_PLAN_START
 
     @pytest.mark.asyncio
-    async def test_start_never_returns_early_on_plan_start_success(self) -> None:
-        """Regression guard for #69: no path returns a bare clean/plan/start ack."""
+    async def test_start_sends_only_start_clean(self) -> None:
+        """Regression guard for #69: no path sends clean/plan/start."""
         client = self._connected_client()
         client.state.map_data = MapData(map_id=1, rooms=[RoomInfo(room_id=3)])
 
@@ -333,7 +326,7 @@ class TestWholeHouseStart:
             await client.start()
 
         sent_topics = [call.args[0] for call in mock_send.await_args_list]
-        assert TOPIC_CMD_PLAN_START not in sent_topics
+        assert sent_topics == [TOPIC_CMD_CLEAN_TASK]
 
     @pytest.mark.asyncio
     async def test_start_forwards_clean_settings(self) -> None:
@@ -347,18 +340,22 @@ class TestWholeHouseStart:
             mock_rooms.return_value = CommandResponse(
                 result_code=CommandResult.SUCCESS
             )
-            await client.start(fan=FanLevel.STRONG, passes=2)
+            await client.start(
+                fan=FanLevel.STRONG,
+                passes=2,
+                route=CleaningRoute.METICULOUS,
+            )
 
         assert mock_rooms.await_args.args[0] == [6]
         assert mock_rooms.await_args.kwargs["fan"] is FanLevel.STRONG
         assert mock_rooms.await_args.kwargs["passes"] == 2
+        assert mock_rooms.await_args.kwargs["route"] is CleaningRoute.METICULOUS
 
     @pytest.mark.asyncio
-    async def test_start_falls_back_to_saved_plan_without_rooms(self) -> None:
-        """No map rooms — fall back to clean/plan/start as a last resort."""
+    async def test_start_without_rooms_returns_not_ready(self) -> None:
+        """No map rooms means no explicit whole-house payload can be built."""
         client = self._connected_client()
         assert client.state.map_data is None
-        plan_resp = CommandResponse(result_code=CommandResult.SUCCESS)
 
         with patch.object(
             client, "get_map", new_callable=AsyncMock
@@ -366,12 +363,10 @@ class TestWholeHouseStart:
             client, "send_command", new_callable=AsyncMock
         ) as mock_send:
             mock_map.side_effect = RuntimeError("no map")
-            mock_send.return_value = plan_resp
             result = await client.start()
 
-        assert result is plan_resp
-        mock_send.assert_awaited_once()
-        assert mock_send.await_args.args[0] == TOPIC_CMD_PLAN_START
+        assert result.result_code == CommandResult.NOT_READY
+        mock_send.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_start_ignores_zero_room_ids(self) -> None:
@@ -385,13 +380,14 @@ class TestWholeHouseStart:
             mock_send.return_value = CommandResponse(
                 result_code=CommandResult.SUCCESS
             )
-            await client.start()
+            result = await client.start()
 
-        assert mock_send.await_args.args[0] == TOPIC_CMD_PLAN_START
+        assert result.result_code == CommandResult.NOT_READY
+        mock_send.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_start_rooms_with_empty_list_does_not_recurse(self) -> None:
-        """start_rooms([]) must not bounce back into start() and loop."""
+    async def test_start_rooms_with_empty_list_returns_not_ready(self) -> None:
+        """start_rooms([]) does not dispatch an ambiguous saved plan."""
         client = self._connected_client()
         client.state.map_data = MapData(map_id=1, rooms=[RoomInfo(room_id=2)])
 
@@ -403,9 +399,8 @@ class TestWholeHouseStart:
             )
             result = await client.start_rooms([])
 
-        mock_send.assert_awaited_once()
-        assert mock_send.await_args.args[0] == TOPIC_CMD_PLAN_START
-        assert result.result_code == CommandResult.SUCCESS
+        mock_send.assert_not_awaited()
+        assert result.result_code == CommandResult.NOT_READY
 
     @pytest.mark.asyncio
     async def test_start_rooms_rejects_active_dock_task(self) -> None:
@@ -431,22 +426,6 @@ class TestWholeHouseStart:
             mock_send.return_value = success
             first = await client.start_rooms([2])
             second = await client.start_rooms([2])
-
-        assert first is success
-        assert second.result_code == CommandResult.NOT_APPLICABLE
-        assert client.state.has_assumed_robot_clean
-        mock_send.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_saved_plan_start_reserves_private_guard_on_acceptance(self) -> None:
-        """Saved-plan fallback shares the direct-start action reservation."""
-        client = self._connected_client()
-        success = CommandResponse(result_code=CommandResult.SUCCESS)
-
-        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
-            mock_send.return_value = success
-            first = await client.start_rooms([])
-            second = await client.start_rooms([])
 
         assert first is success
         assert second.result_code == CommandResult.NOT_APPLICABLE
@@ -481,8 +460,8 @@ class TestWholeHouseStart:
         mock_send.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_start_rejects_active_dock_task_before_map_fallback(self) -> None:
-        """Whole-house start is blocked even when it would use the saved plan."""
+    async def test_start_rejects_active_dock_task_before_map_lookup(self) -> None:
+        """Whole-house start is blocked before map lookup when dock work is active."""
         client = self._connected_client()
         client.state.station_activity = 1
 
@@ -539,6 +518,66 @@ class TestWholeHouseStart:
 
         assert result is success
         mock_send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_get_map_rejection_preserves_cache_but_raises(self) -> None:
+        """A rejected refresh leaves display data intact but fails validation."""
+        client = self._connected_client()
+        cached = MapData(map_id=7, rooms=[RoomInfo(room_id=2)])
+        client.state.map_data = cached
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = CommandResponse(
+                result_code=CommandResult.NOT_APPLICABLE,
+                data={},
+            )
+            with pytest.raises(NarwalCommandError, match="get_map failed"):
+                await client.get_map()
+
+        assert client.state.map_data is cached
+        mock_send.assert_awaited_once_with(TOPIC_CMD_GET_MAP, timeout=15.0)
+
+    @pytest.mark.asyncio
+    async def test_get_map_rejection_without_cache_raises(self) -> None:
+        """A rejected map refresh with no cache is a command failure."""
+        client = self._connected_client()
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = CommandResponse(
+                result_code=CommandResult.NOT_APPLICABLE,
+                data={},
+            )
+            with pytest.raises(NarwalCommandError, match="get_map failed"):
+                await client.get_map()
+
+        mock_send.assert_awaited_once_with(TOPIC_CMD_GET_MAP, timeout=15.0)
+
+    @pytest.mark.asyncio
+    async def test_get_map_empty_payload_without_cache_raises(self) -> None:
+        """A payloadless accepted map response is not a valid empty map."""
+        client = self._connected_client()
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = CommandResponse(data={})
+            with pytest.raises(NarwalCommandError, match="active map"):
+                await client.get_map()
+
+        mock_send.assert_awaited_once_with(TOPIC_CMD_GET_MAP, timeout=15.0)
+
+    @pytest.mark.asyncio
+    async def test_get_map_empty_payload_preserves_cache_but_raises(self) -> None:
+        """An empty accepted refresh cannot validate cached room topology."""
+        client = self._connected_client()
+        cached = MapData(map_id=7, rooms=[RoomInfo(room_id=2)])
+        client.state.map_data = cached
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = CommandResponse(data={})
+            with pytest.raises(NarwalCommandError, match="active map"):
+                await client.get_map()
+
+        assert client.state.map_data is cached
+        mock_send.assert_awaited_once_with(TOPIC_CMD_GET_MAP, timeout=15.0)
 
 
 class TestDockTaskCommands:

--- a/tests/test_client_rooms.py
+++ b/tests/test_client_rooms.py
@@ -7,8 +7,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import blackboxprotobuf
 import pytest
 
-from narwal_client.client import NarwalClient
+from narwal_client.client import NarwalClient, RoomCleanSettings
 from narwal_client.const import (
+    CleaningRoute,
     CommandResult,
     FanLevel,
     MopHumidity,
@@ -67,11 +68,20 @@ class TestBuildStartCleanPayload:
         assert param["4"] == MopHumidity.WET
         assert param["3"] == MopStrengthLevel.HIGH
 
-    def test_overlap_not_sent(self) -> None:
-        """overlapLevel (tag 8) is omitted — live-validated as ignored."""
+    def test_route_omitted_when_unset(self) -> None:
+        """overlapLevel (tag 8) is omitted when no route is supplied."""
         client = NarwalClient("127.0.0.1")
         param = _items(_task(client._build_start_clean_payload([2], 1)))[0]["2"]
         assert "8" not in param
+
+    def test_route_encoded_when_supplied(self) -> None:
+        """Route lands in CleanParam overlapLevel tag 8."""
+        client = NarwalClient("127.0.0.1")
+        payload = client._build_start_clean_payload(
+            [2], 1, route=CleaningRoute.METICULOUS
+        )
+        param = _items(_task(payload))[0]["2"]
+        assert param["8"] == CleaningRoute.METICULOUS
 
     def test_map_zone_and_order(self) -> None:
         """map_id, room zone refs, and 1-based order encode correctly."""
@@ -82,6 +92,67 @@ class TestBuildStartCleanPayload:
         assert [it["1"]["2"] for it in items] == [2, 12]
         assert all(it["1"]["1"] == 1 for it in items)  # zoneType = ROOM
         assert [it["3"] for it in items] == [1, 2]
+
+    def test_per_room_settings_encode_distinct_clean_params(self) -> None:
+        """Each room can carry its own CleanParam in one CleanTask."""
+        client = NarwalClient("127.0.0.1")
+        payload = client._build_start_clean_payload(
+            [2, 12],
+            7,
+            room_settings={
+                2: RoomCleanSettings(
+                    work_mode=WorkMode.VACUUM_THEN_MOP,
+                    fan=FanLevel.UNSPECIFIED,
+                    water=MopHumidity.WET,
+                    mop_strength=MopStrengthLevel.HIGH,
+                    passes=3,
+                    route=CleaningRoute.METICULOUS,
+                ),
+                12: RoomCleanSettings(
+                    work_mode=WorkMode.VACUUM_THEN_MOP,
+                    fan=FanLevel.STRONG,
+                    water=MopHumidity.NORMAL,
+                    mop_strength=MopStrengthLevel.NORMAL,
+                    passes=1,
+                    route=CleaningRoute.STANDARD,
+                ),
+            },
+        )
+
+        task = _task(payload)
+        assert task["5"] == WorkMode.VACUUM_THEN_MOP
+        room_params = {item["1"]["2"]: item["2"] for item in _items(task)}
+        assert room_params[2]["1"] == 5  # VACUUM_THEN_MOP CleanParam.mode
+        assert room_params[2]["3"] == MopStrengthLevel.HIGH
+        assert room_params[2]["4"] == MopHumidity.WET
+        assert room_params[2]["5"] == 3
+        assert room_params[2]["6"] == 3
+        assert room_params[2]["8"] == CleaningRoute.METICULOUS
+
+        assert room_params[12]["1"] == 5  # VACUUM_THEN_MOP CleanParam.mode
+        assert room_params[12]["2"] == FanLevel.STRONG
+        assert room_params[12]["4"] == MopHumidity.NORMAL
+        assert room_params[12]["5"] == 1
+        assert room_params[12]["6"] == 1
+        assert room_params[12]["8"] == CleaningRoute.STANDARD
+
+    def test_mixed_room_modes_use_custom_task_type(self) -> None:
+        """Mixed profiles use the app's custom task envelope and per-room modes."""
+        client = NarwalClient("127.0.0.1")
+        payload = client._build_start_clean_payload(
+            [2, 12],
+            7,
+            room_settings={
+                2: RoomCleanSettings(work_mode=WorkMode.MOP),
+                12: RoomCleanSettings(work_mode=WorkMode.VACUUM),
+            },
+        )
+
+        task = _task(payload)
+        assert task["5"] == 6
+        room_params = {item["1"]["2"]: item["2"] for item in _items(task)}
+        assert room_params[2]["1"] == 3
+        assert room_params[12]["1"] == 2
 
 
 class TestStartRooms:
@@ -94,18 +165,16 @@ class TestStartRooms:
         return client
 
     @pytest.mark.asyncio
-    async def test_empty_rooms_falls_back_to_saved_plan(self) -> None:
-        """start_rooms([]) falls back to the saved plan, not back into start().
-
-        start() now resolves the full room list and calls start_rooms(), so
-        recursing here would loop (#69).
-        """
+    async def test_empty_rooms_return_not_ready_without_dispatch(self) -> None:
+        """start_rooms([]) does not dispatch an ambiguous saved plan."""
         client = self._client()
         with patch.object(
-            client, "_start_saved_plan", new_callable=AsyncMock
-        ) as mock_plan:
-            await client.start_rooms([])
-            mock_plan.assert_awaited_once()
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send:
+            result = await client.start_rooms([])
+
+        assert result.result_code == CommandResult.NOT_READY
+        mock_send.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_forwards_settings_to_payload(self) -> None:
@@ -117,6 +186,7 @@ class TestStartRooms:
             await client.start_rooms(
                 [5], work_mode=WorkMode.MOP, fan=FanLevel.STRONG,
                 water=MopHumidity.DRY, mop_strength=MopStrengthLevel.HIGH, passes=3,
+                route=CleaningRoute.STANDARD,
             )
         mock_send.assert_awaited_once()
         param = _items(_task(mock_send.await_args.kwargs["payload"]))[0]["2"]
@@ -125,6 +195,54 @@ class TestStartRooms:
         assert param["3"] == MopStrengthLevel.HIGH
         assert param["4"] == MopHumidity.DRY
         assert param["6"] == 3  # mopTime pass count
+        assert param["8"] == CleaningRoute.STANDARD
+
+    @pytest.mark.asyncio
+    async def test_mixed_room_modes_are_dispatched_as_custom_task(self) -> None:
+        """Mixed-mode profiles reach clean/start_clean in one custom task."""
+        client = self._client()
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = CommandResponse(result_code=CommandResult.SUCCESS)
+            result = await client.start_rooms(
+                [2, 12],
+                room_settings={
+                    2: RoomCleanSettings(work_mode=WorkMode.MOP),
+                    12: RoomCleanSettings(work_mode=WorkMode.VACUUM),
+                },
+            )
+
+        assert result.accepted
+        mock_send.assert_awaited_once()
+        assert _task(mock_send.await_args.kwargs["payload"])["5"] == 6
+
+    @pytest.mark.asyncio
+    async def test_forwards_room_settings_to_payload(self) -> None:
+        """Per-room settings passed to start_rooms reach the encoded CleanTask."""
+        client = self._client()
+        success = CommandResponse(result_code=CommandResult.SUCCESS)
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = success
+            await client.start_rooms(
+                [5],
+                room_settings={
+                    5: RoomCleanSettings(
+                        work_mode=WorkMode.MOP,
+                        fan=FanLevel.UNSPECIFIED,
+                        water=MopHumidity.WET,
+                        mop_strength=MopStrengthLevel.HIGH,
+                        passes=3,
+                        route=CleaningRoute.METICULOUS,
+                    )
+                },
+            )
+
+        mock_send.assert_awaited_once()
+        param = _items(_task(mock_send.await_args.kwargs["payload"]))[0]["2"]
+        assert param["1"] == 3
+        assert param["3"] == MopStrengthLevel.HIGH
+        assert param["4"] == MopHumidity.WET
+        assert param["6"] == 3
+        assert param["8"] == CleaningRoute.METICULOUS
 
     @pytest.mark.asyncio
     async def test_no_map_id_returns_not_applicable(self) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -6,6 +6,7 @@ UpdateFailed after the threshold, and resets counters on success/push.
 
 from __future__ import annotations
 
+import asyncio
 import sys
 import time
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
@@ -21,17 +22,42 @@ from custom_components.narwal.const import NO_BROADCAST_PRODUCT_KEYS  # noqa: E4
 from custom_components.narwal.coordinator import (  # noqa: E402
     TOPIC_RESUBSCRIBE_AFTER,
     TOPIC_SUBSCRIPTION_TTL,
+    CleanSettings,
     NarwalCoordinator,
-)
+    can_edit_pending_clean_settings,
+    can_start_cleaning,
+    is_clean_session_context,
+    is_live_clean_setting_available,
+    is_narwal_task_busy,
+)  # noqa: E402
 from custom_components.narwal.narwal_client import (  # noqa: E402
     CommandResponse,
     CommandResult,
+    FanLevel,
+    MopHumidity,
     NarwalConnectionError,
     NarwalState,
+    RoomCleanSettings,
     WorkingStatus,
+    WorkMode,
 )
 
 UpdateFailed = sys.modules["homeassistant.helpers.update_coordinator"].UpdateFailed
+
+
+class _RoomSelectionStore:
+    """Minimal storage double for room-selection persistence tests."""
+
+    def __init__(self) -> None:
+        self.data: object | None = None
+
+    async def async_load(self) -> object | None:
+        """Return stored data."""
+        return self.data
+
+    async def async_save(self, data: object) -> None:
+        """Store data."""
+        self.data = data
 
 
 def test_non_broadcast_product_key_configures_polling_client() -> None:
@@ -55,6 +81,728 @@ def test_non_broadcast_product_key_configures_polling_client() -> None:
         topic_prefix=f"/{product_key}",
         supports_broadcasts=False,
     )
+
+
+def test_room_profiles_only_override_customized_fields() -> None:
+    """Read-only room profile creation must not freeze global defaults."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.client = MagicMock()
+    coordinator.client.state = NarwalState()
+    coordinator.data = coordinator.client.state
+    coordinator.clean_settings = CleanSettings()
+    coordinator.room_clean_settings = {}
+    coordinator.room_clean_settings_customized = {}
+
+    coordinator.room_clean_settings_for(4)
+    coordinator.clean_settings.fan = FanLevel.STRONG
+    coordinator.clean_settings.water = MopHumidity.WET
+
+    settings = coordinator.room_clean_settings_for_rooms([4])[4]
+
+    assert settings.fan == FanLevel.STRONG
+    assert settings.water == MopHumidity.WET
+
+    coordinator.set_room_clean_setting(4, "water", MopHumidity.DRY)
+    merged = coordinator.room_clean_settings_for_rooms([4])[4]
+
+    assert merged.fan == FanLevel.STRONG
+    assert merged.water == MopHumidity.DRY
+
+
+def test_effective_room_profile_follows_global_defaults_until_customized() -> None:
+    """Room entity reads should not materialize stale inherited defaults."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.client = MagicMock()
+    coordinator.client.state = NarwalState()
+    coordinator.data = coordinator.client.state
+    coordinator.clean_settings = CleanSettings()
+    coordinator.room_clean_settings = {}
+    coordinator.room_clean_settings_customized = {}
+
+    first = coordinator.effective_room_clean_settings_for(4)
+    coordinator.clean_settings.route = first.route
+    coordinator.clean_settings.fan = FanLevel.STRONG
+
+    inherited = coordinator.effective_room_clean_settings_for(4)
+
+    assert inherited.fan == FanLevel.STRONG
+    assert coordinator.room_clean_settings == {}
+
+    coordinator.set_room_clean_setting(4, "water", MopHumidity.DRY)
+    coordinator.clean_settings.water = MopHumidity.WET
+    customized = coordinator.effective_room_clean_settings_for(4)
+
+    assert customized.fan == FanLevel.STRONG
+    assert customized.water == MopHumidity.DRY
+
+
+def test_room_profiles_can_be_bypassed_for_explicit_service_settings() -> None:
+    """Callers can request exact settings without saved room-profile overrides."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.client = MagicMock()
+    coordinator.client.state = NarwalState()
+    coordinator.data = coordinator.client.state
+    coordinator.clean_settings = CleanSettings()
+    coordinator.room_clean_settings = {}
+    coordinator.room_clean_settings_customized = {}
+    coordinator.set_room_clean_setting(4, "fan", FanLevel.MUTE)
+    requested = RoomCleanSettings(fan=FanLevel.STRONG)
+
+    settings = coordinator.room_clean_settings_for_rooms(
+        [4],
+        default=requested,
+        use_room_profiles=False,
+    )[4]
+
+    assert settings is requested
+    assert settings.fan == FanLevel.STRONG
+
+
+def test_selected_clean_rooms_fall_back_to_all_rooms() -> None:
+    """No room selection means the native start command cleans every room."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.client = MagicMock()
+    coordinator.client.state = NarwalState()
+    coordinator.data = coordinator.client.state
+    coordinator.selected_clean_rooms = {}
+
+    assert coordinator.selected_clean_room_ids_for([4, 5]) == [4, 5]
+
+
+def test_selected_clean_rooms_prune_stale_ids_and_are_map_scoped() -> None:
+    """Known selected rooms remain scoped without mutating stale selections."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.client = MagicMock()
+    coordinator.client.state = NarwalState()
+    coordinator.data = coordinator.client.state
+    coordinator.selected_clean_rooms = {}
+
+    coordinator.set_room_selected_for_clean(5, True, map_id="upstairs")
+    coordinator.set_room_selected_for_clean(99, True, map_id="upstairs")
+
+    assert coordinator.selected_clean_room_ids_for([4, 5], map_id="upstairs") == [5]
+    assert coordinator.selected_clean_room_ids_for([4, 5], map_id="downstairs") == [4, 5]
+
+    coordinator.set_room_selected_for_clean(5, False, map_id="upstairs")
+    assert coordinator.selected_clean_room_ids_for([4, 5], map_id="upstairs") == []
+
+
+def test_selected_clean_rooms_fall_back_when_every_selected_room_vanished() -> None:
+    """A vanished explicit selection continues to fail closed."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.client = MagicMock()
+    coordinator.client.state = NarwalState()
+    coordinator.data = coordinator.client.state
+    coordinator.selected_clean_rooms = {"upstairs": {99}}
+
+    assert coordinator.selected_clean_room_ids_for([4, 5], map_id="upstairs") == []
+    assert coordinator.selected_clean_room_ids_for([4, 5], map_id="upstairs") == []
+    assert coordinator.has_selected_clean_rooms(map_id="upstairs")
+
+
+def test_unidentified_map_selection_remains_explicit_after_identification() -> None:
+    """Learning a map id cannot broaden an unresolved explicit selection."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.selected_clean_rooms = {None: {4}}
+    coordinator._room_selection_store_loaded = True
+
+    assert coordinator.selected_clean_room_ids_for([4, 5], map_id="100") == [4]
+    assert coordinator.has_selected_clean_rooms(map_id="100")
+    assert coordinator.is_room_selected_for_clean(4, map_id="100")
+
+    coordinator._schedule_room_selection_save = MagicMock()
+    coordinator.set_room_selected_for_clean(4, False, map_id="100")
+    coordinator.set_room_selected_for_clean(5, True, map_id="100")
+
+    assert None not in coordinator.selected_clean_rooms
+    assert coordinator.selected_clean_rooms == {"100": {5}}
+
+
+async def test_room_selection_store_preserves_disappeared_selected_room() -> None:
+    """Restart cannot broaden a stale explicit selection to every current room."""
+    store = _RoomSelectionStore()
+    before = NarwalCoordinator.__new__(NarwalCoordinator)
+    before.selected_clean_rooms = {"upstairs": {4}}
+    before._room_selection_store = store
+    before._room_selection_save_lock = asyncio.Lock()
+    before._room_selection_store_loaded = True
+
+    await before._async_save_room_selections()
+
+    after = NarwalCoordinator.__new__(NarwalCoordinator)
+    after.selected_clean_rooms = {}
+    after._room_selection_store = store
+    after._room_selection_store_loaded = False
+    await after._async_restore_room_selections()
+
+    assert after.selected_clean_room_ids_for([5], map_id="upstairs") == []
+    assert after.is_room_selected_for_clean(4, map_id="upstairs")
+
+
+async def test_room_store_restores_customized_profile_without_entities() -> None:
+    """Disabled room controls cannot lose their raw customized values."""
+    store = _RoomSelectionStore()
+    before = NarwalCoordinator.__new__(NarwalCoordinator)
+    before.selected_clean_rooms = {}
+    before.room_clean_settings = {
+        ("upstairs", 4): RoomCleanSettings(
+            work_mode=WorkMode.MOP,
+            fan=FanLevel.STRONG,
+            passes=3,
+        )
+    }
+    before.room_clean_settings_customized = {
+        ("upstairs", 4): {"work_mode", "fan", "passes"}
+    }
+    before._room_selection_store = store
+    before._room_selection_save_lock = asyncio.Lock()
+    before._room_selection_store_loaded = True
+
+    await before._async_save_room_selections()
+
+    after = NarwalCoordinator.__new__(NarwalCoordinator)
+    after.selected_clean_rooms = {}
+    after.room_clean_settings = {}
+    after.room_clean_settings_customized = {}
+    after._room_selection_store = store
+    after._room_selection_store_loaded = False
+    await after._async_restore_room_selections()
+
+    restored = after.room_clean_settings[("upstairs", 4)]
+    assert restored.work_mode == WorkMode.MOP
+    assert restored.fan == FanLevel.STRONG
+    assert restored.passes == 3
+    assert after.room_clean_settings_customized == {
+        ("upstairs", 4): {"work_mode", "fan", "passes"}
+    }
+
+
+async def test_room_selection_load_failure_cannot_overwrite_stored_state() -> None:
+    """A failed restore must not replace unread selections during shutdown."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.selected_clean_rooms = {}
+    coordinator._room_selection_store = MagicMock()
+    coordinator._room_selection_store.async_load = AsyncMock(side_effect=OSError)
+    coordinator._room_selection_store.async_save = AsyncMock()
+    coordinator._room_selection_save_lock = asyncio.Lock()
+    coordinator._room_selection_store_loaded = False
+    coordinator._room_profile_store_loaded = False
+
+    await coordinator._async_restore_room_selections()
+    await coordinator._async_save_room_selections()
+
+    assert coordinator.selected_clean_room_ids_for([4, 5], map_id="100") == []
+    coordinator._room_selection_store.async_save.assert_not_awaited()
+
+
+async def test_selection_change_cannot_authorize_unread_profile_overwrite() -> None:
+    """A room toggle after failed restore cannot replace durable profiles."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.selected_clean_rooms = {}
+    coordinator.room_clean_settings = {
+        ("upstairs", 4): RoomCleanSettings(fan=FanLevel.MUTE)
+    }
+    coordinator.room_clean_settings_customized = {("upstairs", 4): {"fan"}}
+    coordinator._room_selection_store = MagicMock()
+    coordinator._room_selection_store.async_load = AsyncMock(
+        side_effect=[OSError, {"maps": [], "profiles": [{"durable": "profile"}]}]
+    )
+    coordinator._room_selection_store.async_save = AsyncMock()
+    coordinator._room_selection_save_lock = asyncio.Lock()
+    coordinator._room_selection_store_loaded = False
+    coordinator._room_profile_store_loaded = False
+    coordinator._schedule_room_selection_save = MagicMock()
+
+    await coordinator._async_restore_room_selections()
+    coordinator.set_room_selected_for_clean(4, True, map_id="upstairs")
+    await coordinator._async_save_room_selections()
+
+    assert coordinator._room_selection_store_loaded
+    assert not coordinator._room_profile_store_loaded
+    coordinator._room_selection_store.async_save.assert_awaited_once_with(
+        {
+            "maps": [{"map_id": "upstairs", "room_ids": [4]}],
+            "profiles": [{"durable": "profile"}],
+        }
+    )
+
+
+async def test_selection_retry_preserves_other_stored_maps() -> None:
+    """A local toggle after a failed read must merge unrelated stored maps."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.selected_clean_rooms = {}
+    coordinator.room_clean_settings = {}
+    coordinator.room_clean_settings_customized = {}
+    coordinator.data = NarwalState()
+    coordinator.client = MagicMock()
+    coordinator.client.state = coordinator.data
+    coordinator._room_selection_store = MagicMock()
+    coordinator._room_selection_store.async_load = AsyncMock(
+        side_effect=[
+            OSError,
+            {
+                "maps": [
+                    {"map_id": "100", "room_ids": [4]},
+                    {"map_id": "200", "room_ids": [7]},
+                ],
+                "profiles": [],
+            },
+        ]
+    )
+    coordinator._room_selection_store.async_save = AsyncMock()
+    coordinator._room_selection_save_lock = asyncio.Lock()
+    coordinator._room_selection_store_loaded = False
+    coordinator._room_profile_store_loaded = False
+    coordinator._schedule_room_selection_save = MagicMock()
+
+    await coordinator._async_restore_room_selections()
+    coordinator.set_room_selected_for_clean(5, True, map_id="100")
+    await coordinator._async_save_room_selections()
+
+    saved = coordinator._room_selection_store.async_save.await_args.args[0]
+    assert saved["maps"] == [
+        {"map_id": "100", "room_ids": [5]},
+        {"map_id": "200", "room_ids": [7]},
+    ]
+
+
+def test_map_identification_migrates_unresolved_profiles_with_selection() -> None:
+    """Resolving a map keeps its customized room profiles attached."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    profile = RoomCleanSettings(work_mode=WorkMode.VACUUM)
+    coordinator.selected_clean_rooms = {None: {4}}
+    coordinator.room_clean_settings = {(None, 4): profile}
+    coordinator.room_clean_settings_customized = {(None, 4): {"work_mode"}}
+    coordinator._room_selection_store_loaded = True
+    coordinator._schedule_room_selection_save = MagicMock()
+
+    coordinator.set_room_selected_for_clean(5, True, map_id="100")
+
+    assert coordinator.selected_clean_rooms == {"100": {4, 5}}
+    assert coordinator.room_clean_settings == {("100", 4): profile}
+    assert coordinator.room_clean_settings_customized == {
+        ("100", 4): {"work_mode"}
+    }
+
+
+def test_profile_resolution_does_not_require_another_selection_toggle() -> None:
+    """A fetched map immediately attaches unresolved profiles to native starts."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.clean_settings = CleanSettings(work_mode=WorkMode.VACUUM_AND_MOP)
+    coordinator.selected_clean_rooms = {None: {4}}
+    coordinator.room_clean_settings = {
+        (None, 4): RoomCleanSettings(work_mode=WorkMode.VACUUM)
+    }
+    coordinator.room_clean_settings_customized = {(None, 4): {"work_mode"}}
+    coordinator._room_selection_store_loaded = True
+    coordinator._room_selection_dirty_maps = set()
+    coordinator._schedule_room_selection_save = MagicMock()
+
+    settings = coordinator.room_clean_settings_for_rooms([4], map_id="100")
+
+    assert settings[4].work_mode == WorkMode.VACUUM
+    assert coordinator.selected_clean_rooms == {"100": {4}}
+    assert set(coordinator.room_clean_settings) == {("100", 4)}
+    assert coordinator.room_clean_settings[("100", 4)].work_mode == WorkMode.VACUUM
+
+
+async def test_newer_unresolved_selection_supersedes_same_stored_map() -> None:
+    """A post-failure unresolved choice wins when its map becomes known."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.selected_clean_rooms = {}
+    coordinator.room_clean_settings = {}
+    coordinator.room_clean_settings_customized = {}
+    coordinator.data = NarwalState()
+    coordinator.client = MagicMock()
+    coordinator.client.state = coordinator.data
+    coordinator._room_selection_store = MagicMock()
+    coordinator._room_selection_store.async_load = AsyncMock(
+        side_effect=[
+            OSError,
+            {
+                "maps": [{"map_id": "100", "room_ids": [4]}],
+                "profiles": [],
+            },
+        ]
+    )
+    coordinator._room_selection_store.async_save = AsyncMock()
+    coordinator._room_selection_save_lock = asyncio.Lock()
+    coordinator._room_selection_store_loaded = False
+    coordinator._room_profile_store_loaded = False
+    coordinator._room_selection_dirty_maps = set()
+    coordinator._schedule_room_selection_save = MagicMock()
+
+    await coordinator._async_restore_room_selections()
+    coordinator.set_room_selected_for_clean(5, True)
+    await coordinator._async_save_room_selections()
+
+    assert coordinator.selected_clean_room_ids_for([4, 5], map_id="100") == [5]
+    assert coordinator.selected_clean_rooms == {"100": {5}}
+
+    saved = coordinator._room_selection_store.async_save.await_args.args[0]
+    assert saved["maps"] == [
+        {
+            "map_id": None,
+            "room_ids": [5],
+            "pending_map_resolution": True,
+        },
+        {"map_id": "100", "room_ids": [4]},
+    ]
+    restarted = NarwalCoordinator.__new__(NarwalCoordinator)
+    restarted.selected_clean_rooms = {}
+    restarted.room_clean_settings = {}
+    restarted.room_clean_settings_customized = {}
+    restarted._room_selection_store = _RoomSelectionStore()
+    restarted._room_selection_store.data = saved
+    restarted._room_selection_store_loaded = False
+    restarted._room_profile_store_loaded = False
+    restarted._room_selection_dirty_maps = set()
+    restarted._schedule_room_selection_save = MagicMock()
+
+    await restarted._async_restore_room_selections()
+
+    assert restarted.selected_clean_room_ids_for([4, 5], map_id="100") == [5]
+    assert restarted.selected_clean_rooms == {"100": {5}}
+
+
+async def test_persisted_unresolved_precedence_survives_failed_read_retry() -> None:
+    """A shutdown retry cannot treat persisted precedence as a local deletion."""
+    stored = {
+        "maps": [
+            {
+                "map_id": None,
+                "room_ids": [5],
+                "pending_map_resolution": True,
+            },
+            {"map_id": "100", "room_ids": [4]},
+        ],
+        "profiles": [],
+    }
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.selected_clean_rooms = {}
+    coordinator.room_clean_settings = {}
+    coordinator.room_clean_settings_customized = {}
+    coordinator._room_selection_store = MagicMock()
+    coordinator._room_selection_store.async_load = AsyncMock(
+        side_effect=[OSError, stored]
+    )
+    coordinator._room_selection_store.async_save = AsyncMock()
+    coordinator._room_selection_save_lock = asyncio.Lock()
+    coordinator._room_selection_store_loaded = False
+    coordinator._room_profile_store_loaded = False
+    coordinator._room_selection_dirty_maps = set()
+
+    await coordinator._async_restore_room_selections()
+    await coordinator._async_save_room_selections()
+
+    saved = coordinator._room_selection_store.async_save.await_args.args[0]
+    assert saved["maps"] == stored["maps"]
+
+    restarted = NarwalCoordinator.__new__(NarwalCoordinator)
+    restarted.selected_clean_rooms = {}
+    restarted.room_clean_settings = {}
+    restarted.room_clean_settings_customized = {}
+    restarted._room_selection_store = _RoomSelectionStore()
+    restarted._room_selection_store.data = saved
+    restarted._room_selection_store_loaded = False
+    restarted._room_profile_store_loaded = False
+    restarted._room_selection_dirty_maps = set()
+    restarted._schedule_room_selection_save = MagicMock()
+    await restarted._async_restore_room_selections()
+
+    assert restarted.selected_clean_room_ids_for([4, 5], map_id="100") == [5]
+
+
+async def test_newer_unresolved_profile_overrides_scoped_profile_after_restart() -> None:
+    """Profile resolution preserves a newer edit made before map identification."""
+    store = _RoomSelectionStore()
+    store.data = {
+        "maps": [{"map_id": "100", "room_ids": [4]}],
+        "profiles": [
+            {
+                "map_id": "100",
+                "room_id": 4,
+                "values": {"work_mode": int(WorkMode.VACUUM_AND_MOP)},
+            },
+            {
+                "map_id": None,
+                "room_id": 4,
+                "values": {"work_mode": int(WorkMode.VACUUM)},
+                "pending_map_resolution": True,
+            },
+        ],
+    }
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.selected_clean_rooms = {}
+    coordinator.room_clean_settings = {}
+    coordinator.room_clean_settings_customized = {}
+    coordinator.clean_settings = CleanSettings()
+    coordinator._room_selection_store = store
+    coordinator._room_selection_store_loaded = False
+    coordinator._room_profile_store_loaded = False
+    coordinator._room_selection_dirty_maps = set()
+    coordinator._schedule_room_selection_save = MagicMock()
+
+    await coordinator._async_restore_room_selections()
+    settings = coordinator.room_clean_settings_for_rooms([4], map_id="100")
+
+    assert settings[4].work_mode == WorkMode.VACUUM
+    assert set(coordinator.room_clean_settings) == {("100", 4)}
+
+
+async def test_unresolved_profile_edit_preserves_other_scoped_fields() -> None:
+    """Resolution merges newer fields without replacing scoped customization."""
+    store = _RoomSelectionStore()
+    store.data = {
+        "maps": [{"map_id": "100", "room_ids": [4]}],
+        "profiles": [
+            {
+                "map_id": "100",
+                "room_id": 4,
+                "values": {"work_mode": int(WorkMode.VACUUM)},
+            },
+            {
+                "map_id": None,
+                "room_id": 4,
+                "values": {"fan": int(FanLevel.STRONG)},
+                "pending_map_resolution": True,
+            },
+        ],
+    }
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.clean_settings = CleanSettings(work_mode=WorkMode.VACUUM_AND_MOP)
+    coordinator.selected_clean_rooms = {}
+    coordinator.room_clean_settings = {}
+    coordinator.room_clean_settings_customized = {}
+    coordinator._room_selection_store = store
+    coordinator._room_selection_store_loaded = False
+    coordinator._room_profile_store_loaded = False
+    coordinator._room_selection_dirty_maps = set()
+    coordinator._schedule_room_selection_save = MagicMock()
+
+    await coordinator._async_restore_room_selections()
+    settings = coordinator.room_clean_settings_for_rooms([4], map_id="100")
+
+    assert settings[4].work_mode == WorkMode.VACUUM
+    assert settings[4].fan == FanLevel.STRONG
+    assert coordinator.room_clean_settings_customized == {
+        ("100", 4): {"work_mode", "fan"}
+    }
+
+
+async def test_room_selection_write_failure_does_not_escape() -> None:
+    """Store write failures are logged without aborting coordinator shutdown."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.selected_clean_rooms = {"100": {4}}
+    coordinator.room_clean_settings = {}
+    coordinator.room_clean_settings_customized = {}
+    coordinator._room_selection_store = MagicMock()
+    coordinator._room_selection_store.async_save = AsyncMock(
+        side_effect=PermissionError
+    )
+    coordinator._room_selection_save_lock = asyncio.Lock()
+    coordinator._room_selection_store_loaded = True
+    coordinator._room_profile_store_loaded = True
+    coordinator._room_selection_dirty_maps = {"100"}
+
+    await coordinator._async_save_room_selections()
+
+    assert coordinator._room_selection_dirty_maps == {"100"}
+
+
+async def test_cancelled_room_save_cannot_overwrite_newer_selection() -> None:
+    """Serialization remains held until a cancelled Store write completes."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.selected_clean_rooms = {"upstairs": {4}}
+    coordinator.room_clean_settings = {}
+    coordinator.room_clean_settings_customized = {}
+    coordinator._room_selection_store_loaded = True
+    coordinator._room_profile_store_loaded = True
+    coordinator._room_selection_save_lock = asyncio.Lock()
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    saved: list[object] = []
+
+    async def save(data: object) -> None:
+        if not saved:
+            first_started.set()
+            await release_first.wait()
+        saved.append(data)
+
+    coordinator._room_selection_store = MagicMock()
+    coordinator._room_selection_store.async_save = AsyncMock(side_effect=save)
+
+    older = asyncio.create_task(coordinator._async_save_room_selections())
+    await first_started.wait()
+    coordinator.selected_clean_rooms["upstairs"].add(5)
+    newer = asyncio.create_task(coordinator._async_save_room_selections())
+    older.cancel()
+    await asyncio.sleep(0)
+    older.cancel()
+    await asyncio.sleep(0)
+    release_first.set()
+    await asyncio.gather(older, newer, return_exceptions=True)
+
+    assert saved[-1]["maps"] == [
+        {"map_id": "upstairs", "room_ids": [4, 5]}
+    ]
+
+
+async def test_malformed_room_selection_store_remains_non_authoritative() -> None:
+    """Malformed nested data cannot enable starts or be overwritten."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.selected_clean_rooms = {}
+    coordinator._room_selection_store = MagicMock()
+    coordinator._room_selection_store.async_load = AsyncMock(
+        return_value={"maps": [{"map_id": "100", "room_ids": "4"}]}
+    )
+    coordinator._room_selection_store.async_save = AsyncMock()
+    coordinator._room_selection_save_lock = asyncio.Lock()
+    coordinator._room_selection_store_loaded = False
+    coordinator._room_profile_store_loaded = False
+
+    await coordinator._async_restore_room_selections()
+    await coordinator._async_save_room_selections()
+
+    assert coordinator.selected_clean_room_ids_for([4, 5], map_id="100") == []
+    coordinator._room_selection_store.async_save.assert_not_awaited()
+
+
+def test_selected_clean_room_presence_is_map_scoped() -> None:
+    """Whole-floor setup can distinguish explicit selections per map."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.client = MagicMock()
+    coordinator.client.state = NarwalState()
+    coordinator.data = coordinator.client.state
+    coordinator.selected_clean_rooms = {"upstairs": {5}}
+
+    assert coordinator.has_selected_clean_rooms(map_id="upstairs")
+    assert not coordinator.has_selected_clean_rooms(map_id="downstairs")
+
+
+def test_active_clean_settings_follow_current_room_and_runtime_updates() -> None:
+    """Live controls report dispatched room profiles instead of pending globals."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    state = NarwalState(working_status=WorkingStatus.CLEANING)
+    state.current_room_id = 5
+    coordinator.client = MagicMock()
+    coordinator.client.state = state
+    coordinator.data = state
+    coordinator.active_clean_work_mode = None
+    coordinator.active_room_clean_settings = {}
+    requested = {
+        4: RoomCleanSettings(fan=FanLevel.NORMAL),
+        5: RoomCleanSettings(fan=FanLevel.STRONG),
+    }
+
+    coordinator.record_accepted_clean_start(requested)
+
+    assert coordinator.active_clean_setting("fan") == FanLevel.STRONG
+    assert coordinator.active_room_clean_settings[5] is not requested[5]
+
+    coordinator.set_active_clean_setting("fan", FanLevel.DEEP)
+
+    assert coordinator.active_clean_setting("fan") == FanLevel.DEEP
+    assert all(
+        settings.fan == FanLevel.DEEP
+        for settings in coordinator.active_room_clean_settings.values()
+    )
+
+
+def test_runtime_setting_is_retained_without_reconstructed_room_profiles() -> None:
+    """An accepted live command remains visible without startup task profiles."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    state = NarwalState(working_status=WorkingStatus.CLEANING)
+    coordinator.client = MagicMock()
+    coordinator.client.state = state
+    coordinator.data = state
+    coordinator.active_clean_work_mode = None
+    coordinator.active_room_clean_settings = {}
+    coordinator.active_clean_setting_overrides = {}
+
+    coordinator.set_active_clean_setting("fan", FanLevel.STRONG)
+
+    assert coordinator.active_clean_setting("fan") == FanLevel.STRONG
+
+    state.working_status = WorkingStatus.STANDBY
+    coordinator._sync_active_clean_context(state)
+
+    assert coordinator.active_clean_setting_overrides == {}
+
+
+def test_mixed_active_clean_uses_current_room_mode_for_live_controls() -> None:
+    """Runtime control applicability follows the room currently being cleaned."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    state = NarwalState(working_status=WorkingStatus.CLEANING)
+    state.current_room_id = 5
+    coordinator.client = MagicMock()
+    coordinator.client.state = state
+    coordinator.data = state
+    coordinator.active_clean_work_mode = None
+    coordinator.active_room_clean_settings = {}
+
+    coordinator.record_accepted_clean_start(
+        {
+            4: RoomCleanSettings(work_mode=WorkMode.MOP),
+            5: RoomCleanSettings(work_mode=WorkMode.VACUUM),
+        }
+    )
+
+    assert coordinator.active_clean_work_mode is None
+    assert coordinator.clean_setting_applicability_mode(live=True) == WorkMode.VACUUM
+
+    state.current_room_id = 4
+    assert coordinator.clean_setting_applicability_mode(live=True) == WorkMode.MOP
+
+
+def test_paused_standby_task_context_blocks_new_actions() -> None:
+    """Paused STANDBY overlays still represent the current clean task."""
+    state = NarwalState()
+    state.task_progress_percent = 72
+    state.task_elapsed_time = 900
+    state.current_room_id = 4
+
+    state.update_from_base_status({"3": {"1": 1, "2": 1}, "11": 1, "47": 2})
+
+    assert state.working_status == WorkingStatus.STANDBY
+    assert state.is_paused
+    assert state.has_paused_clean_task_context
+    assert is_live_clean_setting_available(state)
+    assert not can_edit_pending_clean_settings(state)
+    assert not can_start_cleaning(state)
+
+
+def test_task_completed_remains_busy_until_terminal_dock_state() -> None:
+    """TASK_COMPLETED is the return leg, not an editable idle state."""
+    state = NarwalState(working_status=WorkingStatus.TASK_COMPLETED)
+    state.dock_presence = 6
+
+    assert state.is_docked
+    assert is_clean_session_context(state)
+    assert is_narwal_task_busy(state)
+    assert not can_edit_pending_clean_settings(state)
+    assert not can_start_cleaning(state)
+
+
+def test_remapping_does_not_expose_live_clean_settings() -> None:
+    """Map-building tasks do not accept live clean-setting commands."""
+    state = NarwalState(working_status=WorkingStatus.REMAPPING)
+
+    assert not is_live_clean_setting_available(state)
+
+
+@pytest.mark.parametrize(
+    "working_status", (WorkingStatus.TASK_COMPLETED, WorkingStatus.ERROR)
+)
+def test_terminal_status_does_not_expose_live_clean_settings(
+    working_status: WorkingStatus,
+) -> None:
+    """Accepted-start context cannot expose controls after a terminal status."""
+    state = NarwalState(working_status=WorkingStatus.CLEANING)
+    state.assume_robot_clean()
+    state.working_status = working_status
+
+    assert not is_live_clean_setting_available(state)
 
 
 class TestCoordinatorResilience:
@@ -90,9 +838,17 @@ class TestCoordinatorResilience:
         # Fresh subscription so renewal does not fire in unrelated tests.
         coordinator._last_topic_subscribe = time.monotonic()
         coordinator._prev_working_status = MagicMock()
+        coordinator.active_clean_work_mode = None
+        coordinator.active_room_clean_settings = {}
         coordinator.update_interval = None
-        # Prevent background task warnings
-        mock_entry.async_create_background_task = MagicMock()
+        def _close_background_task(*args: object) -> None:
+            for arg in args:
+                if hasattr(arg, "close"):
+                    arg.close()
+
+        mock_entry.async_create_background_task = MagicMock(
+            side_effect=_close_background_task
+        )
         return coordinator
 
     async def test_stale_data_on_first_failure(self) -> None:
@@ -104,6 +860,72 @@ class TestCoordinatorResilience:
 
         assert result is coordinator.client.state
         assert coordinator._consecutive_failures == 1
+
+    async def test_poll_retries_failed_room_store_restore(self) -> None:
+        """Polling retries a transient Store read failure without user action."""
+        coordinator = self._make_coordinator()
+        coordinator._room_selection_store = MagicMock()
+        coordinator._room_selection_store.async_load = AsyncMock(
+            side_effect=[OSError, None]
+        )
+        coordinator._room_selection_save_lock = asyncio.Lock()
+        coordinator._room_selection_store_loaded = False
+        coordinator._room_profile_store_loaded = False
+        type(coordinator.client).connected = PropertyMock(return_value=False)
+
+        await coordinator._async_restore_room_selections()
+        assert not coordinator._room_selection_store_loaded
+        assert not coordinator._room_profile_store_loaded
+
+        result = await coordinator._async_update_data()
+
+        assert result is coordinator.client.state
+        assert coordinator._room_selection_store_loaded
+        assert coordinator._room_profile_store_loaded
+        assert coordinator._room_selection_store.async_load.await_count == 2
+
+    async def test_poll_restore_is_serialized_with_room_store_save(self) -> None:
+        """A retry cannot apply an old read after a concurrent save."""
+        coordinator = self._make_coordinator()
+        coordinator.selected_clean_rooms = {}
+        coordinator.room_clean_settings = {}
+        coordinator.room_clean_settings_customized = {}
+        coordinator._room_selection_dirty_maps = set()
+        coordinator._room_profile_pending_resolution = set()
+        coordinator._room_selection_save_lock = asyncio.Lock()
+        coordinator._room_selection_store_loaded = False
+        coordinator._room_profile_store_loaded = False
+        coordinator._schedule_room_selection_save = MagicMock()
+        type(coordinator.client).connected = PropertyMock(return_value=False)
+        read_started = asyncio.Event()
+        release_read = asyncio.Event()
+
+        async def delayed_load() -> object:
+            read_started.set()
+            await release_read.wait()
+            return {
+                "maps": [{"map_id": "upstairs", "room_ids": [4]}],
+                "profiles": [],
+            }
+
+        coordinator._room_selection_store = MagicMock()
+        coordinator._room_selection_store.async_load = AsyncMock(
+            side_effect=delayed_load
+        )
+        coordinator._room_selection_store.async_save = AsyncMock()
+
+        poll_task = asyncio.create_task(coordinator._async_update_data())
+        await read_started.wait()
+        coordinator.set_room_selected_for_clean(5, True, map_id="upstairs")
+        save_task = asyncio.create_task(coordinator._async_save_room_selections())
+        release_read.set()
+        await poll_task
+        await save_task
+
+        assert coordinator.selected_clean_rooms == {"upstairs": {5}}
+        coordinator._room_selection_store.async_save.assert_awaited_once()
+        saved = coordinator._room_selection_store.async_save.await_args.args[0]
+        assert saved["maps"] == [{"map_id": "upstairs", "room_ids": [5]}]
 
     async def test_stale_data_on_consecutive_failures_below_threshold(self) -> None:
         """_async_update_data returns stale state for failures 1-4."""
@@ -178,6 +1000,21 @@ class TestCoordinatorResilience:
 
         assert coordinator._consecutive_failures == 0
         assert not coordinator.has_fresh_state
+
+    async def test_idle_push_clears_active_clean_work_mode(self) -> None:
+        """Accepted-task mode metadata is only kept for active clean contexts."""
+        coordinator = self._make_coordinator()
+        coordinator.active_clean_work_mode = WorkMode.MOP
+        coordinator.active_room_clean_settings = {4: RoomCleanSettings()}
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator._prev_working_status = WorkingStatus.CLEANING
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": int(WorkingStatus.DOCKED), "3": 6}})
+
+        coordinator._on_state_update(state)
+
+        assert coordinator.active_clean_work_mode is None
+        assert coordinator.active_room_clean_settings == {}
 
     async def test_poll_does_not_call_connect(self) -> None:
         """_async_update_data does NOT call client.connect() when disconnected."""
@@ -367,10 +1204,15 @@ class TestTopicSubscriptionRenewal:
         c._consumable_poll_countdown = 99
         c._fast_poll_remaining = 0
         c._listen_task = None
-        c._map_fetch_pending = False
+        # This fixture exercises subscription renewal, not deferred map fetches.
+        # Keep that background path suppressed so its mocked task creator does
+        # not leave an unconsumed coroutine behind.
+        c._map_fetch_pending = True
         c._last_display_map_resub = 0.0
         c._last_topic_subscribe = last_subscribe
         c._prev_working_status = MagicMock()
+        c.active_clean_work_mode = None
+        c.active_room_clean_settings = {}
         c.update_interval = None
         return c
 

--- a/tests/test_coordinator_map.py
+++ b/tests/test_coordinator_map.py
@@ -15,6 +15,7 @@ import tests.ha_stubs  # noqa: E402
 
 tests.ha_stubs.install()
 
+from custom_components.narwal.camera import NarwalMapCamera  # noqa: E402
 from custom_components.narwal.coordinator import NarwalCoordinator  # noqa: E402
 from custom_components.narwal.narwal_client import NarwalState  # noqa: E402
 from custom_components.narwal.narwal_client.const import WorkingStatus  # noqa: E402
@@ -176,3 +177,35 @@ class TestCoordinatorMapRefresh:
 
         assert coordinator._fast_poll_remaining == 0
         assert coordinator.update_interval == POLL_INTERVAL
+
+
+def test_custom_cleaning_starts_a_new_camera_trail() -> None:
+    """A custom room clean must reset the sampled trail like every clean status."""
+    state = NarwalState(working_status=WorkingStatus.CUSTOM_CLEANING)
+    coordinator = MagicMock()
+    coordinator.client.state = state
+    camera = NarwalMapCamera.__new__(NarwalMapCamera)
+    camera.coordinator = coordinator
+    camera._last_cleaning_status = WorkingStatus.STANDBY
+    camera._reset_trail = MagicMock()
+    camera.async_write_ha_state = MagicMock()
+
+    camera._handle_coordinator_update()
+
+    camera._reset_trail.assert_called_once_with()
+
+
+def test_remapping_does_not_start_a_cleaning_trail() -> None:
+    """Map exploration must not be recorded as cleaning history."""
+    state = NarwalState(working_status=WorkingStatus.REMAPPING)
+    coordinator = MagicMock()
+    coordinator.client.state = state
+    camera = NarwalMapCamera.__new__(NarwalMapCamera)
+    camera.coordinator = coordinator
+    camera._last_cleaning_status = WorkingStatus.STANDBY
+    camera._reset_trail = MagicMock()
+    camera.async_write_ha_state = MagicMock()
+
+    camera._handle_coordinator_update()
+
+    camera._reset_trail.assert_not_called()

--- a/tests/test_coordinator_map.py
+++ b/tests/test_coordinator_map.py
@@ -48,6 +48,8 @@ class TestCoordinatorMapRefresh:
         coordinator._last_display_map_resub = 0.0
         coordinator._last_status_resub = 0.0
         coordinator._prev_working_status = WorkingStatus.UNKNOWN
+        coordinator.active_clean_work_mode = None
+        coordinator.active_room_clean_settings = {}
         coordinator.update_interval = None
         coordinator.async_set_updated_data = MagicMock()
         def _close_background_task(*args: object) -> None:

--- a/tests/test_fan_speed.py
+++ b/tests/test_fan_speed.py
@@ -19,8 +19,14 @@ FLOW_2 = "QxMSPG6VSO"
 
 
 def test_canonical_labels_are_the_offered_list() -> None:
-    """The offered labels are the short forms, in ascending suction order."""
-    assert FAN_SPEED_LIST == ["Quiet", "Standard", "Strong", "Super", "Ultra"]
+    """The offered labels match the app, in ascending suction order."""
+    assert FAN_SPEED_LIST == [
+        "Quiet",
+        "Standard",
+        "Strong",
+        "Super Powerful",
+        "Ultra",
+    ]
 
 
 def test_canonical_labels_map_to_the_proto_enum() -> None:
@@ -29,13 +35,14 @@ def test_canonical_labels_map_to_the_proto_enum() -> None:
     assert FAN_SPEED_MAP["Standard"] is FanLevel.NORMAL
     assert FAN_SPEED_MAP["Strong"] is FanLevel.STRONG
     # #70 capture: the app's top tier ("super puissant") sends tag 2 = 4.
-    assert FAN_SPEED_MAP["Super"] is FanLevel.DEEP
-    assert int(FAN_SPEED_MAP["Super"]) == 4
+    assert FAN_SPEED_MAP["Super Powerful"] is FanLevel.DEEP
+    assert int(FAN_SPEED_MAP["Super Powerful"]) == 4
     assert FAN_SPEED_MAP["Ultra"] is FanLevel.SUPER
 
 
 def test_pre_rename_labels_still_resolve() -> None:
     """Labels shipped through v1.0.3 keep working in existing automations."""
+    assert FAN_SPEED_MAP["Super"] is FanLevel.DEEP
     assert FAN_SPEED_MAP["Super powerful"] is FanLevel.DEEP
     assert FAN_SPEED_MAP["Ultra powerful"] is FanLevel.SUPER
 
@@ -50,7 +57,7 @@ def test_lowercase_aliases_still_resolve() -> None:
 
 def test_aliases_are_not_offered_as_options() -> None:
     """Back-compat spellings are accepted but never shown in the picker."""
-    for alias in ("Super powerful", "Ultra powerful", "quiet", "max"):
+    for alias in ("Super", "Super powerful", "Ultra powerful", "quiet", "max"):
         assert alias not in FAN_SPEED_LIST
 
 
@@ -66,7 +73,7 @@ def test_ultra_withheld_where_the_app_cannot_reach_it() -> None:
         "Quiet",
         "Standard",
         "Strong",
-        "Super",
+        "Super Powerful",
     ]
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -433,6 +433,26 @@ class TestNarwalState:
         assert not state.has_assumed_robot_clean
         assert state.is_cleaning
 
+    def test_paused_context_handles_missing_task_metrics(self) -> None:
+        """Paused context is safe before richer task metric fields exist."""
+        state = NarwalState()
+        state.is_paused = True
+
+        assert not state.has_paused_clean_task_context
+
+        state.cleaning_time = 120
+
+        assert state.has_paused_clean_task_context
+
+    def test_paused_context_ignores_stale_metrics_after_docking(self) -> None:
+        """Docked API state ends stale paused overlays from the previous task."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 10, "2": 1, "10": 1}, "11": 2})
+        state.cleaning_time = 120
+        state.current_room_id = 4
+
+        assert not state.has_paused_clean_task_context
+
     def test_dock_task_assumption_is_only_a_short_command_guard(self) -> None:
         """Dock task assumptions must not fabricate long-running device state."""
         state = NarwalState()
@@ -611,15 +631,29 @@ class TestNarwalState:
         """
         from narwal_client import models as models_mod
 
-        models_mod._WARNED_WORKING_STATUS.discard(17)
+        models_mod._WARNED_WORKING_STATUS.discard(255)
         state = NarwalState()
         with caplog.at_level(logging.WARNING, logger=models_mod.__name__):
             for _ in range(50):
-                state.update_from_base_status({"3": {"1": 17}})
+                state.update_from_base_status({"3": {"1": 255}})
 
         warnings = [r for r in caplog.records if "Unknown working_status" in r.message]
         assert len(warnings) == 1
         assert state.working_status == WorkingStatus.UNKNOWN
+
+    def test_custom_cleaning_status_preserves_live_room_metrics(self) -> None:
+        """Status 17 is active custom cleaning, not an unknown idle state."""
+        state = NarwalState()
+        state.update_from_base_status(
+            {"3": {"1": 17, "14": 1, "17": 7}, "11": 1, "47": 2}
+        )
+        state.update_from_working_status({"3": 120, "6": 4})
+
+        assert state.working_status == WorkingStatus.CUSTOM_CLEANING
+        assert state.is_cleaning
+        assert not state.is_docked
+        assert state.current_room_id == 4
+        assert state.cleaning_time == 120
 
     def test_update_from_base_status(self) -> None:
         state = NarwalState()

--- a/tests/test_room_selection_switch.py
+++ b/tests/test_room_selection_switch.py
@@ -1,0 +1,216 @@
+"""Tests for Narwal room-selection switches."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import tests.ha_stubs  # noqa: E402
+
+tests.ha_stubs.install()
+
+from homeassistant.components.switch import SwitchEntity  # noqa: E402
+from homeassistant.exceptions import HomeAssistantError  # noqa: E402
+
+from custom_components.narwal.coordinator import NarwalCoordinator  # noqa: E402
+from custom_components.narwal.switch import (  # noqa: E402
+    NarwalRoomSelectionSwitch,
+    async_setup_entry,
+)
+from narwal_client import NarwalState  # noqa: E402
+from narwal_client.const import WorkingStatus  # noqa: E402
+from narwal_client.models import MapData, RoomInfo  # noqa: E402
+
+
+def _state(
+    working_status: WorkingStatus = WorkingStatus.DOCKED,
+) -> NarwalState:
+    """Return a Narwal state with one room map."""
+    state = NarwalState(working_status=working_status)
+    state.map_data = MapData(
+        map_id=100,
+        rooms=[RoomInfo(room_id=4, name="Kitchen")],
+    )
+    return state
+
+
+def _coordinator(state: NarwalState | None = None) -> NarwalCoordinator:
+    """Create a coordinator stub with real room-selection methods."""
+    state = state or _state()
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.data = {"device_id": "dev1"}
+    coordinator.config_entry.title = "Narwal Test"
+    coordinator.client = MagicMock()
+    coordinator.client.state = state
+    coordinator.client.state.firmware_version = "1.0.0"
+    coordinator.data = state
+    coordinator.last_update_success = True
+    coordinator.selected_clean_rooms = {}
+    coordinator.async_update_listeners = MagicMock()
+    coordinator.async_add_listener = MagicMock()
+    return coordinator
+
+
+def test_room_selection_switch_bases() -> None:
+    """Room selection switches expose coordinator-owned state."""
+    assert issubclass(NarwalRoomSelectionSwitch, SwitchEntity)
+
+
+async def test_room_selection_switch_updates_selected_rooms() -> None:
+    """Turning the switch on/off mutates the coordinator selection state."""
+    coordinator = _coordinator()
+    switch = NarwalRoomSelectionSwitch(coordinator, 4, "Kitchen", map_id="100")
+
+    assert not switch.is_on
+
+    await switch.async_turn_on()
+
+    assert switch.is_on
+    coordinator.async_update_listeners.assert_called_once()
+    assert coordinator.selected_clean_room_ids_for([4, 5], map_id="100") == [4]
+
+    await switch.async_turn_off()
+
+    assert not switch.is_on
+    assert coordinator.selected_clean_room_ids_for([4, 5], map_id="100") == [4, 5]
+    assert coordinator.async_update_listeners.call_count == 2
+
+
+def test_room_selection_switch_unavailable_during_active_clean() -> None:
+    """Room selection is locked while clean setup cannot be edited."""
+    coordinator = _coordinator(_state(WorkingStatus.CLEANING))
+    switch = NarwalRoomSelectionSwitch(coordinator, 4, "Kitchen", map_id="100")
+
+    assert not switch.available
+
+
+@pytest.mark.parametrize("turn_on", [True, False])
+async def test_room_selection_service_rejects_unavailable_switch(turn_on: bool) -> None:
+    """Direct service calls cannot bypass the room-selection availability guard."""
+    coordinator = _coordinator(_state(WorkingStatus.CLEANING))
+    coordinator.selected_clean_rooms = {"100": {4}}
+    switch = NarwalRoomSelectionSwitch(coordinator, 4, "Kitchen", map_id="100")
+
+    with pytest.raises(HomeAssistantError, match="cannot be changed"):
+        if turn_on:
+            await switch.async_turn_on()
+        else:
+            await switch.async_turn_off()
+
+    assert coordinator.selected_clean_rooms == {"100": {4}}
+    coordinator.async_update_listeners.assert_not_called()
+
+
+async def test_room_selection_service_rejects_stale_map() -> None:
+    """A switch from a prior map cannot persist selection into that stale map."""
+    coordinator = _coordinator()
+    switch = NarwalRoomSelectionSwitch(coordinator, 4, "Kitchen", map_id="old")
+
+    with pytest.raises(HomeAssistantError, match="cannot be changed"):
+        await switch.async_turn_on()
+
+    assert coordinator.selected_clean_rooms == {}
+
+
+async def test_removed_selected_room_can_be_deselected() -> None:
+    """A disappeared room cannot leave native starts permanently blocked."""
+    state = _state()
+    state.map_data.rooms = [RoomInfo(room_id=5, name="Hall")]
+    coordinator = _coordinator(state)
+    coordinator.selected_clean_rooms = {"100": {4}}
+    switch = NarwalRoomSelectionSwitch(coordinator, 4, "Kitchen", map_id="100")
+
+    assert switch.available
+    assert switch.is_on
+
+    await switch.async_turn_off()
+
+    assert coordinator.selected_clean_rooms == {}
+
+
+async def test_selected_switch_from_another_map_cannot_be_changed() -> None:
+    """Orphan recovery cannot mutate a selection belonging to a stale map."""
+    coordinator = _coordinator()
+    coordinator.selected_clean_rooms = {"old": {4}}
+    switch = NarwalRoomSelectionSwitch(coordinator, 4, "Kitchen", map_id="old")
+
+    assert not switch.available
+    with pytest.raises(HomeAssistantError, match="cannot be changed"):
+        await switch.async_turn_off()
+
+    assert coordinator.selected_clean_rooms == {"old": {4}}
+
+
+def test_room_selection_switch_uses_cached_map_while_coordinator_unavailable() -> None:
+    """A connectivity outage cannot lock a persisted next-clean selection."""
+    coordinator = _coordinator()
+    coordinator.last_update_success = False
+    switch = NarwalRoomSelectionSwitch(coordinator, 4, "Kitchen", map_id="100")
+
+    assert switch.available
+
+
+async def test_room_selection_entities_update_name_after_map_rename() -> None:
+    """Dynamic room selection switches follow map room renames."""
+    coordinator = _coordinator()
+    entry = MagicMock()
+    entry.runtime_data = coordinator
+    added_entities = []
+    listeners = []
+
+    def add_entities(entities) -> None:
+        added_entities.extend(list(entities))
+
+    coordinator.async_add_listener.side_effect = lambda listener: listeners.append(
+        listener
+    )
+
+    await async_setup_entry(MagicMock(), entry, add_entities)
+
+    room_switch = next(
+        entity
+        for entity in added_entities
+        if isinstance(entity, NarwalRoomSelectionSwitch)
+    )
+    assert room_switch._attr_name == "Kitchen selected"
+    assert room_switch.extra_state_attributes["room_name"] == "Kitchen"
+
+    coordinator.client.state.map_data = MapData(
+        map_id=100,
+        rooms=[RoomInfo(room_id=4, name="Pantry")],
+    )
+    listeners[0]()
+
+    assert room_switch._attr_name == "Pantry selected"
+    assert room_switch.extra_state_attributes["room_name"] == "Pantry"
+
+
+async def test_setup_exposes_same_map_orphan_for_deselection() -> None:
+    """A removed selected room remains recoverable after integration restart."""
+    state = _state()
+    state.map_data.rooms = [RoomInfo(room_id=5, name="Hall")]
+    coordinator = _coordinator(state)
+    coordinator.selected_clean_rooms = {"100": {4}}
+    entry = MagicMock()
+    entry.runtime_data = coordinator
+    added_entities = []
+
+    await async_setup_entry(
+        MagicMock(),
+        entry,
+        lambda entities: added_entities.extend(list(entities)),
+    )
+
+    orphan = next(
+        entity
+        for entity in added_entities
+        if isinstance(entity, NarwalRoomSelectionSwitch) and entity._room_id == 4
+    )
+    assert orphan.available
+    assert orphan.is_on
+
+    await orphan.async_turn_off()
+
+    assert coordinator.selected_clean_rooms == {}

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,505 @@
+"""Tests for Narwal domain services."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import tests.ha_stubs  # noqa: E402
+
+tests.ha_stubs.install()
+
+from homeassistant.exceptions import HomeAssistantError  # noqa: E402
+
+from custom_components.narwal import (  # noqa: E402
+    FIELD_MODE,
+    FIELD_MOP_STRENGTH,
+    FIELD_PASSES,
+    FIELD_ROOMS,
+    FIELD_ROUTE,
+    FIELD_SUCTION,
+    FIELD_WATER,
+    _async_register_services,
+    _async_room_ids_for_coordinator,
+    _async_validate_clean_rooms_targets,
+    _normalise_room_ids,
+    _validate_pass_count,
+)
+from custom_components.narwal.const import DOMAIN, SERVICE_CLEAN_ROOMS  # noqa: E402
+from custom_components.narwal.coordinator import (  # noqa: E402
+    CleanSettings,
+    NarwalCoordinator,
+    can_start_cleaning,
+)
+from custom_components.narwal.narwal_client import (  # noqa: E402
+    CommandResponse,
+    CommandResult,
+    FanLevel,
+    MapData,
+    NarwalState,
+    RoomInfo,
+    WorkingStatus,
+    WorkMode,
+)
+
+
+def _coordinator(
+    *,
+    docked: bool = True,
+    result_code: int = CommandResult.SUCCESS,
+    product_key: str = "QoEsI5qYXO",
+) -> NarwalCoordinator:
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    state = NarwalState()
+    if docked:
+        state.update_from_base_status({"3": {"1": 10, "10": 1}})
+    state.map_data = MapData(rooms=[RoomInfo(room_id=4), RoomInfo(room_id=7)])
+    coordinator.client = MagicMock()
+    coordinator.client.robot_awake = True
+    coordinator.client.state = state
+    coordinator.client.get_map = AsyncMock(return_value=state.map_data)
+    coordinator.client.start_rooms = AsyncMock(
+        return_value=CommandResponse(result_code=result_code)
+    )
+    coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+    coordinator.dock_action_lock = asyncio.Lock()
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.data = {"product_key": product_key}
+    coordinator.clean_settings = CleanSettings()
+    coordinator.room_clean_settings = {}
+    coordinator.room_clean_settings_customized = {}
+    coordinator.active_clean_work_mode = None
+    coordinator.data = state
+    coordinator.async_set_updated_data = MagicMock()
+    return coordinator
+
+
+def _register_clean_rooms_handler(coordinator: NarwalCoordinator):
+    """Register the test service handler for a coordinator."""
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"entry-1": coordinator}}
+    hass.services.has_service.return_value = False
+    handlers = {}
+
+    def register_service(domain: str, service_name: str, handler, **kwargs) -> None:
+        handlers[(domain, service_name)] = handler
+
+    hass.services.async_register.side_effect = register_service
+    registry = MagicMock()
+    registry.async_get.return_value = SimpleNamespace(
+        config_entry_id="entry-1",
+        platform=DOMAIN,
+    )
+    _async_register_services(hass)
+    return handlers[(DOMAIN, SERVICE_CLEAN_ROOMS)], registry
+
+
+def _clean_rooms_call() -> SimpleNamespace:
+    """Return a service call with non-default settings."""
+    return SimpleNamespace(
+        context=SimpleNamespace(user_id=None),
+        data={
+            FIELD_ROOMS: [4, 7],
+            FIELD_MODE: "vacuum_and_mop",
+            FIELD_SUCTION: "strong",
+            FIELD_WATER: "wet",
+            FIELD_MOP_STRENGTH: "high",
+            FIELD_PASSES: 2,
+            FIELD_ROUTE: "standard",
+        },
+    )
+
+
+def test_clean_rooms_schema_uses_all_capable_entity_validator() -> None:
+    """The service target validator must permit Home Assistant's `all` sentinel."""
+    import voluptuous as vol
+    from homeassistant.helpers import config_validation as cv
+
+    service_schemas = [
+        call.args[0]
+        for call in vol.Schema.call_args_list
+        if call.args and isinstance(call.args[0], dict) and FIELD_ROOMS in call.args[0]
+    ]
+    assert len(service_schemas) == 1
+    assert service_schemas[0]["entity_id"] is cv.comp_entity_ids
+
+
+async def test_clean_rooms_rejects_registry_only_target() -> None:
+    """A disabled or stale registry entry cannot address a loaded coordinator."""
+    hass = MagicMock()
+    hass.states.get.return_value = None
+    registry = MagicMock()
+    registry.async_get.return_value = SimpleNamespace(
+        config_entry_id="entry-1",
+        platform=DOMAIN,
+    )
+    call = SimpleNamespace(
+        context=SimpleNamespace(user_id=None),
+        data={"entity_id": "vacuum.downstairs_narwal"},
+    )
+
+    with (
+        patch("custom_components.narwal.er.async_get", return_value=registry),
+        pytest.raises(HomeAssistantError, match="Target must be a Narwal vacuum"),
+    ):
+        await _async_validate_clean_rooms_targets(
+            hass,
+            call,
+            ["vacuum.downstairs_narwal"],
+        )
+
+
+async def test_clean_rooms_service_starts_requested_rooms() -> None:
+    """The service path starts the requested room plan."""
+    coordinator = _coordinator()
+    handler, registry = _register_clean_rooms_handler(coordinator)
+    call = _clean_rooms_call()
+
+    with (
+        patch(
+            "custom_components.narwal.service.async_extract_entity_ids",
+            new_callable=AsyncMock,
+            return_value=["vacuum.downstairs_narwal"],
+        ) as extract_entity_ids,
+        patch("custom_components.narwal.er.async_get", return_value=registry),
+    ):
+        await handler(call)
+
+    extract_entity_ids.assert_awaited_once()
+    assert extract_entity_ids.await_args.args == (call,)
+    coordinator.client.start_rooms.assert_awaited_once()
+    assert coordinator.client.start_rooms.await_args.args[0] == [4, 7]
+    assert coordinator.client.state.has_assumed_robot_clean
+    assert coordinator.active_clean_work_mode == WorkMode.VACUUM_AND_MOP
+    assert not can_start_cleaning(coordinator.client.state)
+    coordinator.async_set_updated_data.assert_called_once_with(coordinator.client.state)
+
+
+async def test_clean_rooms_service_accepts_legacy_extract_signature() -> None:
+    """The service supports HA versions where extraction also takes hass."""
+    coordinator = _coordinator()
+    handler, registry = _register_clean_rooms_handler(coordinator)
+    call = _clean_rooms_call()
+    extract_entity_ids = AsyncMock(
+        side_effect=[TypeError, ["vacuum.downstairs_narwal"]]
+    )
+
+    with (
+        patch(
+            "custom_components.narwal.service.async_extract_entity_ids",
+            extract_entity_ids,
+        ),
+        patch("custom_components.narwal.er.async_get", return_value=registry),
+    ):
+        await handler(call)
+
+    assert extract_entity_ids.await_args_list[0].args == (call,)
+    legacy_args = extract_entity_ids.await_args_list[1].args
+    assert legacy_args[1] is call
+    assert legacy_args[0].data[DOMAIN]["entry-1"] is coordinator
+
+
+async def test_clean_rooms_service_accepts_async_accepted_response() -> None:
+    """The robot can accept a start with code 0 before reporting completion."""
+    coordinator = _coordinator(result_code=0)
+    handler, registry = _register_clean_rooms_handler(coordinator)
+    call = _clean_rooms_call()
+
+    with (
+        patch(
+            "custom_components.narwal.service.async_extract_entity_ids",
+            new_callable=AsyncMock,
+            return_value=["vacuum.downstairs_narwal"],
+        ),
+        patch("custom_components.narwal.er.async_get", return_value=registry),
+    ):
+        await handler(call)
+
+    coordinator.client.start_rooms.assert_awaited_once()
+    assert coordinator.client.state.has_assumed_robot_clean
+    coordinator.async_set_updated_data.assert_called_once_with(coordinator.client.state)
+
+
+async def test_clean_rooms_service_uses_requested_settings_over_room_profiles() -> None:
+    """Explicit service settings should not be silently overridden by room profiles."""
+    coordinator = _coordinator()
+    coordinator.set_room_clean_setting(4, "fan", FanLevel.MUTE)
+    handler, registry = _register_clean_rooms_handler(coordinator)
+    call = _clean_rooms_call()
+
+    with (
+        patch(
+            "custom_components.narwal.service.async_extract_entity_ids",
+            new_callable=AsyncMock,
+            return_value=["vacuum.downstairs_narwal"],
+        ),
+        patch("custom_components.narwal.er.async_get", return_value=registry),
+    ):
+        await handler(call)
+
+    kwargs = coordinator.client.start_rooms.await_args.kwargs
+    assert kwargs["room_settings"][4].fan == FanLevel.STRONG
+    assert kwargs["room_settings"][7].fan == FanLevel.STRONG
+
+
+async def test_clean_rooms_service_rejects_unavailable_start() -> None:
+    """The service enforces the same availability as the start entities."""
+    coordinator = _coordinator(docked=False)
+    handler, registry = _register_clean_rooms_handler(coordinator)
+
+    with (
+        patch(
+            "custom_components.narwal.service.async_extract_entity_ids",
+            new_callable=AsyncMock,
+            return_value=["vacuum.downstairs_narwal"],
+        ),
+        patch("custom_components.narwal.er.async_get", return_value=registry),
+        pytest.raises(Exception, match="cannot be started"),
+    ):
+        await handler(_clean_rooms_call())
+
+    coordinator.client.start_rooms.assert_not_awaited()
+
+
+async def test_clean_rooms_service_rejects_unknown_docked_status() -> None:
+    """Dock fields cannot authorize a clean from an unrecognized robot state."""
+    coordinator = _coordinator()
+    coordinator.client.state.working_status = WorkingStatus.UNKNOWN
+    handler, registry = _register_clean_rooms_handler(coordinator)
+
+    with (
+        patch(
+            "custom_components.narwal.service.async_extract_entity_ids",
+            new_callable=AsyncMock,
+            return_value=["vacuum.downstairs_narwal"],
+        ),
+        patch("custom_components.narwal.er.async_get", return_value=registry),
+        pytest.raises(HomeAssistantError, match="cannot be started"),
+    ):
+        await handler(_clean_rooms_call())
+
+    coordinator.client.start_rooms.assert_not_awaited()
+
+
+async def test_clean_rooms_service_preserves_settings_on_rejected_start() -> None:
+    """Rejected starts must not alter the pending settings for the next clean."""
+    coordinator = _coordinator(result_code=CommandResult.CONFLICT)
+    handler, registry = _register_clean_rooms_handler(coordinator)
+    original_settings = CleanSettings(**coordinator.clean_settings.__dict__)
+
+    with (
+        patch(
+            "custom_components.narwal.service.async_extract_entity_ids",
+            new_callable=AsyncMock,
+            return_value=["vacuum.downstairs_narwal"],
+        ),
+        patch("custom_components.narwal.er.async_get", return_value=registry),
+        pytest.raises(Exception, match="failed"),
+    ):
+        await handler(_clean_rooms_call())
+
+    assert coordinator.clean_settings == original_settings
+    assert not coordinator.client.state.has_assumed_robot_clean
+
+
+async def test_clean_rooms_service_rejects_unsupported_ultra_suction() -> None:
+    """AX26 must not silently map unsupported Ultra suction to Strong."""
+    coordinator = _coordinator(product_key="qV6BujoYLz")
+    handler, registry = _register_clean_rooms_handler(coordinator)
+    call = _clean_rooms_call()
+    call.data[FIELD_SUCTION] = "ultra"
+
+    with (
+        patch(
+            "custom_components.narwal.service.async_extract_entity_ids",
+            new_callable=AsyncMock,
+            return_value=["vacuum.downstairs_narwal"],
+        ),
+        patch("custom_components.narwal.er.async_get", return_value=registry),
+        pytest.raises(Exception, match="Ultra suction is not supported"),
+    ):
+        await handler(call)
+
+    coordinator.client.start_rooms.assert_not_awaited()
+
+
+async def test_clean_rooms_service_rejects_invalid_room_ids() -> None:
+    """Room IDs must be valid positive integers."""
+    coordinator = _coordinator()
+    handler, registry = _register_clean_rooms_handler(coordinator)
+    call = _clean_rooms_call()
+    call.data[FIELD_ROOMS] = [4, 0]
+
+    with (
+        patch(
+            "custom_components.narwal.service.async_extract_entity_ids",
+            new_callable=AsyncMock,
+            return_value=["vacuum.downstairs_narwal"],
+        ),
+        patch("custom_components.narwal.er.async_get", return_value=registry),
+        pytest.raises(Exception, match="positive"),
+    ):
+        await handler(call)
+
+    coordinator.client.start_rooms.assert_not_awaited()
+
+
+def test_room_id_validation_rejects_fractional_values() -> None:
+    """Room IDs must not be silently truncated by int coercion."""
+    with pytest.raises(Exception, match="Invalid Narwal room ID"):
+        _normalise_room_ids([4.5])
+
+
+def test_pass_count_validation_rejects_fractional_values() -> None:
+    """Pass counts must not be silently truncated by int coercion."""
+    with pytest.raises(Exception, match="integer"):
+        _validate_pass_count(2.5)
+
+
+async def test_clean_rooms_service_rejects_unknown_room_ids() -> None:
+    """Room IDs must exist on the active map."""
+    coordinator = _coordinator()
+    handler, registry = _register_clean_rooms_handler(coordinator)
+    call = _clean_rooms_call()
+    call.data[FIELD_ROOMS] = [4, 99]
+
+    with (
+        patch(
+            "custom_components.narwal.service.async_extract_entity_ids",
+            new_callable=AsyncMock,
+            return_value=["vacuum.downstairs_narwal"],
+        ),
+        patch("custom_components.narwal.er.async_get", return_value=registry),
+        pytest.raises(Exception, match="Unknown Narwal room ID"),
+    ):
+        await handler(call)
+
+    coordinator.client.start_rooms.assert_not_awaited()
+
+
+async def test_clean_rooms_service_refreshes_room_topology() -> None:
+    """Service validation uses the current map after room edits."""
+    coordinator = _coordinator()
+    coordinator.client.state.map_data = MapData(
+        map_id=1,
+        rooms=[RoomInfo(room_id=4)],
+    )
+
+    async def refresh_map() -> MapData:
+        coordinator.client.state.map_data = MapData(
+            map_id=1,
+            rooms=[RoomInfo(room_id=7)],
+        )
+        return coordinator.client.state.map_data
+
+    coordinator.client.get_map = AsyncMock(side_effect=refresh_map)
+
+    room_ids = await _async_room_ids_for_coordinator(coordinator, [7])
+
+    assert room_ids == [7]
+    coordinator.client.get_map.assert_awaited_once()
+
+
+async def test_clean_rooms_service_rejects_unloaded_target_before_starting() -> None:
+    """Every explicit Narwal vacuum target must resolve to a loaded coordinator."""
+    coordinator = _coordinator()
+    handler, registry = _register_clean_rooms_handler(coordinator)
+    registry.async_get.return_value = SimpleNamespace(
+        config_entry_id="entry-missing",
+        platform=DOMAIN,
+    )
+
+    with (
+        patch(
+            "custom_components.narwal.service.async_extract_entity_ids",
+            new_callable=AsyncMock,
+            return_value=["vacuum.downstairs_narwal"],
+        ),
+        patch("custom_components.narwal.er.async_get", return_value=registry),
+        pytest.raises(Exception, match="not loaded"),
+    ):
+        await handler(_clean_rooms_call())
+
+    coordinator.client.start_rooms.assert_not_awaited()
+
+
+async def test_clean_rooms_service_rejects_all_mixed_with_explicit_room_ids() -> None:
+    """The `all` shortcut must not be embedded with explicit room IDs."""
+    coordinator = _coordinator()
+
+    with pytest.raises(Exception, match='either "all" or explicit room IDs'):
+        await _async_room_ids_for_coordinator(coordinator, ["all, 4"])
+
+
+async def test_clean_rooms_service_rejects_multiple_vacuums_before_side_effects() -> None:
+    """A single service call cannot partially start multiple vacuums."""
+    first = _coordinator()
+    first.client.robot_awake = False
+    first.client.wake = AsyncMock()
+    second = _coordinator()
+
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"entry-1": first, "entry-2": second}}
+    hass.services.has_service.return_value = False
+    handlers = {}
+
+    def register_service(domain: str, service_name: str, handler, **kwargs) -> None:
+        handlers[(domain, service_name)] = handler
+
+    hass.services.async_register.side_effect = register_service
+    registry = MagicMock()
+    registry.async_get.side_effect = lambda entity_id: {
+        "vacuum.first_narwal": SimpleNamespace(
+            config_entry_id="entry-1",
+            platform=DOMAIN,
+        ),
+        "vacuum.second_narwal": SimpleNamespace(
+            config_entry_id="entry-2",
+            platform=DOMAIN,
+        ),
+    }[entity_id]
+    _async_register_services(hass)
+    handler = handlers[(DOMAIN, SERVICE_CLEAN_ROOMS)]
+
+    with (
+        patch(
+            "custom_components.narwal.service.async_extract_entity_ids",
+            new_callable=AsyncMock,
+            return_value=["vacuum.first_narwal", "vacuum.second_narwal"],
+        ),
+        patch("custom_components.narwal.er.async_get", return_value=registry),
+        pytest.raises(Exception, match="exactly one Narwal vacuum"),
+    ):
+        await handler(_clean_rooms_call())
+
+    first.client.wake.assert_not_awaited()
+    first.client.start_rooms.assert_not_awaited()
+    second.client.start_rooms.assert_not_awaited()
+
+
+async def test_clean_rooms_service_wakes_targets_before_start_preflight() -> None:
+    """Sleeping targets are woken before state-dependent start checks run."""
+    coordinator = _coordinator(docked=False)
+    coordinator.client.robot_awake = False
+    coordinator.client.wake = AsyncMock(
+        side_effect=lambda **_: coordinator.client.state.update_from_base_status(
+            {"3": {"1": 10, "10": 1}, "11": 2}
+        )
+    )
+    handler, registry = _register_clean_rooms_handler(coordinator)
+
+    with (
+        patch(
+            "custom_components.narwal.service.async_extract_entity_ids",
+            new_callable=AsyncMock,
+            return_value=["vacuum.downstairs_narwal"],
+        ),
+        patch("custom_components.narwal.er.async_get", return_value=registry),
+    ):
+        await handler(_clean_rooms_call())
+
+    coordinator.client.wake.assert_awaited_once_with(timeout=10.0)
+    coordinator.client.start_rooms.assert_awaited_once()

--- a/tests/test_vacuum_segments.py
+++ b/tests/test_vacuum_segments.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -18,12 +18,24 @@ import tests.ha_stubs  # noqa: E402
 
 tests.ha_stubs.install()
 
-from homeassistant.components.vacuum import VacuumEntityFeature  # noqa: E402
 from homeassistant.exceptions import HomeAssistantError  # noqa: E402
 
-from custom_components.narwal.coordinator import CleanSettings  # noqa: E402
-from custom_components.narwal.vacuum import NarwalVacuum  # noqa: E402
-from narwal_client.const import CommandResult, WorkingStatus  # noqa: E402
+from custom_components.narwal.coordinator import (  # noqa: E402
+    CleanSettings,
+    NarwalCoordinator,
+    is_clean_session_context,
+)
+from custom_components.narwal.vacuum import (  # noqa: E402
+    FanSettingRestoreData,
+    NarwalVacuum,
+)
+from narwal_client import RoomCleanSettings  # noqa: E402
+from narwal_client.const import (  # noqa: E402
+    CommandResult,
+    FanLevel,
+    WorkingStatus,
+    WorkMode,
+)
 from narwal_client.models import (  # noqa: E402
     DOCK_TASK_DRY_DOCK_BAG,
     DOCK_TASK_DRY_MOP,
@@ -34,6 +46,7 @@ from narwal_client.models import (  # noqa: E402
 )
 
 Segment = sys.modules["homeassistant.components.vacuum"].Segment
+VacuumEntityFeature = sys.modules["homeassistant.components.vacuum"].VacuumEntityFeature
 
 
 def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
@@ -50,8 +63,38 @@ def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
     coordinator.client.get_map = AsyncMock(return_value=client_state.map_data)
     coordinator.last_update_success = True
     coordinator.clean_settings = CleanSettings()
+    coordinator.active_clean_work_mode = None
+    coordinator.active_clean_setting.return_value = None
+    coordinator.has_selected_clean_rooms.return_value = False
     coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
     coordinator.dock_action_lock = asyncio.Lock()
+    coordinator.room_clean_settings_for_rooms = MagicMock(
+        side_effect=lambda room_ids, **_kwargs: {
+            room_id: RoomCleanSettings() for room_id in room_ids
+        }
+    )
+    coordinator.selected_clean_room_ids_for = MagicMock(
+        side_effect=lambda room_ids, **_kwargs: list(room_ids)
+    )
+    coordinator.shared_room_clean_work_mode = MagicMock(
+        side_effect=lambda room_settings: next(
+            iter({settings.work_mode for settings in room_settings.values()}), None
+        )
+    )
+    coordinator.record_accepted_clean_start = MagicMock(
+        side_effect=lambda room_settings: setattr(
+            coordinator,
+            "active_clean_work_mode",
+            next(iter({settings.work_mode for settings in room_settings.values()})),
+        )
+    )
+    coordinator.clean_setting_applicability_mode = MagicMock(
+        side_effect=lambda live=False: (
+            coordinator.active_clean_work_mode
+            if live and is_clean_session_context(coordinator.data)
+            else coordinator.clean_settings.work_mode
+        )
+    )
 
     vac = NarwalVacuum.__new__(NarwalVacuum)
     vac.coordinator = coordinator
@@ -64,6 +107,13 @@ def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
     vac.async_write_ha_state = MagicMock()
 
     return vac
+
+
+def _active_clean_state() -> NarwalState:
+    """Return a state whose working_status still looks like active cleaning."""
+    state = NarwalState()
+    state.working_status = WorkingStatus.CLEANING_ALT
+    return state
 
 
 def _docked_state() -> NarwalState:
@@ -210,6 +260,40 @@ class TestAsyncCleanSegments:
             water=settings.water,
             mop_strength=settings.mop_strength,
             passes=settings.passes,
+            route=settings.route,
+            room_settings={
+                11: RoomCleanSettings(),
+                9: RoomCleanSettings(),
+            },
+        )
+        assert state.has_assumed_robot_clean
+        vac.async_write_ha_state.assert_called_once()
+
+    async def test_deduplicates_segment_ids_without_changing_order(self) -> None:
+        """Repeated HA segment IDs produce one ordered clean item per room."""
+        state = _docked_state()
+        state.map_data = MapData(rooms=[RoomInfo(room_id=11), RoomInfo(room_id=9)])
+        vac = _make_vacuum(state=state)
+        settings = vac.coordinator.clean_settings
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+        vac.coordinator.client.robot_awake = True
+
+        await vac.async_clean_segments(["11", "9", "11"])
+
+        vac.coordinator.client.start_rooms.assert_awaited_once_with(
+            [11, 9],
+            work_mode=settings.work_mode,
+            fan=settings.fan,
+            water=settings.water,
+            mop_strength=settings.mop_strength,
+            passes=settings.passes,
+            route=settings.route,
+            room_settings={
+                11: RoomCleanSettings(),
+                9: RoomCleanSettings(),
+            },
         )
 
     async def test_segment_clean_accepted_response_does_not_warn(self, caplog) -> None:
@@ -253,6 +337,35 @@ class TestAsyncCleanSegments:
         await vac.async_clean_segments(["11"])
 
         assert state.has_assumed_robot_clean
+        vac.coordinator.record_accepted_clean_start.assert_called_once()
+
+    async def test_mixed_room_modes_start_as_one_custom_task(self) -> None:
+        """Mixed room profiles dispatch together without flattening their modes."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=11), RoomInfo(room_id=12)],
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        room_settings = {
+            11: RoomCleanSettings(work_mode=WorkMode.MOP),
+            12: RoomCleanSettings(work_mode=WorkMode.VACUUM),
+        }
+        vac.coordinator.room_clean_settings_for_rooms = MagicMock(
+            return_value=room_settings
+        )
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_clean_segments(["11", "12"])
+
+        vac.coordinator.client.start_rooms.assert_awaited_once()
+        assert (
+            vac.coordinator.client.start_rooms.await_args.kwargs["room_settings"]
+            == room_settings
+        )
 
     async def test_rejected_room_clean_raises_service_error(self) -> None:
         """Rejected clean/start_clean responses fail the HA service call."""
@@ -274,7 +387,7 @@ class TestAsyncCleanSegments:
         vac = _make_vacuum(state=state)
         vac.coordinator.client.robot_awake = True
         vac.coordinator.client.start_rooms = AsyncMock(
-            return_value=MagicMock(result_code=0, success=True)
+            return_value=CommandResponse(result_code=0)
         )
         await vac.coordinator.dock_action_lock.acquire()
 
@@ -331,23 +444,75 @@ class TestAsyncCleanSegments:
         vac.coordinator.client.get_map.assert_awaited_once()
         vac.coordinator.client.start_rooms.assert_awaited_once()
 
+    async def test_segment_validation_rejects_failed_map_refresh(self) -> None:
+        """A cached room cannot authorize cleaning after refresh failure."""
+        state = _docked_state()
+        state.map_data = MapData(map_id=2, rooms=[RoomInfo(room_id=11)])
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.get_map = AsyncMock(side_effect=RuntimeError("offline"))
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="map could not be refreshed"):
+            await vac.async_clean_segments(["11"])
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
     async def test_empty_cached_room_table_defers_validation_to_client(self) -> None:
         """A payloadless cached map must not reject every known HA segment."""
         state = _docked_state()
         state.map_data = MapData()
         vac = _make_vacuum(state=state)
         vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.get_map = AsyncMock(
+            side_effect=lambda: setattr(
+                state,
+                "map_data",
+                MapData(map_id=2, rooms=[RoomInfo(room_id=11)]),
+            )
+        )
         vac.coordinator.client.start_rooms = AsyncMock(
             return_value=CommandResponse(result_code=CommandResult.SUCCESS)
         )
 
         await vac.async_clean_segments(["11"])
 
+        vac.coordinator.client.get_map.assert_awaited_once()
         vac.coordinator.client.start_rooms.assert_awaited_once()
 
 
 class TestDockTaskRobotActionGates:
     """Dock work must not leak unsafe robot controls through the vacuum."""
+
+    def test_unknown_active_mode_hides_native_fan_control(self) -> None:
+        """A reload cannot advertise suction before task mode is reconstructed."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        vac = _make_vacuum(state)
+        vac.coordinator.active_clean_work_mode = None
+
+        assert not vac.supported_features & VacuumEntityFeature.FAN_SPEED
+
+    def test_idle_mop_mode_hides_native_fan_control(self) -> None:
+        """Feature advertisement matches the pending fan command handler."""
+        vac = _make_vacuum(_docked_state())
+        vac.coordinator.clean_settings.work_mode = WorkMode.MOP
+
+        assert not vac.supported_features & VacuumEntityFeature.FAN_SPEED
+
+    def test_selected_rooms_hide_pending_native_fan_control(self) -> None:
+        """Room profiles, not the whole-floor fan command, own selected jobs."""
+        vac = _make_vacuum(_docked_state())
+        vac.coordinator.has_selected_clean_rooms.return_value = True
+
+        assert not vac.supported_features & VacuumEntityFeature.FAN_SPEED
+
+    def test_unread_profiles_hide_new_clean_actions(self) -> None:
+        """Advertised actions must agree with profile-authority guards."""
+        vac = _make_vacuum(_docked_state())
+        vac.coordinator._room_profile_store_loaded = False
+
+        assert not vac.supported_features & VacuumEntityFeature.START
+        assert not vac.supported_features & VacuumEntityFeature.CLEAN_AREA
 
     @staticmethod
     def _active_dock_vacuum() -> NarwalVacuum:
@@ -394,6 +559,151 @@ class TestDockTaskRobotActionGates:
 
         command.assert_not_awaited()
 
+
+class TestVacuumFanSpeed:
+    def test_fan_speed_reports_active_room_profile(self) -> None:
+        """The vacuum entity reports the dispatched room fan while cleaning."""
+        vac = _make_vacuum(state=_active_clean_state())
+        vac.coordinator.clean_settings.fan = FanLevel.NORMAL
+        vac.coordinator.active_clean_setting.return_value = FanLevel.STRONG
+
+        assert vac.fan_speed == "Strong"
+
+    async def test_restore_none_fan_speed_as_ai_suction(self) -> None:
+        """HA persists AI fan_speed as None; restore it as FanLevel.UNSPECIFIED."""
+        vac = _make_vacuum(state=_docked_state())
+        vac.coordinator.clean_settings.fan = FanLevel.NORMAL
+
+        with patch.object(
+            vac,
+            "async_get_last_state",
+            AsyncMock(return_value=MagicMock(attributes={"fan_speed": None})),
+        ):
+            await vac.async_added_to_hass()
+
+        assert vac.coordinator.clean_settings.fan == FanLevel.UNSPECIFIED
+
+    async def test_live_fan_change_applies_while_paused(self) -> None:
+        state = _active_clean_state()
+        state.is_paused = True
+        vac = _make_vacuum(state=state)
+        vac.coordinator.active_clean_work_mode = WorkMode.VACUUM
+        vac.coordinator.client.set_fan_speed = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+
+        await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_awaited_once_with(FanLevel.STRONG)
+        assert vac.coordinator.clean_settings.fan == FanLevel.STRONG
+        vac.coordinator.set_active_clean_setting.assert_called_once_with(
+            "fan", FanLevel.STRONG
+        )
+
+    async def test_fan_change_stages_when_unavailable_idle(self) -> None:
+        """Idle pending fan changes do not need a live coordinator connection."""
+        state = _docked_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.last_update_success = False
+        vac.coordinator.client.set_fan_speed = AsyncMock()
+
+        await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_not_awaited()
+        assert vac.coordinator.clean_settings.fan == FanLevel.STRONG
+
+    async def test_fan_change_rejected_when_entity_unavailable(self) -> None:
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.last_update_success = False
+        vac.coordinator.client.set_fan_speed = AsyncMock()
+
+        with pytest.raises(Exception, match="fan speed cannot be changed"):
+            await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_not_awaited()
+
+    async def test_live_fan_change_uses_active_room_mode(self) -> None:
+        """Live fan gating follows the accepted room mode, not pending global mode."""
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.clean_settings.work_mode = WorkMode.MOP
+        vac.coordinator.active_clean_work_mode = WorkMode.VACUUM
+        vac.coordinator.client.set_fan_speed = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+
+        await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_awaited_once_with(FanLevel.STRONG)
+        assert vac.coordinator.clean_settings.fan == FanLevel.STRONG
+
+    async def test_selected_rooms_block_pending_native_fan_change(self) -> None:
+        """The vacuum service cannot alter global fallback for selected rooms."""
+        vac = _make_vacuum(state=_docked_state())
+        vac.coordinator.has_selected_clean_rooms.return_value = True
+        vac.coordinator.clean_settings.fan = FanLevel.NORMAL
+
+        with pytest.raises(HomeAssistantError, match="cannot be changed"):
+            await vac.async_set_fan_speed("Strong")
+
+        assert vac.coordinator.clean_settings.fan == FanLevel.NORMAL
+
+    async def test_selected_rooms_keep_live_fan_change_runtime_only(self) -> None:
+        """A selected-room task accepts live suction without changing defaults."""
+        vac = _make_vacuum(state=_active_clean_state())
+        vac.coordinator.has_selected_clean_rooms.return_value = True
+        vac.coordinator.active_clean_work_mode = WorkMode.VACUUM
+        vac.coordinator.clean_settings.fan = FanLevel.NORMAL
+        vac.coordinator.client.set_fan_speed = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+
+        await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_awaited_once_with(FanLevel.STRONG)
+        vac.coordinator.set_active_clean_setting.assert_called_once_with(
+            "fan", FanLevel.STRONG
+        )
+        assert vac.coordinator.clean_settings.fan == FanLevel.NORMAL
+
+    async def test_live_fan_change_rejects_active_mop_mode(self) -> None:
+        """Pending vacuum mode must not expose fan control for an active mop-only task."""
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.clean_settings.work_mode = WorkMode.VACUUM
+        vac.coordinator.active_clean_work_mode = WorkMode.MOP
+        vac.coordinator.client.set_fan_speed = AsyncMock()
+
+        with pytest.raises(Exception, match="fan speed cannot be changed|mop-only"):
+            await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_not_awaited()
+
+    async def test_fan_change_rejected_in_mop_only_mode(self) -> None:
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.clean_settings.work_mode = WorkMode.MOP
+        vac.coordinator.client.set_fan_speed = AsyncMock()
+
+        with pytest.raises(Exception, match="mop-only mode"):
+            await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_not_awaited()
+
+    async def test_rejected_live_fan_change_does_not_update_settings(self) -> None:
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.active_clean_work_mode = WorkMode.VACUUM
+        vac.coordinator.client.set_fan_speed = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        )
+        vac.coordinator.clean_settings.fan = FanLevel.NORMAL
+
+        with pytest.raises(Exception, match="set fan speed failed"):
+            await vac.async_set_fan_speed("Strong")
+
+        assert vac.coordinator.clean_settings.fan == FanLevel.NORMAL
 
 class TestCheckSegmentChanges:
     """Tests for _check_segment_changes."""
@@ -459,10 +769,96 @@ class TestCheckSegmentChanges:
 
 
 class TestAsyncStartWholeHouse:
-    """async_start runs a whole-house clean via start_rooms(all rooms), not the saved plan."""
+    """async_start runs a room-selection aware clean via clean/start_clean."""
+
+    async def test_paused_returning_standby_resumes_existing_clean(self) -> None:
+        """Paused return context takes precedence over a stale status enum."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.is_paused = True
+        state.is_returning_to_dock = True
+        state.dock_sub_state = 2
+        state.task_elapsed_time = 60
+        state.dock_presence = 2
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.resume = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        await vac.async_start()
+
+        vac.coordinator.client.resume.assert_awaited_once()
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_rejected_resume_fails_native_start(self) -> None:
+        """A rejected resume cannot be reported to HA as a successful start."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.is_paused = True
+        state.task_elapsed_time = 60
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.resume = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        )
+
+        with pytest.raises(HomeAssistantError, match="resume failed"):
+            await vac.async_start()
+
+    @pytest.mark.parametrize(
+        "working_status", (WorkingStatus.ERROR, WorkingStatus.TASK_COMPLETED)
+    )
+    async def test_terminal_status_does_not_resume_stale_paused_context(
+        self, working_status: WorkingStatus
+    ) -> None:
+        """A terminal packet takes precedence over its stale paused overlay."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.assume_robot_clean()
+        state.update_from_base_status(
+            {"3": {"1": int(working_status), "2": 1}}
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.resume = AsyncMock()
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError):
+            await vac.async_start()
+
+        vac.coordinator.client.resume.assert_not_awaited()
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_hardware_fault_does_not_resume_stale_paused_context(self) -> None:
+        """ErrorCode telemetry blocks resume even with a non-error status enum."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.assume_robot_clean()
+        state.update_from_base_status(
+            {"1": {"1": 2105}, "3": {"1": int(WorkingStatus.STANDBY), "2": 1}}
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.resume = AsyncMock()
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError):
+            await vac.async_start()
+
+        vac.coordinator.client.resume.assert_not_awaited()
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_unread_room_profiles_block_native_start(self) -> None:
+        """A start cannot substitute defaults for unread durable profiles."""
+        vac = _make_vacuum(state=_docked_state())
+        vac.coordinator._room_profile_store_loaded = False
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="not restored"):
+            await vac.async_start()
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
 
     async def test_enumerates_all_rooms(self, caplog) -> None:
-        """Whole-house start passes every room id to clean/start_clean, skipping plan/start."""
+        """With no selected rooms, start passes every room id to clean/start_clean."""
         state = _docked_state()
         state.map_data = MapData(map_id=2, rooms=[
             RoomInfo(room_id=1), RoomInfo(room_id=2), RoomInfo(room_id=0),  # 0 filtered
@@ -479,12 +875,136 @@ class TestAsyncStartWholeHouse:
 
         vac.coordinator.client.start_rooms.assert_awaited_once()
         assert vac.coordinator.client.start_rooms.await_args.args[0] == [1, 2]
+        vac.coordinator.selected_clean_room_ids_for.assert_called_once_with(
+            [1, 2], map_id=vac.coordinator.room_settings_map_id.return_value
+        )
         vac.coordinator.client.start.assert_not_called()
         assert "Start command was rejected" not in caplog.text
         assert state.has_assumed_robot_clean
 
-    async def test_falls_back_to_saved_plan_without_map(self) -> None:
-        """With no map rooms available, falls back to the saved-plan start()."""
+    async def test_start_uses_selected_rooms(self) -> None:
+        """Selected room switches narrow the native vacuum start command."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=1), RoomInfo(room_id=2)],
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.selected_clean_room_ids_for = MagicMock(return_value=[2])
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+
+        await vac.async_start()
+
+        vac.coordinator.selected_clean_room_ids_for.assert_called_once_with(
+            [1, 2], map_id=vac.coordinator.room_settings_map_id.return_value
+        )
+        vac.coordinator.room_clean_settings_for_rooms.assert_called_once_with(
+            [2], map_id=vac.coordinator.room_settings_map_id.return_value
+        )
+        vac.coordinator.client.start_rooms.assert_awaited_once()
+        assert vac.coordinator.client.start_rooms.await_args.args[0] == [2]
+
+    async def test_start_rejects_non_authoritative_room_selection(self) -> None:
+        """A failed selection restore cannot broaden START to every room."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=1), RoomInfo(room_id=2)],
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.selected_clean_room_ids_for = MagicMock(return_value=[])
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="selection is not available"):
+            await vac.async_start()
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_start_rejects_explicit_selection_without_map_identity(self) -> None:
+        """An unidentified refreshed map cannot broaden a scoped selection."""
+        state = _docked_state()
+        state.map_data = MapData(
+            rooms=[RoomInfo(room_id=4), RoomInfo(room_id=5)],
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.selected_clean_rooms = {"100": {4}}
+        vac.coordinator.room_settings_map_id.return_value = None
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="selection is not available"):
+            await vac.async_start()
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_start_scopes_selection_to_map_fetched_after_start(self) -> None:
+        """START resolves selection against the freshly fetched map identity."""
+        state = _docked_state()
+        state.map_data = MapData(map_id=100, rooms=[RoomInfo(room_id=4)])
+        vac = _make_vacuum(state=state)
+        vac.coordinator.selected_clean_rooms = {"100": {4}, "200": {5}}
+        vac.coordinator.room_settings_map_id = MagicMock(
+            side_effect=lambda map_data=None: (
+                str(map_data.map_id) if map_data is not None else None
+            )
+        )
+        vac.coordinator.selected_clean_room_ids_for = MagicMock(
+            side_effect=lambda room_ids, **kwargs: (
+                NarwalCoordinator.selected_clean_room_ids_for(
+                    vac.coordinator,
+                    room_ids,
+                    **kwargs,
+                )
+            )
+        )
+
+        async def get_map() -> None:
+            state.map_data = MapData(
+                map_id=200,
+                rooms=[RoomInfo(room_id=4), RoomInfo(room_id=5)],
+            )
+
+        vac.coordinator.client.get_map = AsyncMock(side_effect=get_map)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+
+        await vac.async_start()
+
+        vac.coordinator.selected_clean_room_ids_for.assert_called_once_with(
+            [4, 5], map_id="200"
+        )
+        assert vac.coordinator.client.start_rooms.await_args.args[0] == [5]
+
+    async def test_whole_house_start_passes_room_profiles(self) -> None:
+        """Whole-house start uses room-specific profiles for each room."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=1), RoomInfo(room_id=2)],
+        )
+        profile = RoomCleanSettings(fan=FanLevel.STRONG)
+        vac = _make_vacuum(state=state)
+        vac.coordinator.room_clean_settings_for_rooms = MagicMock(
+            return_value={1: profile, 2: RoomCleanSettings()}
+        )
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_start()
+
+        kwargs = vac.coordinator.client.start_rooms.await_args.kwargs
+        assert kwargs["room_settings"] == {1: profile, 2: RoomCleanSettings()}
+
+    async def test_whole_house_without_map_raises(self) -> None:
+        """With no map rooms available, no ambiguous start command is sent."""
         state = _docked_state()  # no map_data
         vac = _make_vacuum(state=state)
         vac.coordinator.client.robot_awake = True
@@ -494,9 +1014,10 @@ class TestAsyncStartWholeHouse:
         )
         vac.coordinator.client.start_rooms = AsyncMock()
 
-        await vac.async_start()
+        with pytest.raises(HomeAssistantError, match="room map is not available"):
+            await vac.async_start()
 
-        vac.coordinator.client.start.assert_awaited_once()
+        vac.coordinator.client.start.assert_not_awaited()
         vac.coordinator.client.start_rooms.assert_not_called()
 
     async def test_rejected_whole_house_start_raises_service_error(self) -> None:
@@ -513,8 +1034,55 @@ class TestAsyncStartWholeHouse:
             await vac.async_start()
 
 
+async def test_fan_restore_prefers_pending_value_over_active_room_display() -> None:
+    """An active room's displayed fan must not replace the pending default."""
+    vac = _make_vacuum(state=_docked_state())
+    extra = FanSettingRestoreData(value=int(FanLevel.DEEP))
+
+    with (
+        patch.object(
+            vac,
+            "async_get_last_state",
+            AsyncMock(return_value=MagicMock(attributes={"fan_speed": "Strong"})),
+        ),
+        patch.object(
+            vac,
+            "async_get_last_extra_data",
+            AsyncMock(return_value=extra),
+        ),
+    ):
+        await vac.async_added_to_hass()
+
+    assert vac.coordinator.clean_settings.fan == FanLevel.DEEP
+
+
+def test_fan_extra_restore_data_records_pending_value() -> None:
+    """Vacuum restore data is sourced from the pending global setting."""
+    vac = _make_vacuum(state=_active_clean_state())
+    vac.coordinator.clean_settings.fan = FanLevel.NORMAL
+    vac.coordinator.active_clean_setting.return_value = FanLevel.STRONG
+
+    assert vac.extra_restore_state_data.as_dict()["value"] == int(FanLevel.NORMAL)
+
+
 class TestAsyncStop:
     """Tests for stop routing between robot and dock task contexts."""
+
+    async def test_paused_standby_stops_existing_clean(self) -> None:
+        """Stop honors retained paused task context after a stale status enum."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        state.is_paused = True
+        state.task_elapsed_time = 60
+        state.dock_presence = 2
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_stop()
+
+        vac.coordinator.client.stop.assert_awaited_once()
 
     async def test_stop_routes_dock_only_task_through_dock_policy(self) -> None:
         state = NarwalState(working_status=WorkingStatus.DOCKED)


### PR DESCRIPTION
## Summary
- add route-aware global and per-room Narwal clean profiles
- preserve independent room modes in mixed whole-map and selected-room jobs using Narwal custom-clean task type 6
- expose work mode, suction, water, mop strength, route, passes, and integration-owned room selection entities
- make native `vacuum.start` clean selected rooms, falling back to all known rooms and their individual profiles
- add explicit `narwal.clean_rooms` and `vacuum.clean_segments` command surfaces that do not depend on UI selection
- decode custom-clean status 17 so live room and progress telemetry remain available
- persist raw global/room settings and explicit room selections independently of entity availability and display labels
- keep pending setup controls editable while the robot is unreachable and gate live controls by the accepted room profile

## Why
Room cleaning needs a complete `CleanParam` payload, not just a room id. Narwal uses task type 6 for custom jobs containing different per-room modes; uniform jobs retain their normal work-mode task type. This preserves each room's configured behavior instead of flattening a mixed floor into one global mode. Untouched room fields follow the global profile until the user explicitly configures them.

Structured restore data stores protocol enum values rather than visible labels. That keeps unavailable startup states and later presentation-only label changes from altering the cleaning behavior that Home Assistant restores.

## Commit layout
1. encode per-room settings in the client protocol
2. model global, room, selected-room, and active profiles in the coordinator
3. add explicit room-cleaning services
4. expose and restore cleaning-profile entities
5. apply selected/all-room profiles through native vacuum starts

## Runtime validation
On Flow 2 hardware running v01.09.09.05, native `vacuum.start` accepted one seven-room task containing five vacuum-only rooms and two vacuum-and-mop rooms. The robot reported task type 6 and retained each room's requested mode, suction, route, and two-pass setting. Home Assistant reported the active room and progress, including after a restart during the job.

A separate restart while every room profile and selection entity was unavailable retained the explicit Bathroom profile and the one-room selection through structured restore data; all values returned unchanged after the robot was stopped and docked.

## Stack
#85 and #86 are already merged. This branch contains the five room-settings commits ending at `a00e31c`.