### PR TITLE
feat(vacuum): expose live task state through vacuum entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Shipped in v1.0.2 ([#50](https://github.com/sjmotew/NarwalIntegration/pull/50)) 
 - Battery level, cleaning time, firmware version
 - Docked status (binary sensor), charging state (Charging / Fully Charged / Not Charging)
 - Cleaning area — reports real covered area as of v1.0.1 ([#51](https://github.com/sjmotew/NarwalIntegration/pull/51))
-- Current room being cleaned ([#24](https://github.com/sjmotew/NarwalIntegration/pull/24), v1.0.2)
+- Current room and task progress on the vacuum entity during active cleans
 - Last clean result — why the previous task ended ([#53](https://github.com/sjmotew/NarwalIntegration/pull/53), v1.0.2)
 - Dust bag health and detergent remaining ([#52](https://github.com/sjmotew/NarwalIntegration/pull/52), v1.0.2)
 - Station and consumable binary sensors — clean water tank, sewage tank, dust box, dust bag, station bag, error ([#52](https://github.com/sjmotew/NarwalIntegration/pull/52), v1.0.2)
@@ -247,7 +247,7 @@ Home Assistant shows the option when the entity's domain is `vacuum` and it adve
 - **Check the entity is not `unavailable`.** The row is gated on a live state object, so it will not render while the robot is unreachable.
 - Requires **Home Assistant 2026.3+**, when area mapping was introduced.
 
-Room names come from the robot's map — rooms you named in the Narwal app keep those names, and the rest use the shared room-type table corrected in [#48](https://github.com/sjmotew/NarwalIntegration/pull/48). **Name your rooms in the Narwal app before mapping**: the mapping keys on segment *id*, so renaming later is safe, but naming first means your HA areas, the robot's map and `sensor.current_room` all read the same words.
+Room names come from the robot's map — rooms you named in the Narwal app keep those names, and the rest use the shared room-type table corrected in [#48](https://github.com/sjmotew/NarwalIntegration/pull/48). **Name your rooms in the Narwal app before mapping**: the mapping keys on segment *id*, so renaming later is safe, but naming first means your HA areas, the robot's map and the vacuum entity's current-room attribute all read the same words.
 
 `cleaning_area_id` accepts an **ordered list**, so you can clean several rooms in one job and the robot follows the order you picked.
 
@@ -413,7 +413,7 @@ Camera snapshot and LED entities will be added once the AES decryption key is ex
 | [#73](https://github.com/sjmotew/NarwalIntegration/issues/73) | **v1.0.3** — renews the broadcast subscription before it lapses, so `working_status` and `display_map` keep arriving and the entity stops freezing at `docked` |
 | [#62](https://github.com/sjmotew/NarwalIntegration/pull/62) | Map rendering options as switches — room labels, furniture, furniture labels |
 | [#61](https://github.com/sjmotew/NarwalIntegration/pull/61) | Dock ambient light entity, on models that have one |
-| [#24](https://github.com/sjmotew/NarwalIntegration/pull/24) | `sensor.current_room` — the room being cleaned right now |
+| [#24](https://github.com/sjmotew/NarwalIntegration/pull/24) | Current-room telemetry for the room being cleaned right now |
 | [#53](https://github.com/sjmotew/NarwalIntegration/pull/53) / [#54](https://github.com/sjmotew/NarwalIntegration/pull/54) | Last-clean-result sensor; consumable maintenance and replacement alerts |
 | [#52](https://github.com/sjmotew/NarwalIntegration/pull/52) | `base_status` field audit; station and consumable diagnostics |
 | [#67](https://github.com/sjmotew/NarwalIntegration/pull/67) | Carpet-map camera image; `working_status 7` mapped to remapping |

--- a/custom_components/narwal/__init__.py
+++ b/custom_components/narwal/__init__.py
@@ -23,15 +23,16 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import service
 
 from .const import (
+    CONF_DEVICE_ID,
     CONF_MODEL,
     CONF_PRODUCT_KEY,
     DOMAIN,
     PLATFORMS,
     SERVICE_CLEAN_ROOMS,
     configured_model_name,
-    fan_speed_list_for,
+    fan_speed_map_for,
 )
-from .coordinator import NarwalCoordinator, can_start_cleaning
+from .coordinator import NarwalCoordinator, can_prepare_clean_start
 from .narwal_client import (
     CleaningRoute,
     CommandResult,
@@ -47,6 +48,16 @@ _LOGGER = logging.getLogger(__name__)
 
 NarwalConfigEntry: TypeAlias = ConfigEntry[NarwalCoordinator]
 
+_CONFIG_ENTRY_MINOR_VERSION = 2
+_LEGACY_REPLACED_SENSOR_SUFFIXES = (
+    "base_station_cleaning_filter_used_hours",
+    "current_room",
+    "map_metadata",
+    "status",
+    "task_progress",
+    "task_status",
+)
+
 FIELD_ROOMS = "rooms"
 FIELD_MODE = "mode"
 FIELD_SUCTION = "suction"
@@ -61,16 +72,18 @@ WORK_MODE_OPTIONS: dict[str, WorkMode] = {
     "vacuum_then_mop": WorkMode.VACUUM_THEN_MOP,
     "vacuum_and_mop": WorkMode.VACUUM_AND_MOP,
 }
-SUCTION_OPTIONS: dict[str, FanLevel] = {
-    "ai": FanLevel.UNSPECIFIED,
-    "quiet": FanLevel.MUTE,
-    "standard": FanLevel.NORMAL,
-    "strong": FanLevel.STRONG,
-    "super": FanLevel.DEEP,
-    "ultra": FanLevel.SUPER,
-    "super_powerful": FanLevel.DEEP,
-    "ultra_powerful": FanLevel.SUPER,
-}
+SUCTION_OPTIONS = (
+    "ai",
+    "quiet",
+    "standard",
+    "normal",
+    "strong",
+    "ultra",
+    "super",
+    "ultra_powerful",
+    "super_powerful",
+    "max",
+)
 WATER_OPTIONS: dict[str, MopHumidity] = {
     "dry": MopHumidity.DRY,
     "normal": MopHumidity.NORMAL,
@@ -103,6 +116,34 @@ CLEAN_ROOMS_SCHEMA = vol.Schema(
         vol.Optional(FIELD_ROUTE): vol.In(ROUTE_OPTIONS),
     }
 )
+
+SUCTION_OPTION_LABELS: dict[str, str] = {
+    "quiet": "Quiet",
+    "standard": "Standard",
+    "normal": "Standard",
+    "strong": "Strong",
+    "ultra": "Ultra",
+    "ultra_powerful": "Ultra",
+    "super": "Super",
+    "super_powerful": "Super",
+    "max": "Super",
+}
+
+
+def _suction_for_coordinator(
+    coordinator: NarwalCoordinator,
+    option: str,
+) -> FanLevel:
+    """Return the model-valid suction level for a service option."""
+    if option == "ai":
+        return FanLevel.UNSPECIFIED
+    label = SUCTION_OPTION_LABELS[option]
+    fan_map = fan_speed_map_for(coordinator.config_entry.data, include_aliases=False)
+    if label not in fan_map:
+        raise HomeAssistantError(
+            f"{label} suction is not supported by this Narwal model"
+        )
+    return fan_map[label]
 
 
 def _domain_data(hass: HomeAssistant) -> dict[str, NarwalCoordinator]:
@@ -322,7 +363,6 @@ def _async_register_services(hass: HomeAssistant) -> None:
         coordinator = coordinators[0]
 
         work_mode = WORK_MODE_OPTIONS[call.data[FIELD_MODE]]
-        fan = SUCTION_OPTIONS[call.data[FIELD_SUCTION]]
         water = WATER_OPTIONS[call.data[FIELD_WATER]]
         mop_strength = MOP_STRENGTH_OPTIONS[call.data[FIELD_MOP_STRENGTH]]
         passes = call.data[FIELD_PASSES]
@@ -338,12 +378,7 @@ def _async_register_services(hass: HomeAssistant) -> None:
         if not room_ids:
             raise HomeAssistantError("At least one room must be selected")
 
-        if fan is FanLevel.SUPER and "Ultra" not in fan_speed_list_for(
-            coordinator.config_entry.data
-        ):
-            raise HomeAssistantError(
-                "Ultra suction is not supported by this Narwal model"
-            )
+        fan = _suction_for_coordinator(coordinator, call.data[FIELD_SUCTION])
         route = ROUTE_OPTIONS.get(route_label, coordinator.clean_settings.route)
         requested_settings = RoomCleanSettings(
             work_mode=work_mode,
@@ -362,7 +397,9 @@ def _async_register_services(hass: HomeAssistant) -> None:
         async with coordinator.dock_action_lock:
             if not await coordinator.async_refresh_dock_status():
                 raise HomeAssistantError("Narwal status could not be refreshed")
-            if not can_start_cleaning(coordinator.client.state):
+            if not can_prepare_clean_start(coordinator.client.state):
+                raise HomeAssistantError("Narwal room clean cannot be started right now")
+            if not await coordinator.async_prepare_clean_start():
                 raise HomeAssistantError("Narwal room clean cannot be started right now")
 
             client = coordinator.client
@@ -418,7 +455,9 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
-    """Migrate old config entries to version 2 (add product_key)."""
+    """Migrate old config entries and remove replaced status sensors."""
+    update_kwargs: dict[str, object] = {}
+
     if config_entry.version < 2:
         _LOGGER.info(
             "Migrating Narwal config entry from version %d to 2",
@@ -429,15 +468,65 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             new_data[CONF_PRODUCT_KEY] = "QoEsI5qYXO"
         if CONF_MODEL not in new_data:
             new_data[CONF_MODEL] = "Narwal Flow"
-        hass.config_entries.async_update_entry(
-            config_entry, data=new_data, version=2,
-        )
+        update_kwargs["data"] = new_data
+        update_kwargs["version"] = 2
         _LOGGER.info("Migration complete: product_key=%s", new_data[CONF_PRODUCT_KEY])
+
+    if getattr(config_entry, "minor_version", 1) < _CONFIG_ENTRY_MINOR_VERSION:
+        _async_remove_legacy_replaced_sensors(hass, config_entry)
+        update_kwargs["minor_version"] = _CONFIG_ENTRY_MINOR_VERSION
+
+    if update_kwargs:
+        hass.config_entries.async_update_entry(config_entry, **update_kwargs)
     return True
+
+
+def _async_remove_legacy_replaced_sensors(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+) -> None:
+    """Remove old sensors now represented by native entities or attributes."""
+    device_id = config_entry.data.get(CONF_DEVICE_ID)
+    if not device_id:
+        return
+
+    registry = er.async_get(hass)
+    unique_ids = {
+        f"{device_id}_{suffix}" for suffix in _LEGACY_REPLACED_SENSOR_SUFFIXES
+    }
+    entity_ids: set[str] = set()
+
+    for unique_id in unique_ids:
+        entity_id = registry.async_get_entity_id(
+            "sensor",
+            DOMAIN,
+            unique_id,
+        )
+        if entity_id is not None:
+            entity_ids.add(entity_id)
+
+    for entry in er.async_entries_for_config_entry(
+        registry,
+        config_entry.entry_id,
+    ):
+        if (
+            entry.domain == "sensor"
+            and entry.platform == DOMAIN
+            and entry.unique_id in unique_ids
+        ):
+            entity_ids.add(entry.entity_id)
+
+    for entity_id in sorted(entity_ids):
+        registry_entry = registry.async_get(entity_id)
+        if registry_entry is None or registry_entry.platform != DOMAIN:
+            continue
+        _LOGGER.info("Removing legacy Narwal sensor %s", entity_id)
+        registry.async_remove(entity_id)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: NarwalConfigEntry) -> bool:
     """Set up Narwal from a config entry."""
+    _async_remove_legacy_replaced_sensors(hass, entry)
     coordinator = NarwalCoordinator(hass, entry)
     try:
         await coordinator.async_setup()

--- a/custom_components/narwal/__init__.py
+++ b/custom_components/narwal/__init__.py
@@ -124,9 +124,9 @@ SUCTION_OPTION_LABELS: dict[str, str] = {
     "strong": "Strong",
     "ultra": "Ultra",
     "ultra_powerful": "Ultra",
-    "super": "Super",
-    "super_powerful": "Super",
-    "max": "Super",
+    "super": "Super Powerful",
+    "super_powerful": "Super Powerful",
+    "max": "Super Powerful",
 }
 
 
@@ -137,8 +137,10 @@ def _suction_for_coordinator(
     """Return the model-valid suction level for a service option."""
     if option == "ai":
         return FanLevel.UNSPECIFIED
-    label = SUCTION_OPTION_LABELS[option]
     fan_map = fan_speed_map_for(coordinator.config_entry.data, include_aliases=False)
+    if option == "max":
+        return list(fan_map.values())[-1]
+    label = SUCTION_OPTION_LABELS[option]
     if label not in fan_map:
         raise HomeAssistantError(
             f"{label} suction is not supported by this Narwal model"

--- a/custom_components/narwal/camera.py
+++ b/custom_components/narwal/camera.py
@@ -290,11 +290,17 @@ class NarwalMapCamera(NarwalEntity, Camera):
         # Detect cleaning session transitions — clear trail on new session
         current_status = state.working_status
         was_cleaning = self._last_cleaning_status in _CLEANING_TRAIL_STATUSES
-        is_cleaning = current_status in _CLEANING_TRAIL_STATUSES
+        is_cleaning = (
+            state.is_cleaning and current_status != WorkingStatus.REMAPPING
+        )
         if is_cleaning and not was_cleaning:
             _LOGGER.info("New cleaning session — clearing trail and vision obstacles")
             self._reset_trail()
-        if current_status != WorkingStatus.UNKNOWN:
+        if is_cleaning:
+            self._last_cleaning_status = WorkingStatus.CLEANING
+        elif state.has_paused_clean_task_context:
+            self._last_cleaning_status = WorkingStatus.CLEANING
+        elif current_status != WorkingStatus.UNKNOWN:
             self._last_cleaning_status = current_status
 
         if _DEBUG_VIEW:

--- a/custom_components/narwal/config_flow.py
+++ b/custom_components/narwal/config_flow.py
@@ -64,6 +64,7 @@ class NarwalConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Narwal vacuum."""
 
     VERSION = 2
+    MINOR_VERSION = 2
 
     # Host pre-filled when zeroconf or DHCP finds the robot before the user
     # starts the flow. Class-level default: the flow object is also constructed

--- a/custom_components/narwal/const.py
+++ b/custom_components/narwal/const.py
@@ -12,7 +12,6 @@ from .narwal_client import (
 
 DOMAIN = "narwal"
 DEFAULT_PORT = 9002
-
 MANUFACTURER = "Narwal"
 MODEL = "Flow (AX12)"
 
@@ -159,39 +158,20 @@ _FAN_SPEED_CANONICAL: dict[str, FanLevel] = {
 
 FAN_SPEED_LIST: list[str] = list(_FAN_SPEED_CANONICAL)
 
-# Models whose app exposes only four suction tiers: FanLevel.SUPER (5) is unreachable
-# there, and the live clean/set_fan_level enum (SweepFanLevel) has no SUPER at all, so
-# offering "Ultra" would silently apply Strong. AX26 confirmed by app captures in #70 —
-# its top tier ("Super powerful" / "super puissant") sends CleanParam tag 2 = 4 (DEEP).
-NO_ULTRA_FAN_PRODUCT_KEYS: frozenset[str] = frozenset({"qV6BujoYLz"})
+# Models whose app exposes only four suction tiers: FanLevel.SUPER (5) is
+# unreachable there, and the live clean/set_fan_level enum has no SUPER at all.
+# AX26 confirmed by app captures in #70: its top tier sends CleanParam tag 2 =
+# 4 (DEEP), exposed as "Super Powerful" for those models.
+NO_LEVEL_5_FAN_PRODUCT_KEYS: frozenset[str] = frozenset({"qV6BujoYLz"})
 
+_FAN_SPEED_NO_LEVEL_5: dict[str, FanLevel] = {
+    "Quiet": FanLevel.MUTE,
+    "Standard": FanLevel.NORMAL,
+    "Strong": FanLevel.STRONG,
+    "Super Powerful": FanLevel.DEEP,
+}
 
-def fan_speed_list_for(data: dict) -> list[str]:
-    """fan_speed options for this configured model — no "Ultra" where 5 is unreachable."""
-    if data.get(CONF_PRODUCT_KEY) in NO_ULTRA_FAN_PRODUCT_KEYS:
-        return [
-            label
-            for label, level in _FAN_SPEED_CANONICAL.items()
-            if level is not FanLevel.SUPER
-        ]
-    return FAN_SPEED_LIST
-
-
-def normalize_fan_level_for_model(data: dict, fan: FanLevel) -> FanLevel:
-    """Return a persisted fan level supported by the configured model."""
-    if (
-        fan == FanLevel.SUPER
-        and data.get(CONF_PRODUCT_KEY) in NO_ULTRA_FAN_PRODUCT_KEYS
-    ):
-        return FanLevel.DEEP
-    return fan
-
-
-# FAN_SPEED_MAP also accepts the "… powerful" labels shipped through v1.0.3 and the
-# short "Super" label used by this stack, and the original lowercase fan_speed
-# values (quiet/normal/strong/max) so existing automations keep working; these
-# aliases are not offered in FAN_SPEED_LIST.
-FAN_SPEED_MAP: dict[str, FanLevel] = _FAN_SPEED_CANONICAL | {
+_FAN_SPEED_ALIASES: dict[str, FanLevel] = {
     "Super": FanLevel.DEEP,
     "Super powerful": FanLevel.DEEP,
     "Ultra powerful": FanLevel.SUPER,
@@ -219,6 +199,60 @@ UNVERSIONED_FAN_SPEED_MAP: dict[str, FanLevel] = {
     "max": FanLevel.SUPER,
 }
 
+_FAN_SPEED_NO_LEVEL_5_ALIASES: dict[str, FanLevel] = {
+    "Super": FanLevel.DEEP,
+    "Super powerful": FanLevel.DEEP,
+    "quiet": FanLevel.MUTE,
+    "normal": FanLevel.NORMAL,
+    "strong": FanLevel.STRONG,
+    "max": FanLevel.DEEP,
+}
+
+
+def fan_speed_list_for(data: dict) -> list[str]:
+    """Return visible fan_speed options for this configured model."""
+    return list(fan_speed_map_for(data, include_aliases=False))
+
+
+def fan_speed_map_for(
+    data: dict,
+    *,
+    include_aliases: bool = True,
+) -> dict[str, FanLevel]:
+    """Return visible and compatibility fan_speed labels for this model."""
+    if data.get(CONF_PRODUCT_KEY) in NO_LEVEL_5_FAN_PRODUCT_KEYS:
+        return _FAN_SPEED_NO_LEVEL_5 | (
+            _FAN_SPEED_NO_LEVEL_5_ALIASES if include_aliases else {}
+        )
+    return _FAN_SPEED_CANONICAL | (_FAN_SPEED_ALIASES if include_aliases else {})
+
+
+def fan_speed_label_map_for(data: dict) -> dict[FanLevel, str]:
+    """Return FanLevel -> visible fan_speed label for this model."""
+    return {
+        level: label
+        for label, level in fan_speed_map_for(data, include_aliases=False).items()
+    }
+
+
+def normalize_fan_level_for_model(data: dict, fan: FanLevel) -> FanLevel:
+    """Return a persisted fan level supported by the configured model."""
+    if (
+        fan == FanLevel.SUPER
+        and data.get(CONF_PRODUCT_KEY) in NO_LEVEL_5_FAN_PRODUCT_KEYS
+    ):
+        return FanLevel.DEEP
+    return fan
+
+
+# FAN_SPEED_MAP also accepts the short "Super" label shipped through this stack
+# and v1.0.3's "… powerful" labels, plus the original lowercase fan_speed values
+# (quiet/normal/strong/max) so existing automations keep working; these aliases
+# are not offered in FAN_SPEED_LIST.
+FAN_SPEED_MAP: dict[str, FanLevel] = _FAN_SPEED_CANONICAL | _FAN_SPEED_ALIASES
+
+# Backwards-compatible name for existing imports/tests.
+NO_ULTRA_FAN_PRODUCT_KEYS = NO_LEVEL_5_FAN_PRODUCT_KEYS
 # base_status field 15 (terminateReason) value → HA option key. From the decoded
 # TaskResult enum (re/ENUMS.md). Live-confirmed: 1 = NORMAL_END.
 TASK_RESULT_OPTIONS: dict[int, str] = {

--- a/custom_components/narwal/coordinator.py
+++ b/custom_components/narwal/coordinator.py
@@ -16,6 +16,12 @@ from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, NO_BROADCAST_PRODUCT_KEYS
+from .dock_tasks import (
+    ROBOT_START_STOP_REQUIRED_DOCK_TASKS,
+    can_start_robot_clean,
+    can_stop_dock_task,
+    dock_task_blocks_robot_return,
+)
 from .narwal_client import (
     CleaningRoute,
     CommandResponse,
@@ -144,7 +150,6 @@ def is_clean_session_context(state: NarwalState | None) -> bool:
         or _state_attr_is_true(state, "has_recent_active_working_status")
         or _state_attr_is_true(state, "has_paused_clean_task_context")
         or _state_attr_is_true(state, "is_returning")
-        or _state_attr_is_true(state, "is_charging_to_resume")
     )
 
 
@@ -156,15 +161,14 @@ def is_live_clean_setting_available(state: NarwalState | None) -> bool:
         return False
     return (
         (_state_attr_is_true(state, "is_cleaning") or is_active_clean_session(state))
-        and not _state_attr_is_true(state, "is_charging_to_resume")
-        and not _state_attr_is_true(state, "is_station_active")
+        and not dock_task_blocks_robot_return(state)
     )
 
 
 def clean_setting_applies_to_mode(attr: str, work_mode: WorkMode | None) -> bool:
     """Return True when a clean setting is meaningful for the selected mode."""
     if work_mode is None:
-        return True
+        return attr not in {"fan", "water", "mop_strength"}
     if attr in {"water", "mop_strength"}:
         return work_mode in MOP_WORK_MODES
     if attr == "fan":
@@ -208,8 +212,100 @@ def can_start_cleaning(state: NarwalState | None) -> bool:
     return (
         state.is_docked
         and not is_clean_session_context(state)
-        and not state.blocks_robot_start_for_dock_task
+        and can_start_robot_clean(state)
     )
+
+
+def _can_start_cleaning_without_dock_stop(state: NarwalState | None) -> bool:
+    """Return True when refreshed state permits sending a clean command now."""
+    return (
+        can_start_cleaning(state)
+        and not state.has_unmapped_active_dock_task
+        and state.assumed_active_dock_task is None
+    )
+
+
+def can_prepare_clean_start(
+    state: NarwalState | None,
+    *,
+    allow_dock_stop: bool = True,
+) -> bool:
+    """Return True when a clean start can run now or after a safe dock stop."""
+    if state is None:
+        return False
+    active_tasks = state.active_dock_task_keys
+    if _can_start_cleaning_without_dock_stop(state):
+        return True
+    if not allow_dock_stop:
+        return False
+    if (
+        has_blocking_error(state)
+        or not state.is_docked
+        or is_clean_session_context(state)
+        or state.has_unmapped_active_dock_task
+        or state.assumed_active_dock_task is not None
+    ):
+        return False
+
+    return (
+        len(active_tasks) == 1
+        and active_tasks[0] in ROBOT_START_STOP_REQUIRED_DOCK_TASKS
+        and can_stop_dock_task(state, active_tasks[0])
+    )
+
+
+def can_pause_cleaning(state: NarwalState | None) -> bool:
+    """Return True when the active robot clean can be paused."""
+    if has_blocking_error(state):
+        return False
+    return (
+        (
+            _state_attr_is_true(state, "is_cleaning")
+            or state.working_status == WorkingStatus.REMAPPING
+        )
+        and not _state_attr_is_true(state, "is_paused")
+        and not dock_task_blocks_robot_return(state)
+    )
+
+
+def can_resume_cleaning(state: NarwalState | None) -> bool:
+    """Return True when a paused robot clean can be resumed."""
+    if has_blocking_error(state):
+        return False
+    return (
+        (
+            state.working_status in (*ACTIVE_CLEANING_STATUSES, WorkingStatus.REMAPPING)
+            or _state_attr_is_true(state, "has_paused_clean_task_context")
+        )
+        and _state_attr_is_true(state, "is_paused")
+        and not dock_task_blocks_robot_return(state)
+    )
+
+
+def can_stop_cleaning(state: NarwalState | None) -> bool:
+    """Return True when a robot-side clean task can be stopped."""
+    if has_blocking_error(state):
+        return False
+    return is_clean_session_context(state)
+
+
+def can_return_home(state: NarwalState | None) -> bool:
+    """Return True when the robot can be recalled to the dock."""
+    if has_blocking_error(state):
+        return False
+    return (
+        not state.is_docked
+        and state.working_status != WorkingStatus.TASK_COMPLETED
+        and not _state_attr_is_true(state, "is_returning")
+        and not dock_task_blocks_robot_return(state)
+    )
+
+
+def can_locate_robot(state: NarwalState | None) -> bool:
+    """Return True when the locate command can be sent."""
+    if has_blocking_error(state):
+        return False
+    return not dock_task_blocks_robot_return(state)
 
 
 class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
@@ -1083,6 +1179,75 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         if full_update and not _has_dock_status_payload(response):
             self._mark_dock_status_refresh_failed()
             _LOGGER.debug("Dock status refresh returned no dock-status payload")
+            self._sync_active_clean_context(self.client.state)
+            self.async_set_updated_data(self.client.state)
+            return False
+        if full_update:
+            self._mark_dock_status_refresh_succeeded()
+        self._sync_active_clean_context(self.client.state)
+        self.async_set_updated_data(self.client.state)
+        return True
+
+    async def async_prepare_clean_start(self, *, allow_dock_stop: bool = True) -> bool:
+        """Stop safe dock-side blockers before starting a robot clean."""
+        if not await self.async_refresh_dock_status():
+            return False
+        state = self.client.state
+        active_tasks = state.active_dock_task_keys
+        if _can_start_cleaning_without_dock_stop(state):
+            return True
+        if not allow_dock_stop:
+            return False
+        if (
+            has_blocking_error(state)
+            or not state.is_docked
+            or is_clean_session_context(state)
+            or state.has_unmapped_active_dock_task
+            or state.assumed_active_dock_task is not None
+            or len(active_tasks) != 1
+        ):
+            return False
+
+        blocker = active_tasks[0]
+        if blocker not in ROBOT_START_STOP_REQUIRED_DOCK_TASKS or not can_stop_dock_task(
+            state, blocker
+        ):
+            return False
+        response = await self.client.stop_dock_task(blocker)
+        if not response.accepted:
+            return False
+        self._sync_active_clean_context(self.client.state)
+        self.async_set_updated_data(self.client.state)
+
+        if not await self.async_refresh_dock_status():
+            return False
+        return _can_start_cleaning_without_dock_stop(self.client.state)
+
+    async def async_refresh_action_status(self) -> bool:
+        """Refresh state for a robot action without clobbering live task telemetry."""
+        full_update = not self.client.state.has_recent_active_working_status
+        try:
+            response = await self.client.get_status(full_update=full_update)
+        except Exception:
+            _LOGGER.debug("Failed to refresh Narwal action status")
+            if full_update:
+                self._mark_dock_status_refresh_failed()
+            self._sync_active_clean_context(self.client.state)
+            self.async_set_updated_data(self.client.state)
+            return False
+        if not response.accepted:
+            _LOGGER.debug(
+                "Narwal action status refresh was rejected with code %s",
+                response.result_code,
+            )
+            if full_update:
+                self._mark_dock_status_refresh_failed()
+            self._sync_active_clean_context(self.client.state)
+            self.async_set_updated_data(self.client.state)
+            return False
+        if full_update and not _has_dock_status_payload(response):
+            _LOGGER.debug("Narwal action status refresh returned no dock-status payload")
+            self._mark_dock_status_refresh_failed()
             self._sync_active_clean_context(self.client.state)
             self.async_set_updated_data(self.client.state)
             return False

--- a/custom_components/narwal/dock_tasks.py
+++ b/custom_components/narwal/dock_tasks.py
@@ -67,6 +67,11 @@ GENERIC_STOP_DOCK_TASKS = frozenset(
 )
 SCOPED_STOP_DOCK_TASKS = frozenset({DOCK_TASK_DRY_DOCK_BAG, DOCK_TASK_DRY_DUST_BIN})
 STOPPABLE_DOCK_TASKS = GENERIC_STOP_DOCK_TASKS | SCOPED_STOP_DOCK_TASKS
+ROBOT_RETURN_COMPATIBLE_DOCK_TASKS = frozenset({DOCK_TASK_DRY_DOCK_BAG})
+ROBOT_START_COMPATIBLE_DOCK_TASKS = frozenset(
+    {DOCK_TASK_DRY_MOP, DOCK_TASK_DRY_DUST_BIN, DOCK_TASK_DRY_DOCK_BAG}
+)
+ROBOT_START_STOP_REQUIRED_DOCK_TASKS = frozenset({DOCK_TASK_EMPTY_DUSTBIN, DOCK_TASK_WASH_MOP})
 
 
 def has_blocking_error(state: NarwalState | None) -> bool:
@@ -84,6 +89,7 @@ def is_clean_session_context(state: NarwalState | None) -> bool:
         or state.working_status in ACTIVE_CLEANING_STATUSES
         or state.working_status == WorkingStatus.TASK_COMPLETED
         or state.has_recent_active_working_status
+        or state.has_paused_clean_task_context
         or state.is_returning
     )
 
@@ -97,6 +103,7 @@ def is_robot_work_context(state: NarwalState | None) -> bool:
         or state.has_assumed_robot_clean
         or state.working_status in ACTIVE_CLEANING_STATUSES
         or state.has_recent_active_working_status
+        or state.has_paused_clean_task_context
         or state.is_returning
     )
 
@@ -140,9 +147,32 @@ def can_start_robot_clean(state: NarwalState | None) -> bool:
         return False
     if state.working_status == WorkingStatus.UNKNOWN:
         return False
-    if state.has_assumed_robot_clean:
+    if not state.is_docked or is_clean_session_context(state):
         return False
+    if state.has_unmapped_active_dock_task or state.assumed_active_dock_task is not None:
+        return False
+    active_tasks = set(state.active_dock_task_keys)
+    if active_tasks:
+        return active_tasks <= ROBOT_START_COMPATIBLE_DOCK_TASKS and active_tasks <= set(
+            state.telemetry_dock_task_keys
+        )
     return not state.blocks_robot_start_for_dock_task
+
+
+def dock_task_blocks_robot_return(state: NarwalState | None) -> bool:
+    """Return True when dock work should block recalling an off-dock robot."""
+    if state is None:
+        return False
+    if state.has_unmapped_active_dock_task:
+        return True
+    if state.assumed_active_dock_task is not None:
+        return state.assumed_active_dock_task not in ROBOT_RETURN_COMPATIBLE_DOCK_TASKS
+    if not state.is_station_active:
+        return False
+    active_tasks = set(state.active_dock_task_keys)
+    if not active_tasks:
+        return True
+    return not active_tasks <= ROBOT_RETURN_COMPATIBLE_DOCK_TASKS
 
 
 def can_stop_dock_task(state: NarwalState | None, task_key: str | None = None) -> bool:

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -122,6 +122,7 @@ def _clean_session_context(state: NarwalState) -> bool:
         or state.working_status in ACTIVE_CLEANING_STATUSES
         or state.working_status == WorkingStatus.TASK_COMPLETED
         or state.has_recent_active_working_status
+        or state.has_paused_clean_task_context
         or state.is_returning
     )
 
@@ -133,13 +134,20 @@ def _robot_work_blocks_generic_dock_stop(state: NarwalState) -> bool:
         or state.has_assumed_robot_clean
         or state.working_status in ACTIVE_CLEANING_STATUSES
         or state.has_recent_active_working_status
+        or state.has_paused_clean_task_context
         or state.is_returning
     )
 
 
 def _robot_start_blocked(state: NarwalState) -> bool:
-    """Return true when a private guard or dock task blocks a start."""
-    return state.has_assumed_robot_clean or state.blocks_robot_start_for_dock_task
+    """Return true unless fresh state permits dispatching a robot start."""
+    return (
+        state.has_error
+        or state.working_status in (WorkingStatus.UNKNOWN, WorkingStatus.ERROR)
+        or not state.is_docked
+        or _clean_session_context(state)
+        or state.blocks_robot_start_for_dock_task
+    )
 
 
 def _can_force_end_scoped_dock_task(state: NarwalState, task: str | None) -> bool:
@@ -177,33 +185,6 @@ def _base_status_working_status(decoded: dict[str, Any] | object) -> WorkingStat
         return WorkingStatus(int(field3["1"]))
     except (TypeError, ValueError):
         return None
-
-
-def _base_status_confirms_docked(
-    decoded: dict[str, Any] | object, status: WorkingStatus | None
-) -> bool:
-    """Return true when a terminal status also carries live dock indicators."""
-    if not isinstance(decoded, dict) or status not in _STALE_DOCK_BASE_STATUSES:
-        return False
-
-    field3 = decoded.get("3")
-    if isinstance(field3, list):
-        field3 = field3[0] if field3 else None
-    field3 = field3 if isinstance(field3, dict) else {}
-
-    def int_field(container: dict[str, Any], field: str) -> int:
-        try:
-            return int(container.get(field, 0))
-        except (TypeError, ValueError):
-            return 0
-
-    return (
-        int_field(decoded, "11") >= 2
-        or int_field(decoded, "47") in (1, 3)
-        or int_field(field3, "3") in (1, 6)
-        or int_field(field3, "10") == 1
-        or int_field(field3, "12") > 0
-    )
 
 
 def _base_status_payload(response: CommandResponse) -> dict[str, Any] | None:
@@ -360,7 +341,6 @@ class NarwalClient:
         if (
             self.state.has_recent_active_working_status
             and status in _STALE_DOCK_BASE_STATUSES
-            and not _base_status_confirms_docked(decoded, status)
         ):
             self.state.update_battery_from_base_status(decoded)
             _LOGGER.debug(
@@ -1226,14 +1206,14 @@ class NarwalClient:
         Newer firmware answers SUCCESS there and does nothing, so this path
         fails clearly when no room list is available instead (#69).
         """
+        if not self.connected:
+            raise NarwalConnectionError("Not connected to vacuum")
         if _robot_start_blocked(self.state):
             _LOGGER.warning(
                 "start: robot or dock task active (%s); not starting whole-house clean",
                 self.state.active_dock_task_keys or "unmapped",
             )
             return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
-        if not self.connected:
-            raise NarwalConnectionError("Not connected to vacuum")
         room_ids = await self._all_room_ids()
         if not room_ids:
             _LOGGER.warning("start(): no map rooms available")
@@ -1518,7 +1498,11 @@ class NarwalClient:
 
             map_data = self.state.map_data
             if not map_data or not map_data.map_id:
-                map_data = await self.get_map()
+                try:
+                    map_data = await self.get_map()
+                except NarwalCommandError as err:
+                    _LOGGER.warning("start_rooms: map fetch failed: %s", err)
+                    map_data = self.state.map_data
             map_id = map_data.map_id if map_data else 0
             if not map_id:
                 _LOGGER.warning(
@@ -1541,6 +1525,11 @@ class NarwalClient:
             except ValueError as err:
                 _LOGGER.warning("start_rooms: %s", err)
                 return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            if _robot_start_blocked(self.state):
+                _LOGGER.warning(
+                    "start_rooms: state changed before dispatch; not starting room clean"
+                )
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
             resp = await self.send_command(
                 TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
             )
@@ -1556,6 +1545,11 @@ class NarwalClient:
                     break
                 _LOGGER.info("start_rooms: robot docking/settling, retrying clean/start_clean")
                 await asyncio.sleep(3.0)
+                if _robot_start_blocked(self.state):
+                    _LOGGER.warning(
+                        "start_rooms: state changed before retry; not starting room clean"
+                    )
+                    return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
                 resp = await self.send_command(
                     TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
                 )

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -1207,6 +1207,11 @@ class NarwalState:
                     self.working_status = WorkingStatus.UNKNOWN
                 if self.working_status not in ACTIVE_CLEANING_STATUSES:
                     self.last_active_working_status_time = 0.0
+                if self.working_status in {
+                    WorkingStatus.TASK_COMPLETED,
+                    WorkingStatus.ERROR,
+                }:
+                    self.clear_assumed_robot_clean()
             # Sub-field 2: paused overlay (0 or absent = not paused, 1 = paused)
             self.is_paused = bool(field3.get("2"))
             # Sub-field 7: returning to dock on old FW (value 1 = returning).

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -23,9 +23,15 @@ _LOGGER = logging.getLogger(__name__)
 _WARNED_WORKING_STATUS: set[Any] = set()
 
 _ACTIVE_WORKING_STATUS_TTL = 15.0
+_TERMINAL_WORKING_STATUS_TTL = 15.0
 _DOCK_DRYING_STATUS_TTL = 180.0
 _DOCK_TASK_ASSUME_TTL = 30.0
-_ROBOT_START_ASSUME_TTL = 30.0
+# clean/start_clean can be accepted long before working_status metrics arrive.
+_ROBOT_START_ASSUME_TTL = 180.0
+# Live hardware has taken about 50 seconds to leave a stale docked status after
+# accepting a room clean. After this handoff window, repeated idle dock
+# telemetry is stronger evidence than the accepted-command reservation.
+_ROBOT_START_DOCKED_HANDOFF_GRACE = 60.0
 _KNOWN_DOCK_ACTIVITY_VALUES = {0, 2, 3, 4, 6}
 
 DOCK_TASK_EMPTY_DUSTBIN = "empty_dustbin"
@@ -649,6 +655,15 @@ class NarwalState:
     cleaning_area: float = 0.0  # m² (coveredArea)
     cleaning_time: int = 0  # seconds
     last_active_working_status_time: float = 0.0
+    last_terminal_working_status_time: float = 0.0
+    pending_active_working_status: dict[str, Any] | None = field(
+        default=None, repr=False
+    )
+    pending_active_working_status_time: float = 0.0
+    task_progress_percent: int | None = None
+    task_elapsed_time: int = 0
+    task_remaining_time: int = 0
+    current_room_aux_name: str = ""
 
     # Consumables / station / fault (base_status; present on dock and during cleaning)
     dust_bag_health: float = 0.0  # field 35 stationBagHealthScore (%)
@@ -743,8 +758,6 @@ class NarwalState:
     @property
     def has_recent_active_working_status(self) -> bool:
         """True while live working_status task metrics are still fresh."""
-        if self.working_status not in ACTIVE_CLEANING_STATUSES:
-            return False
         if self.last_active_working_status_time <= 0:
             return False
         return (
@@ -753,13 +766,24 @@ class NarwalState:
         )
 
     @property
+    def has_recent_terminal_working_status(self) -> bool:
+        """True just after authoritative terminal base-status telemetry."""
+        if self.last_terminal_working_status_time <= 0:
+            return False
+        return (
+            time.monotonic() - self.last_terminal_working_status_time
+            <= _TERMINAL_WORKING_STATUS_TTL
+        )
+
+    @property
     def has_paused_clean_task_context(self) -> bool:
         """True when a paused overlay still has retained robot clean details."""
-        if not self.is_paused or self.is_docked:
+        if not self.is_paused:
             return False
         return (
             getattr(self, "task_progress_percent", None) is not None
-            or getattr(self, "task_elapsed_time", self.cleaning_time) > 0
+            or getattr(self, "task_elapsed_time", 0) > 0
+            or self.cleaning_time > 0
             or getattr(self, "task_remaining_time", 0) > 0
             or self.current_room_id is not None
             or bool(getattr(self, "current_room_aux_name", ""))
@@ -775,7 +799,7 @@ class NarwalState:
         return (
             self.working_status in ACTIVE_CLEANING_STATUSES
             and not self.is_paused
-            and not self.is_returning_to_dock
+            and not self.is_returning
         )
 
     @property
@@ -810,14 +834,14 @@ class NarwalState:
         cleaning is not active, since the robot can report unmapped states
         (e.g. self-test) while physically docked.
         """
+        if self.has_recent_active_working_status:
+            return False
         if self.has_explicit_off_dock_signal:
             return False
         if self.working_status in (
             WorkingStatus.DOCKED, WorkingStatus.CHARGED, WorkingStatus.DOCKED_V2,
         ):
             return True
-        if self.has_recent_active_working_status:
-            return False
         if self.working_status in ACTIVE_CLEANING_STATUSES:
             return False
         # For STANDBY, UNKNOWN, or any other status: check dock field signals.
@@ -871,6 +895,12 @@ class NarwalState:
     @property
     def is_station_active(self) -> bool:
         """True when the dock/base station is running a dock-side task."""
+        if self.has_recent_active_working_status:
+            return (
+                self.station_activity in (1, 2, 3)
+                or self.is_washing_mop
+                or bool(self.active_dock_drying_tasks)
+            )
         return (
             self.is_washing_mop
             or self.is_drying_mop
@@ -895,9 +925,9 @@ class NarwalState:
         if not telemetry_tasks:
             return False
         return not (
-            telemetry_tasks == {DOCK_TASK_DRY_DOCK_BAG}
+            telemetry_tasks.issubset(_DOCK_DRYING_TASK_ORDER)
             and self.has_recent_dock_drying_status
-            and self.dock_task_timer(DOCK_TASK_DRY_DOCK_BAG) is not None
+            and all(self.dock_task_timer(task) is not None for task in telemetry_tasks)
         )
 
     @property
@@ -926,12 +956,17 @@ class NarwalState:
     def telemetry_dock_task_keys(self) -> tuple[str, ...]:
         """Return active dock task keys from robot telemetry only."""
         tasks: list[str] = []
-        if self.station_activity == 1:
-            tasks.append(DOCK_TASK_EMPTY_DUSTBIN)
-        if self.is_washing_mop:
-            tasks.append(DOCK_TASK_WASH_MOP)
+        if not self.has_recent_active_working_status:
+            if self.station_activity == 1:
+                tasks.append(DOCK_TASK_EMPTY_DUSTBIN)
+            if self.is_washing_mop:
+                tasks.append(DOCK_TASK_WASH_MOP)
         tasks.extend(self.telemetry_dock_drying_tasks)
-        if self.is_drying_mop and DOCK_TASK_DRY_MOP not in tasks:
+        if (
+            not self.has_recent_active_working_status
+            and self.is_drying_mop
+            and DOCK_TASK_DRY_MOP not in tasks
+        ):
             tasks.append(DOCK_TASK_DRY_MOP)
         active = set(tasks)
         return tuple(task for task in DOCK_TASK_KEYS if task in active)
@@ -1017,6 +1052,39 @@ class NarwalState:
         """Clear the local robot-clean command reservation."""
         self.assumed_robot_clean_until = 0.0
 
+    def _clear_assumed_robot_clean_on_terminal_base_status(
+        self,
+        *,
+        is_paused: bool,
+    ) -> None:
+        """Clear accepted-start context once base status proves it is terminal."""
+        if not self.has_assumed_robot_clean:
+            return
+        if self.has_error or self.working_status == WorkingStatus.ERROR:
+            self.clear_assumed_robot_clean()
+            return
+        if self.working_status == WorkingStatus.TASK_COMPLETED:
+            self.clear_assumed_robot_clean()
+            return
+        handoff_ends = (
+            self.assumed_robot_clean_until
+            - _ROBOT_START_ASSUME_TTL
+            + _ROBOT_START_DOCKED_HANDOFF_GRACE
+        )
+        if (
+            not is_paused
+            and time.monotonic() >= handoff_ends
+            and self.working_status
+            in (
+                WorkingStatus.STANDBY,
+                WorkingStatus.DOCKED,
+                WorkingStatus.CHARGED,
+                WorkingStatus.DOCKED_V2,
+            )
+            and self.is_docked
+        ):
+            self.clear_assumed_robot_clean()
+
     def dock_task_timer(self, task: str) -> DockTaskTimer | None:
         """Return timer details for one active dock task."""
         timer = self.dock_drying_tasks.get(task)
@@ -1074,11 +1142,68 @@ class NarwalState:
         if self.current_room_id is None:
             return None
         if self.map_data is None:
-            return None
+            return self.current_room_aux_name or None
         for room in self.map_data.rooms:
             if room.room_id == self.current_room_id:
                 return room.display_name
+        return self.current_room_aux_name or None
+
+    def clear_task_details(self) -> None:
+        """Clear active robot-task detail fields."""
+        self.is_paused = False
+        self.cleaning_area = 0.0
+        self.cleaning_time = 0
+        self.task_progress_percent = None
+        self.task_elapsed_time = 0
+        self.task_remaining_time = 0
+        self.current_room_id = None
+        self.current_room_aux_name = ""
+
+    @staticmethod
+    def _task_progress_percent(value: Any) -> int | None:
+        """Return a percent for task progress encoded as percent or 0..1 float."""
+        if isinstance(value, float):
+            if 0.0 <= value <= 1.0:
+                return round(value * 100)
+            if 0.0 <= value <= 100.0:
+                return round(value)
+        progress = _optional_int(value)
+        if progress is not None and 0 <= progress <= 100:
+            return progress
+        progress_float = _to_float32(value)
+        if progress_float is None:
+            return None
+        if 0.0 <= progress_float <= 1.0:
+            return round(progress_float * 100)
+        if 0.0 <= progress_float <= 100.0:
+            return round(progress_float)
         return None
+
+    def _update_current_room(self, payload: dict[str, Any]) -> None:
+        """Parse scalar and nested current-room working-status fields."""
+        room = payload.get("6")
+        if not isinstance(room, dict):
+            room = payload.get("8")
+        if isinstance(room, dict):
+            room_id = _optional_int(room.get("1"))
+            if room_id is not None:
+                self.current_room_id = room_id or None
+            name = room.get("3")
+            if isinstance(name, (bytes, bytearray)):
+                self.current_room_aux_name = bytes(name).decode(
+                    "utf-8", errors="replace"
+                )
+            else:
+                self.current_room_aux_name = str(name) if name else ""
+                if (
+                    self.current_room_aux_name.startswith("b'")
+                    and self.current_room_aux_name.endswith("'")
+                ):
+                    self.current_room_aux_name = self.current_room_aux_name[2:-1]
+        else:
+            room_id = _optional_int(payload.get("6"))
+            if room_id is not None:
+                self.current_room_id = room_id or None
 
     def update_from_working_status(self, decoded: dict[str, Any]) -> None:
         """Update state from a decoded working_status message.
@@ -1092,8 +1217,29 @@ class NarwalState:
         not area — reading it as area is why the sensor was stuck at 1.8 m².
         """
         self.raw_working_status = decoded
+        reported_task_details: dict[str, Any] = {}
+        previous_task_details = (
+            self.task_progress_percent,
+            self.cleaning_area,
+            self.cleaning_time,
+            self.task_remaining_time,
+            self.current_room_id,
+            self.current_room_aux_name,
+        )
+        progress = self._task_progress_percent(decoded.get("1"))
+        if progress is not None:
+            self.task_progress_percent = max(0, min(100, progress))
+            reported_task_details["progress"] = self.task_progress_percent
+        remaining = _optional_int(decoded.get("4"))
+        if remaining is not None:
+            self.task_remaining_time = max(0, remaining)
+            reported_task_details["remaining"] = self.task_remaining_time
+        has_robot_side_drying = False
         if _has_dock_drying_timer_fields(decoded):
             timers = _dock_drying_timers(decoded)
+            has_robot_side_drying = bool(
+                timers.keys() & {DOCK_TASK_DRY_MOP, DOCK_TASK_DRY_DUST_BIN}
+            )
             self.dock_drying_tasks = timers
             self.has_dock_drying_timer_snapshot = True
             self.has_unmapped_dock_drying_timer = _has_unmapped_dock_drying_timer(
@@ -1109,6 +1255,8 @@ class NarwalState:
         if "3" in decoded:
             try:
                 self.cleaning_time = int(decoded["3"])
+                self.task_elapsed_time = self.cleaning_time
+                reported_task_details["elapsed"] = self.cleaning_time
                 active_payload = active_payload or self.cleaning_time > 0
             except (ValueError, TypeError):
                 pass
@@ -1116,29 +1264,97 @@ class NarwalState:
             area = _to_float32(decoded["2"])
             if area is not None and area >= 0:
                 self.cleaning_area = area
+                reported_task_details["area"] = self.cleaning_area
                 active_payload = active_payload or area > 0
-        if "6" in decoded:
-            # Field 6 = current target room_id (confirmed 2026-04-24 from live capture:
-            # value changed 4→1 as robot moved from Corridor to Living Room).
-            try:
-                room_id = int(decoded["6"])
-                self.current_room_id = room_id if room_id != 0 else None
-            except (ValueError, TypeError):
-                pass
-        if active_payload:
-            if self.working_status != WorkingStatus.CUSTOM_CLEANING:
-                self.working_status = WorkingStatus.CLEANING
-            self.last_active_working_status_time = time.monotonic()
-            self.clear_assumed_robot_clean()
-            self.is_paused = False
-            self.is_returning_to_dock = False
-            self.dock_sub_state = 0
+        if "6" in decoded or isinstance(decoded.get("8"), dict):
+            # Field 6 is a scalar room id on Flow 2 and a nested room detail
+            # message on other firmware; field 8 is the alternate nested shape.
+            self._update_current_room(decoded)
+            reported_task_details["room"] = (
+                self.current_room_id,
+                self.current_room_aux_name,
+            )
+        current_task_details = (
+            self.task_progress_percent,
+            self.cleaning_area,
+            self.cleaning_time,
+            self.task_remaining_time,
+            self.current_room_id,
+            self.current_room_aux_name,
+        )
+        task_details_changed = previous_task_details != current_task_details
+        # Clean counters can arrive late from the previous session. Fresh
+        # empty/wash telemetry is authoritative because raw clean commands
+        # cannot start robot work during either task.
+        has_blocking_station_task = (
+            self.station_activity in (1, 2, 3)
+            or self.dock_activity == 3
+            or has_robot_side_drying
+            or self.assumed_active_dock_task
+            in (DOCK_TASK_EMPTY_DUSTBIN, DOCK_TASK_WASH_MOP)
+        )
+        explicit_terminal_status = self.working_status in {
+            WorkingStatus.TASK_COMPLETED,
+            WorkingStatus.ERROR,
+        }
+        now = time.monotonic()
+        pending_candidate = self.pending_active_working_status
+        pending_candidate_fresh = (
+            pending_candidate is not None
+            and now - self.pending_active_working_status_time
+            <= _TERMINAL_WORKING_STATUS_TTL
+        )
+        confirmed_external_clean = (
+            active_payload
+            and not explicit_terminal_status
+            and self.has_recent_terminal_working_status
+            and pending_candidate_fresh
+            and pending_candidate is not None
+            and any(
+                key in pending_candidate and pending_candidate[key] != value
+                for key, value in reported_task_details.items()
+            )
+        )
+        has_terminal_robot_status = not self.has_assumed_robot_clean and (
+            explicit_terminal_status
+            or (
+                self.has_recent_terminal_working_status
+                and not confirmed_external_clean
+            )
+        )
+        if (
+            active_payload
+            and not has_blocking_station_task
+            and not has_terminal_robot_status
+        ):
+            if task_details_changed:
+                self.last_active_working_status_time = now
+                self.is_paused = False
+            self.last_terminal_working_status_time = 0.0
+            self.pending_active_working_status = None
+            self.pending_active_working_status_time = 0.0
             self.dock_activity = 0
             self.station_activity = 0
             self.clear_assumed_dock_task()
-            self.dock_presence = 2
-            self.dock_field11 = 1
-            self.dock_field47 = 2
+        elif has_terminal_robot_status:
+            if active_payload and not explicit_terminal_status:
+                if not pending_candidate_fresh:
+                    self.pending_active_working_status = dict(reported_task_details)
+                    self.pending_active_working_status_time = now
+                else:
+                    assert pending_candidate is not None
+                    pending_candidate.update(reported_task_details)
+            else:
+                self.pending_active_working_status = None
+                self.pending_active_working_status_time = 0.0
+            self.clear_task_details()
+
+    def _update_battery_level(self, raw_value: Any) -> None:
+        """Update battery level from base-status telemetry."""
+        bat = _to_float32(raw_value)
+        if bat is None:
+            return
+        self.battery_level = round(bat)
 
     def update_from_base_status(self, decoded: dict[str, Any]) -> None:
         """Update state from a decoded robot_base_status message.
@@ -1162,6 +1378,8 @@ class NarwalState:
         Note: field 32 mirrors field 3 exactly (redundant).
         """
         self.raw_base_status = decoded
+        if "2" in decoded:
+            self._update_battery_level(decoded["2"])
         # Field 11 = dock indicator (2=docked, 1=undocked)
         if "11" in decoded:
             try:
@@ -1190,10 +1408,40 @@ class NarwalState:
         field3 = decoded.get("3")
         if isinstance(field3, list):
             field3 = field3[0] if field3 else None
+        current_reports_docked = False
         if isinstance(field3, dict):
+            is_paused = bool(field3.get("2"))
+            current_presence = _optional_int(field3.get("3"))
+            current_sub_state = _optional_int(field3.get("10"))
+            current_field11 = _optional_int(decoded.get("11"))
+            current_field47 = _optional_int(decoded.get("47"))
+            if current_presence is not None:
+                self.dock_presence = current_presence
+            if current_sub_state is not None:
+                self.dock_sub_state = current_sub_state
+            current_reports_docked = (
+                current_presence in (1, 6)
+                or current_sub_state == 1
+                or (current_field11 is not None and current_field11 >= 2)
+                or current_field47 in (1, 3)
+            )
+            current_reports_off_dock = (
+                current_presence == 2
+                or current_sub_state == 2
+                or (current_field11 == 1 and current_field47 == 2)
+            )
+            if current_reports_docked or current_reports_off_dock:
+                if current_presence is None:
+                    self.dock_presence = 0
+                if current_sub_state is None:
+                    self.dock_sub_state = 0
+                if current_field11 is None:
+                    self.dock_field11 = 0
+                if current_field47 is None:
+                    self.dock_field47 = 0
             if "1" in field3:
                 try:
-                    self.working_status = WorkingStatus(int(field3["1"]))
+                    next_working_status = WorkingStatus(int(field3["1"]))
                 except (ValueError, TypeError):
                     raw_val = field3["1"]
                     if raw_val not in _WARNED_WORKING_STATUS:
@@ -1203,24 +1451,46 @@ class NarwalState:
                             "Please report this value at the GitHub repo. "
                             "(further occurrences of this value are suppressed)",
                             raw_val,
-                        )
-                    self.working_status = WorkingStatus.UNKNOWN
-                if self.working_status not in ACTIVE_CLEANING_STATUSES:
+                    )
+                    next_working_status = WorkingStatus.UNKNOWN
+                self.working_status = next_working_status
+                terminal_robot = self.working_status in {
+                    WorkingStatus.TASK_COMPLETED,
+                    WorkingStatus.ERROR,
+                }
+                terminal_dock = self.working_status in {
+                    WorkingStatus.DOCKED,
+                    WorkingStatus.CHARGED,
+                    WorkingStatus.DOCKED_V2,
+                }
+                if terminal_robot or (
+                    terminal_dock and not self.has_explicit_off_dock_signal
+                ):
+                    self.last_terminal_working_status_time = time.monotonic()
+                elif (
+                    terminal_dock
+                    or current_reports_off_dock
+                    or self.working_status in ACTIVE_CLEANING_STATUSES
+                ):
+                    self.last_terminal_working_status_time = 0.0
+                if (
+                    self.working_status not in ACTIVE_CLEANING_STATUSES
+                    and not is_paused
+                    and not self.has_assumed_robot_clean
+                ):
                     self.last_active_working_status_time = 0.0
+                    self.clear_task_details()
                 if self.working_status in {
                     WorkingStatus.TASK_COMPLETED,
                     WorkingStatus.ERROR,
                 }:
                     self.clear_assumed_robot_clean()
             # Sub-field 2: paused overlay (0 or absent = not paused, 1 = paused)
-            self.is_paused = bool(field3.get("2"))
+            self.is_paused = is_paused
             # Sub-field 7: returning to dock on old FW (value 1 = returning).
             # On newer FW, field 7 is repurposed (e.g. value 7 during cleaning).
             # Only treat value 1 as returning — other values are not the flag.
             self.is_returning_to_dock = field3.get("7") == 1
-            if "10" in field3:
-                with contextlib.suppress(ValueError, TypeError):
-                    self.dock_sub_state = int(field3["10"])
             if "12" in field3:
                 with contextlib.suppress(ValueError, TypeError):
                     self.dock_activity = int(field3["12"])
@@ -1230,9 +1500,6 @@ class NarwalState:
             if "18" in field3:
                 with contextlib.suppress(ValueError, TypeError):
                     self.station_activity = int(field3["18"])
-            if "3" in field3:
-                with contextlib.suppress(ValueError, TypeError):
-                    self.dock_presence = int(field3["3"])
             if self.working_status in ACTIVE_CLEANING_STATUSES:
                 self.clear_assumed_robot_clean()
                 if "10" not in field3:
@@ -1299,12 +1566,41 @@ class NarwalState:
                 "Please report this at the GitHub repo.",
                 type(field3).__name__, field3,
             )
-        if "2" in decoded:
-            # Field 2 = real-time battery SOC as float32 (batteryPercentage)
-            # (e.g. 1118175232 → 83.0%; bbp may return int or float)
-            bat = _to_float32(decoded["2"])
-            if bat is not None:
-                self.battery_level = round(bat)
+        if isinstance(field3, dict) and "1" in field3:
+            self._clear_assumed_robot_clean_on_terminal_base_status(
+                is_paused=bool(field3.get("2"))
+            )
+        standby_docked = (
+            isinstance(field3, dict)
+            and self.working_status == WorkingStatus.STANDBY
+            and not self.is_paused
+            and not self.has_assumed_robot_clean
+            and current_reports_docked
+        )
+        has_current_working_status = isinstance(field3, dict) and "1" in field3
+        terminal_docked = standby_docked or (
+            has_current_working_status
+            and self.working_status
+            in (
+                WorkingStatus.DOCKED,
+                WorkingStatus.CHARGED,
+                WorkingStatus.DOCKED_V2,
+            )
+        )
+        terminal_robot = has_current_working_status and self.working_status in (
+            WorkingStatus.TASK_COMPLETED,
+            WorkingStatus.ERROR,
+        )
+        if standby_docked:
+            self.last_terminal_working_status_time = time.monotonic()
+        if (
+            (terminal_robot or (terminal_docked and not self.has_explicit_off_dock_signal))
+            and not self.has_assumed_robot_clean
+        ):
+            # The paused overlay can remain set after docking. A terminal
+            # base-status packet is authoritative over retained task context.
+            self.last_active_working_status_time = 0.0
+            self.clear_task_details()
         self._update_consumables(decoded)
         if "13" in decoded:
             raw = decoded["13"]
@@ -1381,9 +1677,7 @@ class NarwalState:
         """
         self.raw_base_status = decoded
         if "2" in decoded:
-            bat = _to_float32(decoded["2"])
-            if bat is not None:
-                self.battery_level = round(bat)
+            self._update_battery_level(decoded["2"])
         self._update_consumables(decoded)
 
     def update_from_upgrade_status(self, decoded: dict[str, Any]) -> None:

--- a/custom_components/narwal/select.py
+++ b/custom_components/narwal/select.py
@@ -18,13 +18,13 @@ from homeassistant.util import slugify
 
 from . import NarwalConfigEntry
 from .const import (
-    FAN_SPEED_LIST,
-    FAN_SPEED_MAP,
     MOP_STRENGTH_MAP,
     UNVERSIONED_FAN_SPEED_MAP,
     WATER_MAP,
     WORK_MODE_MAP,
+    fan_speed_label_map_for,
     fan_speed_list_for,
+    fan_speed_map_for,
     normalize_fan_level_for_model,
 )
 from .coordinator import (
@@ -122,7 +122,7 @@ SELECT_DESCRIPTIONS: tuple[NarwalSelectEntityDescription, ...] = (
 )
 
 LEGACY_MODE_OPTIONS = ("Vacuum", "Mop", "Vacuum then mop", "Vacuum and mop")
-LEGACY_SUCTION_OPTIONS = ("AI", *FAN_SPEED_LIST)
+LEGACY_SUCTION_OPTIONS = ("AI", *fan_speed_list_for({}))
 LEGACY_WATER_OPTIONS = ("Dry", "Normal", "Wet")
 LEGACY_SCRUB_OPTIONS = ("Normal", "High")
 LEGACY_ROUTE_OPTIONS = ("Standard", "Meticulous")
@@ -137,17 +137,14 @@ LEGACY_MODE_MAP: dict[str, WorkMode] = {
 LEGACY_MODE_LABELS: dict[WorkMode, str] = {
     value: label for label, value in LEGACY_MODE_MAP.items()
 }
-LEGACY_SUCTION_MAP: dict[str, FanLevel] = {
-    "AI": FanLevel.UNSPECIFIED,
-    "Super": FanLevel.DEEP,
-    "Super powerful": FanLevel.DEEP,
-    "Ultra powerful": FanLevel.SUPER,
-    **{option: FAN_SPEED_MAP[option] for option in FAN_SPEED_LIST},
-}
-LEGACY_SUCTION_LABELS: dict[FanLevel, str] = {
-    FanLevel.UNSPECIFIED: "AI",
-    **{FAN_SPEED_MAP[option]: option for option in FAN_SPEED_LIST},
-}
+def _legacy_suction_map_for(data: dict) -> dict[str, FanLevel]:
+    """Return legacy suction options for this model, including hidden aliases."""
+    return {"AI": FanLevel.UNSPECIFIED, **fan_speed_map_for(data)}
+
+
+def _legacy_suction_labels_for(data: dict) -> dict[FanLevel, str]:
+    """Return FanLevel labels for this model's visible legacy suction options."""
+    return {FanLevel.UNSPECIFIED: "AI", **fan_speed_label_map_for(data)}
 LEGACY_WATER_MAP: dict[str, MopHumidity] = {
     "Dry": MopHumidity.DRY,
     "Normal": MopHumidity.NORMAL,
@@ -417,12 +414,9 @@ class NarwalSelect(NarwalEntity, RestoreEntity, SelectEntity):
             return setup_available and setup_applies
         live_available = super().available and is_live_clean_setting_available(state)
         live_mode = self.coordinator.clean_setting_applicability_mode(live=True)
-        live_applies = (
-            live_mode is not None
-            and clean_setting_applies_to_mode(
-                self.entity_description.attr,
-                live_mode,
-            )
+        live_applies = clean_setting_applies_to_mode(
+            self.entity_description.attr,
+            live_mode,
         )
         return (
             (setup_available and setup_applies)
@@ -456,12 +450,9 @@ class NarwalSelect(NarwalEntity, RestoreEntity, SelectEntity):
             self.coordinator.clean_settings.work_mode,
         )
         live_mode = self.coordinator.clean_setting_applicability_mode(live=True)
-        live_applies = (
-            live_mode is not None
-            and clean_setting_applies_to_mode(
-                self.entity_description.attr,
-                live_mode,
-            )
+        live_applies = clean_setting_applies_to_mode(
+            self.entity_description.attr,
+            live_mode,
         )
         if not (
             (setup_available and setup_applies)
@@ -684,7 +675,7 @@ class RoomNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
         if key == "mode":
             return LEGACY_MODE_LABELS.get(value)
         if key == "suction":
-            return LEGACY_SUCTION_LABELS.get(value)
+            return self._suction_labels.get(value)
         if key == "water":
             labels = {value: label for label, value in LEGACY_WATER_MAP.items()}
             return labels.get(value)
@@ -704,7 +695,7 @@ class RoomNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
             return option
         if self.entity_description.setting_key != "suction":
             return None
-        label = LEGACY_SUCTION_LABELS.get(LEGACY_SUCTION_MAP.get(option))
+        label = self._suction_labels.get(self._suction_map.get(option))
         return label if label in self.options else None
 
     @staticmethod
@@ -731,7 +722,7 @@ class RoomNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
             mapping = (
                 UNVERSIONED_FAN_SPEED_MAP
                 if unversioned
-                else LEGACY_SUCTION_MAP
+                else self._suction_map
             )
             return mapping.get(option)
         elif key == "water":
@@ -794,6 +785,16 @@ class RoomNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
             value,
             map_id=self._map_id,
         )
+
+    @property
+    def _suction_map(self) -> dict[str, FanLevel]:
+        """Return the model-specific room suction map."""
+        return _legacy_suction_map_for(self.coordinator.config_entry.data)
+
+    @property
+    def _suction_labels(self) -> dict[FanLevel, str]:
+        """Return the model-specific room suction labels."""
+        return _legacy_suction_labels_for(self.coordinator.config_entry.data)
 
     async def async_select_option(self, option: str) -> None:
         """Apply a room profile option."""
@@ -910,7 +911,7 @@ class LegacyNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
         """Return whether the legacy setting applies to the selected mode."""
         mode = self._mode_for_applicability(live=live)
         if mode is None:
-            return not live
+            return key not in {"suction", "water", "scrub"}
         if key == "water" and mode not in LEGACY_MOP_MODES:
             return False
         if key == "scrub" and mode not in LEGACY_MOP_MODES:
@@ -949,7 +950,7 @@ class LegacyNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
             settings.work_mode = LEGACY_MODE_MAP[option]
             self.coordinator._legacy_mode_option = option
         elif key == "suction":
-            settings.fan = LEGACY_SUCTION_MAP[option]
+            settings.fan = self._suction_map[option]
         elif key == "water":
             settings.water = LEGACY_WATER_MAP[option]
         elif key == "scrub":
@@ -1028,7 +1029,7 @@ class LegacyNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
             option = LEGACY_MODE_LABELS.get(settings.work_mode)
         elif key == "suction":
             value = self.coordinator.active_clean_setting("fan")
-            option = LEGACY_SUCTION_LABELS.get(
+            option = self._suction_labels.get(
                 value if value is not None else settings.fan
             )
         elif key == "water":
@@ -1056,7 +1057,7 @@ class LegacyNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
             return option
         if self.entity_description.setting_key != "suction":
             return None
-        label = LEGACY_SUCTION_LABELS.get(LEGACY_SUCTION_MAP.get(option))
+        label = self._suction_labels.get(self._suction_map.get(option))
         return label if label in self.options else None
 
     async def async_select_option(self, option: str) -> None:
@@ -1102,7 +1103,7 @@ class LegacyNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
         if live_available and live_applies and not setup_available:
             if key == "suction":
                 response = await self.coordinator.client.set_fan_speed(
-                    LEGACY_SUCTION_MAP[option]
+                    self._suction_map[option]
                 )
             elif key == "water":
                 response = await self.coordinator.client.set_mop_humidity(
@@ -1121,7 +1122,7 @@ class LegacyNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
         if response is not None:
             attr = "fan" if key == "suction" else "water"
             value = (
-                LEGACY_SUCTION_MAP[option]
+                self._suction_map[option]
                 if key == "suction"
                 else LEGACY_WATER_MAP[option]
             )
@@ -1131,3 +1132,13 @@ class LegacyNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
             self._apply_option(option)
         self.async_write_ha_state()
         self.coordinator.async_update_listeners()
+
+    @property
+    def _suction_map(self) -> dict[str, FanLevel]:
+        """Return the model-specific legacy suction map."""
+        return _legacy_suction_map_for(self.coordinator.config_entry.data)
+
+    @property
+    def _suction_labels(self) -> dict[FanLevel, str]:
+        """Return the model-specific legacy suction labels."""
+        return _legacy_suction_labels_for(self.coordinator.config_entry.data)

--- a/custom_components/narwal/sensor.py
+++ b/custom_components/narwal/sensor.py
@@ -26,8 +26,18 @@ from .narwal_client import NarwalState
 class NarwalSensorEntityDescription(SensorEntityDescription):
     """Describes a Narwal sensor entity."""
 
-    value_fn: Callable[[NarwalState], float | str | None]
+    value_fn: Callable[[NarwalState], float | int | str | None]
+    available_fn: Callable[[NarwalState], bool] | None = None
     dock_device: bool = False
+
+
+def _has_active_cleaning_metrics(state: NarwalState) -> bool:
+    """Return true while live clean-progress metrics describe the current task."""
+    return (
+        state.is_cleaning
+        or state.has_recent_active_working_status
+        or state.has_paused_clean_task_context
+    )
 
 
 SENSOR_DESCRIPTIONS: tuple[NarwalSensorEntityDescription, ...] = (
@@ -48,6 +58,7 @@ SENSOR_DESCRIPTIONS: tuple[NarwalSensorEntityDescription, ...] = (
         value_fn=lambda state: round(state.cleaning_area, 2)
         if state.cleaning_area > 0
         else None,
+        available_fn=_has_active_cleaning_metrics,
     ),
     NarwalSensorEntityDescription(
         key="cleaning_time",
@@ -60,6 +71,19 @@ SENSOR_DESCRIPTIONS: tuple[NarwalSensorEntityDescription, ...] = (
         value_fn=lambda state: state.cleaning_time
         if state.cleaning_time > 0
         else None,
+        available_fn=_has_active_cleaning_metrics,
+    ),
+    NarwalSensorEntityDescription(
+        key="remaining_time",
+        translation_key="remaining_time",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        state_class=SensorStateClass.MEASUREMENT,
+        # base_status task ETA, populated while the robot keeps an active clean task.
+        value_fn=lambda state: state.task_remaining_time
+        if state.task_remaining_time > 0
+        else None,
+        available_fn=_has_active_cleaning_metrics,
     ),
     NarwalSensorEntityDescription(
         key="dust_bag_health",
@@ -100,14 +124,6 @@ SENSOR_DESCRIPTIONS: tuple[NarwalSensorEntityDescription, ...] = (
         # base_status field 15 terminateReason (TaskResult) — why the last task ended.
         value_fn=lambda state: TASK_RESULT_OPTIONS.get(state.terminate_reason),
     ),
-    NarwalSensorEntityDescription(
-        key="current_room",
-        translation_key="current_room",
-        icon="mdi:map-marker",
-        # working_status field 6: room_id of the room currently being cleaned.
-        # Resolved to a display name via the cached room map from get_map.
-        value_fn=lambda state: state.current_room_name,
-    ),
 )
 
 
@@ -147,12 +163,22 @@ class NarwalSensor(NarwalEntity, SensorEntity):
         self._attr_unique_id = f"{device_id}_{description.key}"
 
     @property
-    def native_value(self) -> float | str | None:
+    def native_value(self) -> float | int | str | None:
         """Return the sensor value."""
         state = self.coordinator.data
         if state is None:
             return None
         return self.entity_description.value_fn(state)
+
+    @property
+    def available(self) -> bool:
+        """Return True when this sensor has meaningful current data."""
+        if not super().available:
+            return False
+        if self.entity_description.available_fn is None:
+            return True
+        state = self.coordinator.data
+        return state is not None and self.entity_description.available_fn(state)
 
 
 class NarwalDockSensor(NarwalDockEntity, SensorEntity):
@@ -172,12 +198,22 @@ class NarwalDockSensor(NarwalDockEntity, SensorEntity):
         self._attr_unique_id = f"{device_id}_{description.key}"
 
     @property
-    def native_value(self) -> float | str | None:
+    def native_value(self) -> float | int | str | None:
         """Return the sensor value."""
         state = self.coordinator.data
         if state is None:
             return None
         return self.entity_description.value_fn(state)
+
+    @property
+    def available(self) -> bool:
+        """Return True when this sensor has meaningful current data."""
+        if not super().available:
+            return False
+        if self.entity_description.available_fn is None:
+            return True
+        state = self.coordinator.data
+        return state is not None and self.entity_description.available_fn(state)
 
 
 class NarwalChargingStateSensor(NarwalEntity, SensorEntity):

--- a/custom_components/narwal/strings.json
+++ b/custom_components/narwal/strings.json
@@ -42,6 +42,9 @@
       "cleaning_time": {
         "name": "Cleaning time"
       },
+      "remaining_time": {
+        "name": "Remaining time"
+      },
       "firmware_version": {
         "name": "Firmware version"
       },
@@ -81,9 +84,6 @@
           "fully_charged": "Fully Charged",
           "not_charging": "Not Charging"
         }
-      },
-      "current_room": {
-        "name": "Current room"
       }
     },
     "binary_sensor": {

--- a/custom_components/narwal/switch.py
+++ b/custom_components/narwal/switch.py
@@ -225,6 +225,8 @@ class NarwalDockTaskSwitch(NarwalDockEntity, SwitchEntity):
                 await client.wake(timeout=10.0, force=force_wake)
             if not await self.coordinator.async_refresh_dock_status():
                 raise HomeAssistantError("Narwal dock status could not be refreshed")
+            if self.is_on:
+                return
             if not can_start_dock_task(client.state, self.entity_description.key):
                 raise HomeAssistantError("Narwal dock task cannot be started right now")
 
@@ -247,6 +249,8 @@ class NarwalDockTaskSwitch(NarwalDockEntity, SwitchEntity):
                 await client.wake(timeout=10.0, force=force_wake)
             if not await self.coordinator.async_refresh_dock_status():
                 raise HomeAssistantError("Narwal dock status could not be refreshed")
+            if self.entity_description.key not in client.state.active_dock_task_keys:
+                return
             if not can_stop_dock_task(client.state, self.entity_description.key):
                 raise HomeAssistantError("Narwal dock task cannot be stopped right now")
 

--- a/custom_components/narwal/translations/en.json
+++ b/custom_components/narwal/translations/en.json
@@ -42,6 +42,9 @@
       "cleaning_time": {
         "name": "Cleaning time"
       },
+      "remaining_time": {
+        "name": "Remaining time"
+      },
       "firmware_version": {
         "name": "Firmware version"
       },
@@ -81,9 +84,6 @@
           "fully_charged": "Fully Charged",
           "not_charging": "Not Charging"
         }
-      },
-      "current_room": {
-        "name": "Current room"
       }
     },
     "binary_sensor": {

--- a/custom_components/narwal/vacuum.py
+++ b/custom_components/narwal/vacuum.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.components.vacuum import (
@@ -18,19 +19,30 @@ except ImportError:
     Segment = None  # HA < 2026.3 — room cleaning unavailable
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 
 from . import NarwalConfigEntry
-from .const import FAN_SPEED_LIST, FAN_SPEED_MAP, fan_speed_list_for
-from .coordinator import NarwalCoordinator
+from .const import (
+    FAN_SPEED_LIST,
+    FAN_SPEED_MAP,
+    fan_speed_list_for,
+    normalize_fan_level_for_model,
+)
+from .coordinator import (
+    NarwalCoordinator,
+    can_edit_pending_clean_settings,
+    clean_setting_applies_to_mode,
+    has_blocking_error,
+    is_clean_session_context,
+    is_live_clean_setting_available,
+)
 from .dock_tasks import (
     can_start_robot_clean,
     can_stop_dock_task,
     has_active_dock_work,
-    is_clean_session_context,
 )
 from .entity import NarwalEntity
-from .narwal_client import CommandResult, WorkingStatus
+from .narwal_client import CommandResult, FanLevel, WorkingStatus
 from .narwal_client.const import ACTIVE_CLEANING_STATUSES
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,6 +50,18 @@ _LOGGER = logging.getLogger(__name__)
 # working_status values already reported as unmapped. Activity is recomputed on
 # every state broadcast, so warn once per distinct value instead of flooding.
 _WARNED_UNMAPPED_ACTIVITY: set[int] = set()
+
+
+@dataclass(frozen=True)
+class FanSettingRestoreData(ExtraStoredData):
+    """Persist pending suction by its stable robot value."""
+
+    value: int
+    version: int = 1
+
+    def as_dict(self) -> dict[str, int]:
+        """Return a JSON-serializable representation."""
+        return {"version": self.version, "value": self.value}
 
 WORKING_STATUS_TO_ACTIVITY: dict[WorkingStatus, VacuumActivity] = {
     WorkingStatus.DOCKED: VacuumActivity.DOCKED,
@@ -47,6 +71,7 @@ WORKING_STATUS_TO_ACTIVITY: dict[WorkingStatus, VacuumActivity] = {
     WorkingStatus.CLEANING_V2: VacuumActivity.CLEANING,
     WorkingStatus.CLEANING: VacuumActivity.CLEANING,
     WorkingStatus.CLEANING_ALT: VacuumActivity.CLEANING,
+    WorkingStatus.CUSTOM_CLEANING: VacuumActivity.CLEANING,
     # Mapping/exploration is active robot work.
     WorkingStatus.REMAPPING: VacuumActivity.CLEANING,
     WorkingStatus.TASK_COMPLETED: VacuumActivity.RETURNING,
@@ -66,6 +91,15 @@ def _result_name(result_code: int | CommandResult) -> str:
 
 # FanLevel value -> fan_speed label. FAN_SPEED_MAP also holds back-compat aliases.
 _FAN_LABELS: dict[int, str] = {int(FAN_SPEED_MAP[label]): label for label in FAN_SPEED_LIST}
+
+
+def _raise_if_command_failed(response: Any, action: str) -> None:
+    """Raise a Home Assistant service error for rejected robot commands."""
+    if response.accepted:
+        return
+    raise HomeAssistantError(
+        f"Narwal {action} failed: {_result_name(response.result_code)}"
+    )
 
 
 async def async_setup_entry(
@@ -97,6 +131,25 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         """Hide robot actions while dock work makes them unsafe or ambiguous."""
         features = self._BASE_SUPPORTED_FEATURES
         state = self.coordinator.data
+        setup_fan = (
+            can_edit_pending_clean_settings(state)
+            and not self.coordinator.has_selected_clean_rooms()
+            and clean_setting_applies_to_mode(
+                "fan", self.coordinator.clean_settings.work_mode
+            )
+        )
+        live_fan = False
+        if is_live_clean_setting_available(state):
+            live_mode = self.coordinator.clean_setting_applicability_mode(live=True)
+            live_fan = live_mode is not None and clean_setting_applies_to_mode(
+                "fan", live_mode
+            )
+        if not setup_fan and not live_fan:
+            features &= ~VacuumEntityFeature.FAN_SPEED
+        if not getattr(self.coordinator, "_room_profile_store_loaded", True):
+            features &= ~VacuumEntityFeature.CLEAN_AREA
+            if not (state and state.is_paused and is_clean_session_context(state)):
+                features &= ~VacuumEntityFeature.START
         if not has_active_dock_work(state):
             return features
         features &= ~(
@@ -121,8 +174,37 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         """Restore the pending fan speed into clean_settings (persists across restarts)."""
         await super().async_added_to_hass()
         last = await self.async_get_last_state()
-        if last is not None and (fan := last.attributes.get("fan_speed")) in FAN_SPEED_MAP:
-            self.coordinator.clean_settings.fan = FAN_SPEED_MAP[fan]
+        extra = await self.async_get_last_extra_data()
+        if extra is not None:
+            data = extra.as_dict()
+            raw_value = data.get("value")
+            values = {int(value): value for value in FanLevel}
+            if (
+                data.get("version") == 1
+                and isinstance(raw_value, int)
+                and not isinstance(raw_value, bool)
+                and raw_value in values
+            ):
+                self.coordinator.clean_settings.fan = normalize_fan_level_for_model(
+                    self.coordinator.config_entry.data,
+                    values[raw_value],
+                )
+                return
+        if last is None or "fan_speed" not in last.attributes:
+            return
+        fan = last.attributes.get("fan_speed")
+        if fan is None:
+            self.coordinator.clean_settings.fan = FanLevel.UNSPECIFIED
+        elif fan in FAN_SPEED_MAP:
+            self.coordinator.clean_settings.fan = normalize_fan_level_for_model(
+                self.coordinator.config_entry.data,
+                FAN_SPEED_MAP[fan],
+            )
+
+    @property
+    def extra_restore_state_data(self) -> ExtraStoredData:
+        """Return pending suction independently of its displayed active value."""
+        return FanSettingRestoreData(value=int(self.coordinator.clean_settings.fan))
 
     @property
     def activity(self) -> VacuumActivity:
@@ -173,7 +255,10 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         pending value held in coordinator.clean_settings (applied at the next clean
         and, while cleaning, written live via set_fan_speed).
         """
-        return _FAN_LABELS.get(int(self.coordinator.clean_settings.fan))
+        fan = self.coordinator.active_clean_setting("fan")
+        if fan is None:
+            fan = self.coordinator.clean_settings.fan
+        return _FAN_LABELS.get(int(fan))
 
     # Timeout for action commands (start/stop/return) — robot may need
     # time to load map, plan route, etc., especially after waking.
@@ -202,38 +287,62 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         """Start or resume cleaning."""
         await self._ensure_awake()
         state = self.coordinator.data
-        # is_paused stays stale after docking — only trust it during cleaning
-        is_cleaning = state and state.working_status in ACTIVE_CLEANING_STATUSES
-        if is_cleaning and state.is_paused:
-            await self.coordinator.client.resume(timeout=self._ACTION_TIMEOUT)
+        if (
+            state
+            and not has_blocking_error(state)
+            and state.working_status != WorkingStatus.TASK_COMPLETED
+            and state.is_paused
+            and is_clean_session_context(state)
+        ):
+            response = await self.coordinator.client.resume(
+                timeout=self._ACTION_TIMEOUT
+            )
+            _raise_if_command_failed(response, "resume")
             return
+        if getattr(self.coordinator, "_room_profile_store_loaded", True) is False:
+            raise HomeAssistantError("Narwal room profiles are not restored yet")
         room_ids: list[int] = []
         async with self.coordinator.dock_action_lock:
             await self._validate_clean_start()
 
-            # Whole-house clean enumerates every room via clean/start_clean, matching the
-            # app's allRoomIds() path. clean/plan/start (StartWithPlan) would instead re-run
-            # the saved current plan — i.e. the last room selection — not the whole house.
-            room_ids = await self._all_room_ids()
-            if room_ids:
-                settings = self.coordinator.clean_settings
-                resp = await self.coordinator.client.start_rooms(
-                    room_ids,
-                    work_mode=settings.work_mode,
-                    fan=settings.fan,
-                    water=settings.water,
-                    mop_strength=settings.mop_strength,
-                    passes=settings.passes,
-                )
-            else:
-                # No map rooms known — best-effort fall back to the saved-plan start.
-                resp = await self.coordinator.client.start()
+            # The HA vacuum start command uses integration-owned room selections:
+            # selected rooms when any are on, otherwise all rooms.
+            all_room_ids = await self._all_room_ids()
+            if not all_room_ids:
+                raise HomeAssistantError("Narwal room map is not available")
+            map_id = self.coordinator.room_settings_map_id(
+                self.coordinator.client.state.map_data
+            )
+            if map_id is None and self.coordinator.selected_clean_rooms:
+                raise HomeAssistantError("Narwal room selection is not available")
+            room_ids = self.coordinator.selected_clean_room_ids_for(
+                all_room_ids,
+                map_id=map_id,
+            )
+            if not room_ids:
+                raise HomeAssistantError("Narwal room selection is not available")
+            settings = self.coordinator.clean_settings
+            room_settings = self.coordinator.room_clean_settings_for_rooms(
+                room_ids,
+                map_id=map_id,
+            )
+            resp = await self.coordinator.client.start_rooms(
+                room_ids,
+                work_mode=settings.work_mode,
+                fan=settings.fan,
+                water=settings.water,
+                mop_strength=settings.mop_strength,
+                passes=settings.passes,
+                route=settings.route,
+                room_settings=room_settings,
+            )
             if resp.accepted:
+                self.coordinator.record_accepted_clean_start(room_settings)
                 self.coordinator.client.state.assume_robot_clean()
                 self.coordinator.async_set_updated_data(self.coordinator.client.state)
         _LOGGER.info(
-            "Whole-house start: code=%s, success=%s, rooms=%s",
-            resp.result_code, resp.success, room_ids or "(saved plan)",
+            "Room-aware start: code=%s, success=%s, rooms=%s",
+            resp.result_code, resp.success, room_ids,
         )
         if not resp.accepted:
             _LOGGER.warning(
@@ -244,27 +353,18 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
             raise HomeAssistantError(
                 f"Narwal start command failed: {_result_name(resp.result_code)}"
             )
+        self.async_write_ha_state()
 
     async def _all_room_ids(self) -> list[int]:
-        """Every cleanable room id for a whole-house clean; fetches the map if not cached."""
-        state = self.coordinator.data
-        if state is None or state.map_data is None:
-            try:
-                await self.coordinator.client.get_map()
-            except Exception:  # noqa: BLE001 — best-effort prefetch; fall through to fallback
-                _LOGGER.debug("get_map for whole-house clean failed")
-            state = self.coordinator.data
+        """Return room ids from an authoritative static map."""
+        try:
+            await self.coordinator.client.get_map()
+        except Exception as err:
+            raise HomeAssistantError("Narwal map could not be refreshed") from err
+        state = self.coordinator.client.state
         if state and state.map_data:
             return [r.room_id for r in state.map_data.rooms if r.room_id > 0]
-        # Map still unavailable — reuse the HA segment cache (Segment.id == str(room_id)).
-        cached = getattr(self, "last_seen_segments", None) or []
-        ids: list[int] = []
-        for seg in cached:
-            try:
-                ids.append(int(seg.id))
-            except (ValueError, AttributeError, TypeError):
-                continue
-        return ids
+        return []
 
     async def async_stop(self, **kwargs) -> None:
         """Stop cleaning."""
@@ -338,17 +438,49 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
     async def async_set_fan_speed(self, fan_speed: str, **kwargs) -> None:
         """Set the fan speed.
 
-        Stores it as the pending suction for the next clean; if the robot is
-        currently cleaning, also writes it live via set_fan_speed.
+        Stores it as whole-floor pending suction when no rooms are selected;
+        while cleaning, it also writes the active task live.
         """
         level = FAN_SPEED_MAP.get(fan_speed)
         if level is None:
             return
-        self.coordinator.clean_settings.fan = level
-        self.async_write_ha_state()
         state = self.coordinator.data
-        if state is not None and state.is_cleaning:
-            await self.coordinator.client.set_fan_speed(level)
+        has_selected_rooms = self.coordinator.has_selected_clean_rooms()
+        setup_available = (
+            can_edit_pending_clean_settings(state)
+            and not has_selected_rooms
+        )
+        live_available = super().available and is_live_clean_setting_available(state)
+        setup_applies = clean_setting_applies_to_mode(
+            "fan",
+            self.coordinator.clean_settings.work_mode,
+        )
+        live_mode = self.coordinator.clean_setting_applicability_mode(live=True)
+        live_applies = (
+            live_mode is not None
+            and clean_setting_applies_to_mode("fan", live_mode)
+        )
+        if not (
+            (setup_available and setup_applies)
+            or (live_available and live_applies)
+        ):
+            if not setup_applies and not live_applies:
+                raise HomeAssistantError(
+                    "Narwal fan speed is not available in mop-only mode"
+                )
+            raise HomeAssistantError("Narwal fan speed cannot be changed right now")
+        if live_available and not live_applies:
+            raise HomeAssistantError(
+                "Narwal fan speed is not available in mop-only mode"
+            )
+        if live_available:
+            resp = await self.coordinator.client.set_fan_speed(level)
+            _raise_if_command_failed(resp, "set fan speed")
+            self.coordinator.set_active_clean_setting("fan", level)
+        if not has_selected_rooms:
+            self.coordinator.clean_settings.fan = level
+        self.async_write_ha_state()
+        self.coordinator.async_update_listeners()
 
     # --- Segment API (HA 2026.3 room-specific cleaning) ---
 
@@ -387,38 +519,48 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         Converts string segment IDs back to integer room IDs and sends
         a room-specific clean command to the robot.
         """
+        if getattr(self.coordinator, "_room_profile_store_loaded", True) is False:
+            raise HomeAssistantError("Narwal room profiles are not restored yet")
         await self._ensure_awake()
         try:
-            room_ids = [int(sid) for sid in segment_ids]
+            room_ids = list(dict.fromkeys(int(sid) for sid in segment_ids))
         except (TypeError, ValueError) as err:
             raise HomeAssistantError("Narwal segment IDs must be numeric") from err
+        if not room_ids:
+            raise HomeAssistantError("Narwal segment IDs must not be empty")
+        if any(room_id <= 0 for room_id in room_ids):
+            raise HomeAssistantError("Narwal segment IDs must be positive")
 
         async with self.coordinator.dock_action_lock:
             await self._validate_clean_start()
             try:
                 await self.coordinator.client.get_map()
-            except Exception:
-                _LOGGER.debug("Could not refresh Narwal map before segment clean")
+            except Exception as err:
+                raise HomeAssistantError(
+                    "Narwal map could not be refreshed"
+                ) from err
             state = self.coordinator.client.state
-            known_room_ids = {
+            known_ids = {
                 room.room_id
                 for room in getattr(getattr(state, "map_data", None), "rooms", ())
                 if room.room_id > 0
             }
-            if known_room_ids:
-                unknown_room_ids = [
-                    room_id for room_id in room_ids if room_id not in known_room_ids
-                ]
-                if unknown_room_ids:
-                    raise HomeAssistantError(
-                        f"Unknown Narwal room ID: {', '.join(map(str, unknown_room_ids))}"
-                    )
+            if not known_ids:
+                raise HomeAssistantError("Narwal map is not available")
+            unknown_ids = [room_id for room_id in room_ids if room_id not in known_ids]
+            if unknown_ids:
+                raise HomeAssistantError(
+                    "Unknown Narwal room ID: "
+                    f"{', '.join(str(room_id) for room_id in unknown_ids)}"
+                )
             settings = self.coordinator.clean_settings
+            room_settings = self.coordinator.room_clean_settings_for_rooms(room_ids)
             _LOGGER.info(
                 "Starting room-specific clean: rooms=%s mode=%s fan=%s water=%s "
-                "mop_strength=%s passes=%s",
+                "mop_strength=%s passes=%s route=%s",
                 room_ids, settings.work_mode.name, settings.fan.name,
                 settings.water.name, settings.mop_strength.name, settings.passes,
+                settings.route.name,
             )
             resp = await self.coordinator.client.start_rooms(
                 room_ids,
@@ -427,8 +569,11 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
                 water=settings.water,
                 mop_strength=settings.mop_strength,
                 passes=settings.passes,
+                route=settings.route,
+                room_settings=room_settings,
             )
             if resp.accepted:
+                self.coordinator.record_accepted_clean_start(room_settings)
                 self.coordinator.client.state.assume_robot_clean()
                 self.coordinator.async_set_updated_data(self.coordinator.client.state)
         result_name = _result_name(resp.result_code)
@@ -447,6 +592,7 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
             raise HomeAssistantError(
                 f"Narwal room clean failed: {result_name}"
             )
+        self.async_write_ha_state()
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/narwal/vacuum.py
+++ b/custom_components/narwal/vacuum.py
@@ -23,33 +23,30 @@ from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 
 from . import NarwalConfigEntry
 from .const import (
-    FAN_SPEED_LIST,
-    FAN_SPEED_MAP,
+    UNVERSIONED_FAN_SPEED_MAP,
+    fan_speed_label_map_for,
     fan_speed_list_for,
+    fan_speed_map_for,
     normalize_fan_level_for_model,
 )
 from .coordinator import (
     NarwalCoordinator,
     can_edit_pending_clean_settings,
+    can_locate_robot,
+    can_pause_cleaning,
+    can_prepare_clean_start,
+    can_resume_cleaning,
+    can_return_home,
+    can_start_cleaning,
+    can_stop_cleaning,
     clean_setting_applies_to_mode,
-    has_blocking_error,
-    is_clean_session_context,
     is_live_clean_setting_available,
-)
-from .dock_tasks import (
-    can_start_robot_clean,
-    can_stop_dock_task,
-    has_active_dock_work,
 )
 from .entity import NarwalEntity
 from .narwal_client import CommandResult, FanLevel, WorkingStatus
 from .narwal_client.const import ACTIVE_CLEANING_STATUSES
 
 _LOGGER = logging.getLogger(__name__)
-
-# working_status values already reported as unmapped. Activity is recomputed on
-# every state broadcast, so warn once per distinct value instead of flooding.
-_WARNED_UNMAPPED_ACTIVITY: set[int] = set()
 
 
 @dataclass(frozen=True)
@@ -62,6 +59,7 @@ class FanSettingRestoreData(ExtraStoredData):
     def as_dict(self) -> dict[str, int]:
         """Return a JSON-serializable representation."""
         return {"version": self.version, "value": self.value}
+
 
 WORKING_STATUS_TO_ACTIVITY: dict[WorkingStatus, VacuumActivity] = {
     WorkingStatus.DOCKED: VacuumActivity.DOCKED,
@@ -77,8 +75,6 @@ WORKING_STATUS_TO_ACTIVITY: dict[WorkingStatus, VacuumActivity] = {
     WorkingStatus.TASK_COMPLETED: VacuumActivity.RETURNING,
     WorkingStatus.ERROR: VacuumActivity.ERROR,
 }
-
-
 def _result_name(result_code: int | CommandResult) -> str:
     """Return a readable Narwal command result name."""
     if result_code == 0:
@@ -89,10 +85,6 @@ def _result_name(result_code: int | CommandResult) -> str:
         return f"UNKNOWN({result_code})"
 
 
-# FanLevel value -> fan_speed label. FAN_SPEED_MAP also holds back-compat aliases.
-_FAN_LABELS: dict[int, str] = {int(FAN_SPEED_MAP[label]): label for label in FAN_SPEED_LIST}
-
-
 def _raise_if_command_failed(response: Any, action: str) -> None:
     """Raise a Home Assistant service error for rejected robot commands."""
     if response.accepted:
@@ -100,6 +92,102 @@ def _raise_if_command_failed(response: Any, action: str) -> None:
     raise HomeAssistantError(
         f"Narwal {action} failed: {_result_name(response.result_code)}"
     )
+
+
+def _task_status(state: Any) -> str:
+    """Return a compact active-task status for dashboards and automations."""
+    is_cleaning_state = (
+        state.working_status in ACTIVE_CLEANING_STATUSES
+        or state.has_assumed_robot_clean
+        or state.has_recent_active_working_status
+        or state.has_paused_clean_task_context
+    )
+    if state.working_status == WorkingStatus.ERROR or getattr(state, "has_error", False):
+        return "error"
+    if state.is_paused and is_cleaning_state:
+        return "paused"
+    if state.working_status == WorkingStatus.REMAPPING:
+        return "remapping"
+    if state.is_returning or state.working_status == WorkingStatus.TASK_COMPLETED:
+        return "returning"
+    if state.is_cleaning or state.has_assumed_robot_clean:
+        return "cleaning"
+    if state.is_station_active:
+        return "station_active"
+    if state.is_docked:
+        return "docked"
+    if state.working_status == WorkingStatus.STANDBY:
+        return "idle"
+    return "unknown"
+
+
+def _is_dock_side(state: Any) -> bool:
+    """Return true when robot telemetry says it is physically dock-side."""
+    return state.is_docked
+
+
+def _has_active_cleaning_metrics(state: Any) -> bool:
+    """Return true while live clean-progress details are current."""
+    return (
+        state.is_cleaning
+        or state.has_assumed_robot_clean
+        or state.has_recent_active_working_status
+        or state.has_paused_clean_task_context
+    )
+
+
+def _has_dock_stop_context(state: Any) -> bool:
+    """Return true when dock-side work must be considered before generic stop."""
+    return (
+        state.is_station_active
+        or state.has_unmapped_active_dock_task
+        or bool(state.active_dock_task_keys)
+    )
+
+
+def _can_stop_vacuum(state: Any) -> bool:
+    """Return true when the aggregate vacuum stop command is safe to expose."""
+    if _has_dock_stop_context(state) and not _has_live_robot_stop_context(state):
+        return False
+    return can_stop_cleaning(state)
+
+
+def _can_accept_return_home(state: Any) -> bool:
+    """Return true when return-home can act or is an idle dock no-op."""
+    return can_return_home(state) or (
+        state.is_docked
+        and not _has_dock_stop_context(state)
+        and not _has_live_robot_stop_context(state)
+    )
+
+
+def _has_live_robot_stop_context(state: Any) -> bool:
+    """Return true when robot telemetry identifies live stoppable work."""
+    return (
+        state.working_status in ACTIVE_CLEANING_STATUSES
+        or state.working_status == WorkingStatus.REMAPPING
+        or state.has_assumed_robot_clean
+        or state.has_paused_clean_task_context
+        or state.is_returning
+    )
+
+
+def _status_summary(state: Any) -> str:
+    """Return one concise status line for HA tile state content."""
+    status = _task_status(state)
+    if status in {"error", "paused", "remapping", "returning"}:
+        return status.replace("_", " ").title()
+    active_cleaning_metrics = _has_active_cleaning_metrics(state)
+    parts: list[str] = []
+
+    if active_cleaning_metrics and state.current_room_name:
+        parts.append(state.current_room_name)
+    if active_cleaning_metrics and state.task_progress_percent is not None:
+        parts.append(f"{state.task_progress_percent}%")
+    if parts:
+        return " - ".join(parts)
+
+    return status.replace("_", " ").title()
 
 
 async def async_setup_entry(
@@ -116,52 +204,6 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
     """Representation of a Narwal robot vacuum."""
 
     _attr_translation_key = "vacuum"
-    _BASE_SUPPORTED_FEATURES = (
-        VacuumEntityFeature.STATE
-        | VacuumEntityFeature.START
-        | VacuumEntityFeature.STOP
-        | VacuumEntityFeature.PAUSE
-        | VacuumEntityFeature.RETURN_HOME
-        | VacuumEntityFeature.FAN_SPEED
-        | VacuumEntityFeature.LOCATE
-    ) | (VacuumEntityFeature.CLEAN_AREA if Segment is not None else VacuumEntityFeature(0))
-
-    @property
-    def supported_features(self) -> VacuumEntityFeature:
-        """Hide robot actions while dock work makes them unsafe or ambiguous."""
-        features = self._BASE_SUPPORTED_FEATURES
-        state = self.coordinator.data
-        setup_fan = (
-            can_edit_pending_clean_settings(state)
-            and not self.coordinator.has_selected_clean_rooms()
-            and clean_setting_applies_to_mode(
-                "fan", self.coordinator.clean_settings.work_mode
-            )
-        )
-        live_fan = False
-        if is_live_clean_setting_available(state):
-            live_mode = self.coordinator.clean_setting_applicability_mode(live=True)
-            live_fan = live_mode is not None and clean_setting_applies_to_mode(
-                "fan", live_mode
-            )
-        if not setup_fan and not live_fan:
-            features &= ~VacuumEntityFeature.FAN_SPEED
-        if not getattr(self.coordinator, "_room_profile_store_loaded", True):
-            features &= ~VacuumEntityFeature.CLEAN_AREA
-            if not (state and state.is_paused and is_clean_session_context(state)):
-                features &= ~VacuumEntityFeature.START
-        if not has_active_dock_work(state):
-            return features
-        features &= ~(
-            VacuumEntityFeature.START
-            | VacuumEntityFeature.PAUSE
-            | VacuumEntityFeature.RETURN_HOME
-            | VacuumEntityFeature.LOCATE
-            | VacuumEntityFeature.CLEAN_AREA
-        )
-        if not is_clean_session_context(state):
-            features &= ~VacuumEntityFeature.STOP
-        return features
 
     def __init__(self, coordinator: NarwalCoordinator) -> None:
         """Initialize the vacuum entity."""
@@ -169,6 +211,7 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         self._attr_unique_id = coordinator.config_entry.data["device_id"]
         # Offered tiers are per-model: models whose app tops out at DEEP don't get "Ultra".
         self._attr_fan_speed_list = fan_speed_list_for(coordinator.config_entry.data)
+        self._last_reported_segment_signature = None
 
     async def async_added_to_hass(self) -> None:
         """Restore the pending fan speed into clean_settings (persists across restarts)."""
@@ -195,11 +238,81 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         fan = last.attributes.get("fan_speed")
         if fan is None:
             self.coordinator.clean_settings.fan = FanLevel.UNSPECIFIED
-        elif fan in FAN_SPEED_MAP:
+            return
+        if fan in UNVERSIONED_FAN_SPEED_MAP:
             self.coordinator.clean_settings.fan = normalize_fan_level_for_model(
                 self.coordinator.config_entry.data,
-                FAN_SPEED_MAP[fan],
+                UNVERSIONED_FAN_SPEED_MAP[fan],
             )
+
+    @property
+    def supported_features(self) -> VacuumEntityFeature:
+        """Return currently usable native Home Assistant vacuum features."""
+        features = VacuumEntityFeature.STATE
+        state = self.coordinator.data
+        if state is None or not self.available:
+            return features
+
+        if can_resume_cleaning(state) or self._can_start_selected_rooms(state):
+            features |= VacuumEntityFeature.START
+        if _can_stop_vacuum(state):
+            features |= VacuumEntityFeature.STOP
+        if can_pause_cleaning(state):
+            features |= VacuumEntityFeature.PAUSE
+        if _can_accept_return_home(state):
+            features |= VacuumEntityFeature.RETURN_HOME
+        if can_locate_robot(state):
+            features |= VacuumEntityFeature.LOCATE
+        if self._fan_speed_available(state):
+            features |= VacuumEntityFeature.FAN_SPEED
+        if (
+            Segment is not None
+            and can_prepare_clean_start(state)
+            and getattr(self.coordinator, "_room_profile_store_loaded", True)
+        ):
+            features |= VacuumEntityFeature.CLEAN_AREA
+        return features
+
+    def _can_start_selected_rooms(self, state: Any) -> bool:
+        """Return True when native START can use the current room selection."""
+        if not can_prepare_clean_start(state):
+            return False
+        if not getattr(self.coordinator, "_room_selection_store_loaded", True):
+            return False
+        if not getattr(self.coordinator, "_room_profile_store_loaded", True):
+            return False
+        room_ids = self._known_room_ids(state)
+        if room_ids is None:
+            # async_start can still fetch the map before dispatch.
+            return True
+        if not room_ids:
+            return False
+        selected_room_ids = self.coordinator.selected_clean_room_ids_for(room_ids)
+        return bool(selected_room_ids)
+
+    @staticmethod
+    def _known_room_ids(state: Any) -> list[int] | None:
+        """Return currently cached cleanable room IDs."""
+        map_data = getattr(state, "map_data", None)
+        if map_data is None:
+            return None
+        return [room.room_id for room in map_data.rooms if room.room_id > 0]
+
+    def _fan_speed_available(self, state: Any) -> bool:
+        """Return True when HA should expose the native fan speed control."""
+        setup_available = can_edit_pending_clean_settings(state)
+        live_available = super().available and is_live_clean_setting_available(state)
+        setup_applies = clean_setting_applies_to_mode(
+            "fan",
+            self.coordinator.clean_settings.work_mode,
+        )
+        live_applies = clean_setting_applies_to_mode(
+            "fan",
+            self.coordinator.clean_setting_applicability_mode(live=True),
+        )
+        return (setup_available and setup_applies) or (
+            live_available and live_applies
+        )
 
     @property
     def extra_restore_state_data(self) -> ExtraStoredData:
@@ -214,8 +327,12 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
             return VacuumActivity.IDLE
         is_cleaning_state = (
             state.working_status in ACTIVE_CLEANING_STATUSES
+            or state.has_assumed_robot_clean
             or state.has_recent_active_working_status
+            or state.has_paused_clean_task_context
         )
+        if state.working_status == WorkingStatus.ERROR or getattr(state, "has_error", False):
+            return VacuumActivity.ERROR
         # is_paused (field 3.2) stays stale after docking — only trust
         # during cleaning states. Paused takes priority over returning
         # since the robot physically stops when paused mid-return.
@@ -225,25 +342,21 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         # while navigating back to dock (field 3.7=1 indicates returning)
         if state.is_returning:
             return VacuumActivity.RETURNING
-        if state.is_cleaning:
+        if state.is_cleaning or state.has_assumed_robot_clean:
             return VacuumActivity.CLEANING
-        if state.is_docked:
+        if _is_dock_side(state):
             return VacuumActivity.DOCKED
         activity = WORKING_STATUS_TO_ACTIVITY.get(state.working_status)
+        if activity == VacuumActivity.DOCKED:
+            return VacuumActivity.IDLE
         if activity is not None:
             return activity
-        # Unknown working_status value: infer from dock signals so we don't
-        # report IDLE while the robot is clearly active off-dock. New firmware
-        # versions may introduce values we haven't mapped yet.
-        if not state.is_docked:
-            if state.working_status.value not in _WARNED_UNMAPPED_ACTIVITY:
-                _WARNED_UNMAPPED_ACTIVITY.add(state.working_status.value)
-                _LOGGER.warning(
-                    "Unmapped working_status %s (%d) while off-dock; reporting "
-                    "CLEANING (further occurrences are suppressed)",
-                    state.working_status.name,
-                    state.working_status.value,
-                )
+        if (
+            state.working_status == WorkingStatus.UNKNOWN
+            and state.has_explicit_off_dock_signal
+        ):
+            # New firmware may report an unknown status while the physical
+            # telemetry still proves the robot is away from its dock.
             return VacuumActivity.CLEANING
         return VacuumActivity.IDLE
 
@@ -258,7 +371,25 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         fan = self.coordinator.active_clean_setting("fan")
         if fan is None:
             fan = self.coordinator.clean_settings.fan
-        return _FAN_LABELS.get(int(fan))
+        return fan_speed_label_map_for(self.coordinator.config_entry.data).get(fan)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return task context for dashboard cards and automations."""
+        state = self.coordinator.data
+        if state is None:
+            return None
+
+        attributes: dict[str, Any] = {
+            "task_status": _task_status(state),
+            "status_summary": _status_summary(state),
+        }
+        active_cleaning_metrics = _has_active_cleaning_metrics(state)
+        if active_cleaning_metrics and state.task_progress_percent is not None:
+            attributes["progress"] = state.task_progress_percent
+        if active_cleaning_metrics and state.current_room_name:
+            attributes["current_room"] = state.current_room_name
+        return attributes
 
     # Timeout for action commands (start/stop/return) — robot may need
     # time to load map, plan route, etc., especially after waking.
@@ -277,33 +408,24 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
             await client.wake(timeout=10.0)
 
     async def _validate_clean_start(self) -> None:
-        """Refresh dock state and reject starts that conflict with dock work."""
-        if not await self.coordinator.async_refresh_dock_status():
-            raise HomeAssistantError("Narwal status could not be refreshed")
-        if not can_start_robot_clean(self.coordinator.client.state):
-            raise HomeAssistantError("Narwal dock task is active")
+        """Refresh dock state and clear safe dock blockers before clean start."""
+        if not await self.coordinator.async_prepare_clean_start():
+            raise HomeAssistantError("Narwal clean cannot be started right now")
 
     async def async_start(self) -> None:
         """Start or resume cleaning."""
-        await self._ensure_awake()
-        state = self.coordinator.data
-        if (
-            state
-            and not has_blocking_error(state)
-            and state.working_status != WorkingStatus.TASK_COMPLETED
-            and state.is_paused
-            and is_clean_session_context(state)
-        ):
-            response = await self.coordinator.client.resume(
-                timeout=self._ACTION_TIMEOUT
-            )
-            _raise_if_command_failed(response, "resume")
-            return
-        if getattr(self.coordinator, "_room_profile_store_loaded", True) is False:
-            raise HomeAssistantError("Narwal room profiles are not restored yet")
         room_ids: list[int] = []
         async with self.coordinator.dock_action_lock:
-            await self._validate_clean_start()
+            await self._ensure_awake()
+            if not await self.coordinator.async_refresh_action_status():
+                raise HomeAssistantError("Narwal status could not be refreshed")
+            state = self.coordinator.client.state
+            if can_resume_cleaning(state):
+                resp = await self.coordinator.client.resume(timeout=self._ACTION_TIMEOUT)
+                _raise_if_command_failed(resp, "resume")
+                return
+            if getattr(self.coordinator, "_room_profile_store_loaded", True) is False:
+                raise HomeAssistantError("Narwal room profiles are not restored yet")
 
             # The HA vacuum start command uses integration-owned room selections:
             # selected rooms when any are on, otherwise all rooms.
@@ -326,6 +448,9 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
                 room_ids,
                 map_id=map_id,
             )
+            await self._validate_clean_start()
+            if not can_start_cleaning(self.coordinator.client.state):
+                raise HomeAssistantError("Narwal clean cannot be started right now")
             resp = await self.coordinator.client.start_rooms(
                 room_ids,
                 work_mode=settings.work_mode,
@@ -356,7 +481,7 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         self.async_write_ha_state()
 
     async def _all_room_ids(self) -> list[int]:
-        """Return room ids from an authoritative static map."""
+        """Return every room from an authoritative map refresh."""
         try:
             await self.coordinator.client.get_map()
         except Exception as err:
@@ -367,52 +492,43 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         return []
 
     async def async_stop(self, **kwargs) -> None:
-        """Stop cleaning."""
-        await self._ensure_awake()
+        """Stop robot-side cleaning without affecting dock-only work."""
         async with self.coordinator.dock_action_lock:
-            refreshed = await self.coordinator.async_refresh_dock_status()
+            await self._ensure_awake()
+            refreshed = await self.coordinator.async_refresh_action_status()
+            if not refreshed:
+                raise HomeAssistantError("Narwal status could not be refreshed")
             state = self.coordinator.client.state
-            clean_context = is_clean_session_context(state)
-            if state.has_unmapped_active_dock_task and not clean_context:
-                raise HomeAssistantError(
-                    "Narwal dock task cannot be stopped safely right now"
-                )
-            if state.is_station_active and not clean_context:
-                if not can_stop_dock_task(state):
-                    raise HomeAssistantError(
-                        "Narwal dock task cannot be stopped safely right now"
-                    )
-                resp = await self.coordinator.client.stop_dock_task()
-            elif not clean_context:
-                if not refreshed:
-                    raise HomeAssistantError("Narwal status could not be refreshed")
-                raise HomeAssistantError("Narwal has no active task to stop")
-            else:
-                resp = await self.coordinator.client.stop()
+            if not _can_stop_vacuum(state):
+                raise HomeAssistantError("Narwal has no active robot task to stop")
+            resp = await self.coordinator.client.stop()
         _LOGGER.info("Stop response: code=%s, success=%s", resp.result_code, resp.success)
-        if not resp.accepted:
-            raise HomeAssistantError(
-                f"Narwal stop command failed: {_result_name(resp.result_code)}"
-            )
+        _raise_if_command_failed(resp, "stop")
 
     async def async_pause(self) -> None:
         """Pause cleaning."""
         async with self.coordinator.dock_action_lock:
-            if not await self.coordinator.async_refresh_dock_status():
+            await self._ensure_awake()
+            if not await self.coordinator.async_refresh_action_status():
                 raise HomeAssistantError("Narwal status could not be refreshed")
-            if has_active_dock_work(self.coordinator.client.state):
-                raise HomeAssistantError("Narwal dock task is active")
+            state = self.coordinator.client.state
+            if not can_pause_cleaning(state):
+                raise HomeAssistantError("Narwal clean cannot be paused right now")
             resp = await self.coordinator.client.pause()
         _LOGGER.info("Pause response: code=%s, success=%s", resp.result_code, resp.success)
+        _raise_if_command_failed(resp, "pause")
 
     async def async_return_to_base(self, **kwargs) -> None:
         """Return to the dock."""
-        await self._ensure_awake()
         async with self.coordinator.dock_action_lock:
-            if not await self.coordinator.async_refresh_dock_status():
+            await self._ensure_awake()
+            if not await self.coordinator.async_refresh_action_status():
                 raise HomeAssistantError("Narwal status could not be refreshed")
-            if has_active_dock_work(self.coordinator.client.state):
-                raise HomeAssistantError("Narwal dock task is active")
+            state = self.coordinator.client.state
+            if state.is_docked and _can_accept_return_home(state):
+                return
+            if not can_return_home(state):
+                raise HomeAssistantError("Narwal cannot return to the dock right now")
             resp = await self.coordinator.client.return_to_base(timeout=self._ACTION_TIMEOUT)
         _LOGGER.info(
             "Return-to-base response: code=%s, success=%s",
@@ -424,16 +540,20 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
                 _result_name(resp.result_code),
                 resp.result_code,
             )
+        _raise_if_command_failed(resp, "return to dock")
+        self.async_write_ha_state()
 
     async def async_locate(self, **kwargs) -> None:
         """Locate the vacuum — robot says 'Robot is here'."""
-        await self._ensure_awake()
         async with self.coordinator.dock_action_lock:
-            if not await self.coordinator.async_refresh_dock_status():
+            await self._ensure_awake()
+            if not await self.coordinator.async_refresh_action_status():
                 raise HomeAssistantError("Narwal status could not be refreshed")
-            if has_active_dock_work(self.coordinator.client.state):
-                raise HomeAssistantError("Narwal dock task is active")
-            await self.coordinator.client.locate()
+            state = self.coordinator.client.state
+            if not can_locate_robot(state):
+                raise HomeAssistantError("Narwal locate cannot be used right now")
+            resp = await self.coordinator.client.locate()
+        _raise_if_command_failed(resp, "locate")
 
     async def async_set_fan_speed(self, fan_speed: str, **kwargs) -> None:
         """Set the fan speed.
@@ -441,9 +561,10 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         Stores it as whole-floor pending suction when no rooms are selected;
         while cleaning, it also writes the active task live.
         """
-        level = FAN_SPEED_MAP.get(fan_speed)
+        fan_speed_map = fan_speed_map_for(self.coordinator.config_entry.data)
+        level = fan_speed_map.get(fan_speed)
         if level is None:
-            return
+            raise HomeAssistantError(f"Unsupported Narwal fan speed: {fan_speed}")
         state = self.coordinator.data
         has_selected_rooms = self.coordinator.has_selected_clean_rooms()
         setup_available = (
@@ -455,10 +576,9 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
             "fan",
             self.coordinator.clean_settings.work_mode,
         )
-        live_mode = self.coordinator.clean_setting_applicability_mode(live=True)
-        live_applies = (
-            live_mode is not None
-            and clean_setting_applies_to_mode("fan", live_mode)
+        live_applies = clean_setting_applies_to_mode(
+            "fan",
+            self.coordinator.clean_setting_applicability_mode(live=True),
         )
         if not (
             (setup_available and setup_applies)
@@ -532,13 +652,10 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
             raise HomeAssistantError("Narwal segment IDs must be positive")
 
         async with self.coordinator.dock_action_lock:
-            await self._validate_clean_start()
             try:
                 await self.coordinator.client.get_map()
             except Exception as err:
-                raise HomeAssistantError(
-                    "Narwal map could not be refreshed"
-                ) from err
+                raise HomeAssistantError("Narwal map could not be refreshed") from err
             state = self.coordinator.client.state
             known_ids = {
                 room.room_id
@@ -555,6 +672,7 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
                 )
             settings = self.coordinator.clean_settings
             room_settings = self.coordinator.room_clean_settings_for_rooms(room_ids)
+            await self._validate_clean_start()
             _LOGGER.info(
                 "Starting room-specific clean: rooms=%s mode=%s fan=%s water=%s "
                 "mop_strength=%s passes=%s route=%s",
@@ -619,9 +737,15 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
             if r.room_id > 0
         }
         last_set = {(s.id, s.name) for s in last}
-        if current_set != last_set:
-            _LOGGER.info(
-                "Segment change detected: %d -> %d rooms",
-                len(last_set), len(current_set),
-            )
-            self.async_create_segments_issue()
+        if current_set == last_set:
+            self._last_reported_segment_signature = None
+            return
+        signature = (frozenset(last_set), frozenset(current_set))
+        if signature == self._last_reported_segment_signature:
+            return
+        self._last_reported_segment_signature = signature
+        _LOGGER.info(
+            "Segment change detected: %d -> %d rooms",
+            len(last_set), len(current_set),
+        )
+        self.async_create_segments_issue()

--- a/custom_components/narwal/vacuum.py
+++ b/custom_components/narwal/vacuum.py
@@ -42,6 +42,7 @@ from .coordinator import (
     clean_setting_applies_to_mode,
     is_live_clean_setting_available,
 )
+from .dock_tasks import ROBOT_RETURN_COMPATIBLE_DOCK_TASKS
 from .entity import NarwalEntity
 from .narwal_client import CommandResult, FanLevel, WorkingStatus
 from .narwal_client.const import ACTIVE_CLEANING_STATUSES
@@ -147,7 +148,17 @@ def _has_dock_stop_context(state: Any) -> bool:
 
 def _can_stop_vacuum(state: Any) -> bool:
     """Return true when the aggregate vacuum stop command is safe to expose."""
-    if _has_dock_stop_context(state) and not _has_live_robot_stop_context(state):
+    compatible_metric_clean = (
+        state.has_recent_active_working_status
+        and not state.has_unmapped_active_dock_task
+        and set(state.active_dock_task_keys)
+        <= ROBOT_RETURN_COMPATIBLE_DOCK_TASKS
+    )
+    if (
+        _has_dock_stop_context(state)
+        and not _has_live_robot_stop_context(state)
+        and not compatible_metric_clean
+    ):
         return False
     return can_stop_cleaning(state)
 
@@ -300,7 +311,10 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
 
     def _fan_speed_available(self, state: Any) -> bool:
         """Return True when HA should expose the native fan speed control."""
-        setup_available = can_edit_pending_clean_settings(state)
+        setup_available = (
+            can_edit_pending_clean_settings(state)
+            and not self.coordinator.has_selected_clean_rooms()
+        )
         live_available = super().available and is_live_clean_setting_available(state)
         setup_applies = clean_setting_applies_to_mode(
             "fan",

--- a/docs/DOCK_TASKS.md
+++ b/docs/DOCK_TASKS.md
@@ -89,10 +89,19 @@ Current verified policy should be conservative:
 
 - Do not allow dock-to-dock parallel starts unless hardware testing proves the
   exact combination.
-- Allow robot start during `dry_dock_bag` only when there is typed live evidence
-  that the active task is dock-bag drying.
-- Block robot starts for emptying, washing, mop drying, dust-bin drying, and
-  unmapped station activity.
+- Treat robot Start/Clean Area as an intent. Send it directly during typed mop,
+  dust-bin, or dock-bag drying: live Flow 2 tests show that the robot ends the
+  first two itself and allows dock-bag drying to continue after departure.
+- Stop a single typed emptying or washing task, refresh, then send the robot
+  command. A wash stop may transition into mop drying, which is safe to hand off
+  to the clean command.
+- Keep mixed emptying/washing plus drying states fail-closed because generic
+  force-end cannot identify one task safely in that state.
+- For multi-target room-clean service calls, reject dock-stop preparation
+  instead of partially cancelling maintenance on one target before another
+  target fails.
+- Block robot starts for ambiguous mixed station activity, unmapped station
+  activity, active robot work, faults, and stale status.
 - Keep robot `stop` available during a dock-side phase that belongs to an
   active clean.
 - Do not infer charge-to-resume from dock maintenance.

--- a/docs/DOCK_TASK_TEST_PLAN.md
+++ b/docs/DOCK_TASK_TEST_PLAN.md
@@ -79,8 +79,8 @@ Direct client calls:
 | Charging to resume | all five dock tasks | active task if present | Separate recharge from dock maintenance |
 | Dock-side phase during clean | none | robot stop, matching dock stop | Keep robot cancellation available |
 | Unmapped active station task | all five dock tasks | active task if known | Block unsafe starts |
-| `dry_dock_bag` active | room clean, all other dock tasks | `dry_dock_bag` | Validate robot-compatible dock task |
-| Robot leaves while `dry_dock_bag` active | no dock starts | `dry_dock_bag` | Preserve dock-owned task after departure |
+| `dry_dock_bag` active | room clean, all other dock tasks | `dry_dock_bag` | Validate clean starts while dock-bag drying continues |
+| Robot leaves while `dry_dock_bag` active | no dock starts | `dry_dock_bag` | Preserve already-running dock-owned task after departure |
 
 ## Conflict Matrix
 
@@ -106,7 +106,9 @@ For each active dock task, also try:
 Expected conservative default before verification:
 
 - Other dock task starts are unavailable.
-- Robot start is unavailable except during verified `dry_dock_bag`.
+- Robot start is exposed directly during typed drying tasks. During a single
+  emptying or washing task, it is exposed when preflight can stop that task,
+  refresh, then send the clean command.
 - Robot stop remains available only when the dock task is part of an active
   robot clean session.
 - Locate and return-to-base should not run while station work would make the
@@ -185,6 +187,71 @@ confirmed the same dust-bin drying task was active. Treat that as real device
 telemetry, not a restored HA switch assumption. Dock task switches should only
 come from robot telemetry or a short accepted-command guard.
 
+### 2026-08-29, Flow 2 upstairs, firmware `v01.09.08.00`
+
+Tested through Home Assistant service calls against the upstairs robot.
+
+| Scenario | Result | Notes |
+|---|---|---|
+| HA restart/load while robot docked idle | needs refresh | Vacuum loaded as `docked`, but all dock task switches were `unavailable` until `homeassistant.update_entity` refreshed the Narwal entities. |
+| `empty_dustbin` start/stop | verified | Start set only the empty switch on; other dock starts were unavailable; stop cleared it back to idle. |
+| `wash_mop` start/stop | verified | Stop was accepted and then the dock automatically entered `dry_mop`, matching app-style wash behavior. |
+| clean start during `dry_mop` | blocked | Current code returned a service error instead of stopping the safe blocker first. |
+| `dry_mop` stop | verified | Generic single-task stop cleared the task after the auto-dry phase. |
+| `dry_dust_bin` start | verified | Timer/progress appeared as `45m` and percent progress. |
+| clean start during `dry_dust_bin` | blocked | Current code rejected before attempting a safe blocker stop. |
+| `dry_dust_bin` stop after stale state | fixed in code | First stop attempt was rejected before refresh; an explicit entity refresh then allowed the scoped `0805` stop to clear it. Switch stop now refreshes before stop validation. |
+| `dry_dock_bag` start/stop | verified with caveat | Scoped `0801` stop cleared a correctly typed dock-bag drying task after status settled. A generic-force-end probe did not clear it and briefly exposed overlapping dry task telemetry; do not replace the scoped payload. |
+| clean start during `dry_dock_bag` | accepted, needs repeat | `narwal.clean_rooms` returned success while dock-bag drying was active; HA did not show robot progress for ~25s, then after a HA restart the robot reported Bathroom cleaning at 91%. Treat this as evidence that the robot may accept it, not as the integration rule for a new Start intent. |
+| robot pause during near-complete clean | inconclusive | `vacuum.pause` returned success but HA stayed cleaning at 91%; this may have been a near-completion race. |
+| robot stop/return after accepted clean | verified | `vacuum.stop` accepted, then `vacuum.return_to_base` accepted. After a refresh the vacuum was `docked` and all dock switches were idle. |
+| repeat clean start after `dry_mop` | blocked by hardware fault | After deploying the stricter start planner, a room clean request stopped `dry_mop` and was accepted. Follow-up refresh showed Bathroom progress, but the robot then entered fault `34603041` (`0x02100021`): trapped while navigating back to the base, with no automatic recall. Further live testing needs the upstairs robot physically cleared/reset first. |
+
+Code follow-up from this run:
+
+- Dock switch start/stop service methods refresh before rejecting so stale local
+  state does not block a task that fresh telemetry can stop.
+- Clean start paths should treat Start as an intent: hand typed drying tasks to
+  the robot command, or stop one known emptying/washing task and refresh first.
+  They still fail closed for unmapped activity, ambiguous mixed blockers,
+  active robot work, faults, and stale status.
+- Multi-target room-clean service calls preflight every target before any start.
+  If any target would require stopping a dock task, the call fails before
+  mutation because dock-stop preparation cannot be rolled back atomically.
+- Vacuum supported features should expose Start/Clean Area when the clean-start
+  planner can first clear a safe dock blocker.
+
+### 2026-08-29, Flow 2 downstairs, firmware `v01.09.08.00`
+
+Tested through Home Assistant first, then with Core stopped and a direct local
+client for commands that intentionally bypass the integration's safety gate.
+
+| Active dock task | HA Start with preflight | Raw clean command | Start rule |
+|---|---|---|---|
+| none | accepted; cleaning began | not repeated | send directly |
+| `empty_dustbin` | stopped task, then cleaning began | `CONFLICT` in the direct-client matrix | stop, refresh, start |
+| `wash_mop` | stopped task, then cleaning began | previously returned success without starting and left contradictory fields | stop, refresh, start |
+| `dry_mop` | stopped by the old preflight, then cleaning began | accepted; timer cleared and robot departed | send directly |
+| `dry_dust_bin` | stopped by the old preflight, then cleaning began | accepted; timer cleared and robot departed | send directly |
+| `dry_dock_bag` | stopped by the old preflight, then cleaning began | accepted; timer remained active after robot departure | send directly |
+
+While the robot was cleaning, Home Assistant removed the native Start feature.
+The public service therefore rejected a second start before it reached the
+integration action method.
+
+A raw `dry_station_bag` command sent while `dry_mop` was active returned success,
+but repeated full status refreshes never reported dock-bag drying. This is a
+no-op, not proof that user-started dock tasks can run in parallel. Parallel dock
+task starts remain unavailable. If authoritative telemetry reports multiple
+drying timers, the clean command may be sent directly because each reported
+drying task has independently been verified as start-compatible. Mixed
+emptying/washing plus drying remains fail-closed.
+
+Direct raw starts also showed why command acceptance alone is insufficient:
+after a clean command, coarse `DOCKED_V2` persisted briefly while fields 11 and
+47 correctly changed to off-dock. Follow-up telemetry, not the response code or
+coarse status, was used to classify every result.
+
 ## Per-Task Evidence
 
 ### Empty dustbin
@@ -235,7 +302,8 @@ Verify:
 - Start command accepted from docked idle.
 - Active state maps to `dry_dock_bag`.
 - Timer fields `12/13`, if present, produce `progress` and `time_left`.
-- Robot can start a clean while dock-bag drying continues.
+- A new robot Start intent leaves dock-bag drying active and sends the clean
+  command directly.
 - The switch stays on after the robot leaves the dock if the dock task is still
   running.
 - Typed stop stops dock-bag drying without cancelling a robot clean.
@@ -255,8 +323,8 @@ Unit/entity tests should cover:
 - Wake paths refresh status and revalidate the selected task before command
   dispatch.
 - Polling-only command assumptions clear on authoritative idle state or TTL.
-- `dry_dock_bag` is preserved during robot departure only when backed by typed
-  evidence or a bounded accepted-command fallback.
+- `dry_dock_bag` remains active when a new robot Start is sent; authoritative
+  dock-bag telemetry remains visible after the robot departs.
 - Dock maintenance does not create charge-to-resume.
 - Robot stop remains available during active-clean dock phases.
 

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -122,6 +122,7 @@ def _clean_session_context(state: NarwalState) -> bool:
         or state.working_status in ACTIVE_CLEANING_STATUSES
         or state.working_status == WorkingStatus.TASK_COMPLETED
         or state.has_recent_active_working_status
+        or state.has_paused_clean_task_context
         or state.is_returning
     )
 
@@ -133,13 +134,20 @@ def _robot_work_blocks_generic_dock_stop(state: NarwalState) -> bool:
         or state.has_assumed_robot_clean
         or state.working_status in ACTIVE_CLEANING_STATUSES
         or state.has_recent_active_working_status
+        or state.has_paused_clean_task_context
         or state.is_returning
     )
 
 
 def _robot_start_blocked(state: NarwalState) -> bool:
-    """Return true when a private guard or dock task blocks a start."""
-    return state.has_assumed_robot_clean or state.blocks_robot_start_for_dock_task
+    """Return true unless fresh state permits dispatching a robot start."""
+    return (
+        state.has_error
+        or state.working_status in (WorkingStatus.UNKNOWN, WorkingStatus.ERROR)
+        or not state.is_docked
+        or _clean_session_context(state)
+        or state.blocks_robot_start_for_dock_task
+    )
 
 
 def _can_force_end_scoped_dock_task(state: NarwalState, task: str | None) -> bool:
@@ -177,33 +185,6 @@ def _base_status_working_status(decoded: dict[str, Any] | object) -> WorkingStat
         return WorkingStatus(int(field3["1"]))
     except (TypeError, ValueError):
         return None
-
-
-def _base_status_confirms_docked(
-    decoded: dict[str, Any] | object, status: WorkingStatus | None
-) -> bool:
-    """Return true when a terminal status also carries live dock indicators."""
-    if not isinstance(decoded, dict) or status not in _STALE_DOCK_BASE_STATUSES:
-        return False
-
-    field3 = decoded.get("3")
-    if isinstance(field3, list):
-        field3 = field3[0] if field3 else None
-    field3 = field3 if isinstance(field3, dict) else {}
-
-    def int_field(container: dict[str, Any], field: str) -> int:
-        try:
-            return int(container.get(field, 0))
-        except (TypeError, ValueError):
-            return 0
-
-    return (
-        int_field(decoded, "11") >= 2
-        or int_field(decoded, "47") in (1, 3)
-        or int_field(field3, "3") in (1, 6)
-        or int_field(field3, "10") == 1
-        or int_field(field3, "12") > 0
-    )
 
 
 def _base_status_payload(response: CommandResponse) -> dict[str, Any] | None:
@@ -360,7 +341,6 @@ class NarwalClient:
         if (
             self.state.has_recent_active_working_status
             and status in _STALE_DOCK_BASE_STATUSES
-            and not _base_status_confirms_docked(decoded, status)
         ):
             self.state.update_battery_from_base_status(decoded)
             _LOGGER.debug(
@@ -1226,14 +1206,14 @@ class NarwalClient:
         Newer firmware answers SUCCESS there and does nothing, so this path
         fails clearly when no room list is available instead (#69).
         """
+        if not self.connected:
+            raise NarwalConnectionError("Not connected to vacuum")
         if _robot_start_blocked(self.state):
             _LOGGER.warning(
                 "start: robot or dock task active (%s); not starting whole-house clean",
                 self.state.active_dock_task_keys or "unmapped",
             )
             return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
-        if not self.connected:
-            raise NarwalConnectionError("Not connected to vacuum")
         room_ids = await self._all_room_ids()
         if not room_ids:
             _LOGGER.warning("start(): no map rooms available")
@@ -1518,7 +1498,11 @@ class NarwalClient:
 
             map_data = self.state.map_data
             if not map_data or not map_data.map_id:
-                map_data = await self.get_map()
+                try:
+                    map_data = await self.get_map()
+                except NarwalCommandError as err:
+                    _LOGGER.warning("start_rooms: map fetch failed: %s", err)
+                    map_data = self.state.map_data
             map_id = map_data.map_id if map_data else 0
             if not map_id:
                 _LOGGER.warning(
@@ -1541,6 +1525,11 @@ class NarwalClient:
             except ValueError as err:
                 _LOGGER.warning("start_rooms: %s", err)
                 return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            if _robot_start_blocked(self.state):
+                _LOGGER.warning(
+                    "start_rooms: state changed before dispatch; not starting room clean"
+                )
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
             resp = await self.send_command(
                 TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
             )
@@ -1556,6 +1545,11 @@ class NarwalClient:
                     break
                 _LOGGER.info("start_rooms: robot docking/settling, retrying clean/start_clean")
                 await asyncio.sleep(3.0)
+                if _robot_start_blocked(self.state):
+                    _LOGGER.warning(
+                        "start_rooms: state changed before retry; not starting room clean"
+                    )
+                    return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
                 resp = await self.send_command(
                     TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
                 )

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -1207,6 +1207,11 @@ class NarwalState:
                     self.working_status = WorkingStatus.UNKNOWN
                 if self.working_status not in ACTIVE_CLEANING_STATUSES:
                     self.last_active_working_status_time = 0.0
+                if self.working_status in {
+                    WorkingStatus.TASK_COMPLETED,
+                    WorkingStatus.ERROR,
+                }:
+                    self.clear_assumed_robot_clean()
             # Sub-field 2: paused overlay (0 or absent = not paused, 1 = paused)
             self.is_paused = bool(field3.get("2"))
             # Sub-field 7: returning to dock on old FW (value 1 = returning).

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -23,9 +23,15 @@ _LOGGER = logging.getLogger(__name__)
 _WARNED_WORKING_STATUS: set[Any] = set()
 
 _ACTIVE_WORKING_STATUS_TTL = 15.0
+_TERMINAL_WORKING_STATUS_TTL = 15.0
 _DOCK_DRYING_STATUS_TTL = 180.0
 _DOCK_TASK_ASSUME_TTL = 30.0
-_ROBOT_START_ASSUME_TTL = 30.0
+# clean/start_clean can be accepted long before working_status metrics arrive.
+_ROBOT_START_ASSUME_TTL = 180.0
+# Live hardware has taken about 50 seconds to leave a stale docked status after
+# accepting a room clean. After this handoff window, repeated idle dock
+# telemetry is stronger evidence than the accepted-command reservation.
+_ROBOT_START_DOCKED_HANDOFF_GRACE = 60.0
 _KNOWN_DOCK_ACTIVITY_VALUES = {0, 2, 3, 4, 6}
 
 DOCK_TASK_EMPTY_DUSTBIN = "empty_dustbin"
@@ -649,6 +655,15 @@ class NarwalState:
     cleaning_area: float = 0.0  # m² (coveredArea)
     cleaning_time: int = 0  # seconds
     last_active_working_status_time: float = 0.0
+    last_terminal_working_status_time: float = 0.0
+    pending_active_working_status: dict[str, Any] | None = field(
+        default=None, repr=False
+    )
+    pending_active_working_status_time: float = 0.0
+    task_progress_percent: int | None = None
+    task_elapsed_time: int = 0
+    task_remaining_time: int = 0
+    current_room_aux_name: str = ""
 
     # Consumables / station / fault (base_status; present on dock and during cleaning)
     dust_bag_health: float = 0.0  # field 35 stationBagHealthScore (%)
@@ -743,8 +758,6 @@ class NarwalState:
     @property
     def has_recent_active_working_status(self) -> bool:
         """True while live working_status task metrics are still fresh."""
-        if self.working_status not in ACTIVE_CLEANING_STATUSES:
-            return False
         if self.last_active_working_status_time <= 0:
             return False
         return (
@@ -753,13 +766,24 @@ class NarwalState:
         )
 
     @property
+    def has_recent_terminal_working_status(self) -> bool:
+        """True just after authoritative terminal base-status telemetry."""
+        if self.last_terminal_working_status_time <= 0:
+            return False
+        return (
+            time.monotonic() - self.last_terminal_working_status_time
+            <= _TERMINAL_WORKING_STATUS_TTL
+        )
+
+    @property
     def has_paused_clean_task_context(self) -> bool:
         """True when a paused overlay still has retained robot clean details."""
-        if not self.is_paused or self.is_docked:
+        if not self.is_paused:
             return False
         return (
             getattr(self, "task_progress_percent", None) is not None
-            or getattr(self, "task_elapsed_time", self.cleaning_time) > 0
+            or getattr(self, "task_elapsed_time", 0) > 0
+            or self.cleaning_time > 0
             or getattr(self, "task_remaining_time", 0) > 0
             or self.current_room_id is not None
             or bool(getattr(self, "current_room_aux_name", ""))
@@ -775,7 +799,7 @@ class NarwalState:
         return (
             self.working_status in ACTIVE_CLEANING_STATUSES
             and not self.is_paused
-            and not self.is_returning_to_dock
+            and not self.is_returning
         )
 
     @property
@@ -810,14 +834,14 @@ class NarwalState:
         cleaning is not active, since the robot can report unmapped states
         (e.g. self-test) while physically docked.
         """
+        if self.has_recent_active_working_status:
+            return False
         if self.has_explicit_off_dock_signal:
             return False
         if self.working_status in (
             WorkingStatus.DOCKED, WorkingStatus.CHARGED, WorkingStatus.DOCKED_V2,
         ):
             return True
-        if self.has_recent_active_working_status:
-            return False
         if self.working_status in ACTIVE_CLEANING_STATUSES:
             return False
         # For STANDBY, UNKNOWN, or any other status: check dock field signals.
@@ -871,6 +895,12 @@ class NarwalState:
     @property
     def is_station_active(self) -> bool:
         """True when the dock/base station is running a dock-side task."""
+        if self.has_recent_active_working_status:
+            return (
+                self.station_activity in (1, 2, 3)
+                or self.is_washing_mop
+                or bool(self.active_dock_drying_tasks)
+            )
         return (
             self.is_washing_mop
             or self.is_drying_mop
@@ -895,9 +925,9 @@ class NarwalState:
         if not telemetry_tasks:
             return False
         return not (
-            telemetry_tasks == {DOCK_TASK_DRY_DOCK_BAG}
+            telemetry_tasks.issubset(_DOCK_DRYING_TASK_ORDER)
             and self.has_recent_dock_drying_status
-            and self.dock_task_timer(DOCK_TASK_DRY_DOCK_BAG) is not None
+            and all(self.dock_task_timer(task) is not None for task in telemetry_tasks)
         )
 
     @property
@@ -926,12 +956,17 @@ class NarwalState:
     def telemetry_dock_task_keys(self) -> tuple[str, ...]:
         """Return active dock task keys from robot telemetry only."""
         tasks: list[str] = []
-        if self.station_activity == 1:
-            tasks.append(DOCK_TASK_EMPTY_DUSTBIN)
-        if self.is_washing_mop:
-            tasks.append(DOCK_TASK_WASH_MOP)
+        if not self.has_recent_active_working_status:
+            if self.station_activity == 1:
+                tasks.append(DOCK_TASK_EMPTY_DUSTBIN)
+            if self.is_washing_mop:
+                tasks.append(DOCK_TASK_WASH_MOP)
         tasks.extend(self.telemetry_dock_drying_tasks)
-        if self.is_drying_mop and DOCK_TASK_DRY_MOP not in tasks:
+        if (
+            not self.has_recent_active_working_status
+            and self.is_drying_mop
+            and DOCK_TASK_DRY_MOP not in tasks
+        ):
             tasks.append(DOCK_TASK_DRY_MOP)
         active = set(tasks)
         return tuple(task for task in DOCK_TASK_KEYS if task in active)
@@ -1017,6 +1052,39 @@ class NarwalState:
         """Clear the local robot-clean command reservation."""
         self.assumed_robot_clean_until = 0.0
 
+    def _clear_assumed_robot_clean_on_terminal_base_status(
+        self,
+        *,
+        is_paused: bool,
+    ) -> None:
+        """Clear accepted-start context once base status proves it is terminal."""
+        if not self.has_assumed_robot_clean:
+            return
+        if self.has_error or self.working_status == WorkingStatus.ERROR:
+            self.clear_assumed_robot_clean()
+            return
+        if self.working_status == WorkingStatus.TASK_COMPLETED:
+            self.clear_assumed_robot_clean()
+            return
+        handoff_ends = (
+            self.assumed_robot_clean_until
+            - _ROBOT_START_ASSUME_TTL
+            + _ROBOT_START_DOCKED_HANDOFF_GRACE
+        )
+        if (
+            not is_paused
+            and time.monotonic() >= handoff_ends
+            and self.working_status
+            in (
+                WorkingStatus.STANDBY,
+                WorkingStatus.DOCKED,
+                WorkingStatus.CHARGED,
+                WorkingStatus.DOCKED_V2,
+            )
+            and self.is_docked
+        ):
+            self.clear_assumed_robot_clean()
+
     def dock_task_timer(self, task: str) -> DockTaskTimer | None:
         """Return timer details for one active dock task."""
         timer = self.dock_drying_tasks.get(task)
@@ -1074,11 +1142,68 @@ class NarwalState:
         if self.current_room_id is None:
             return None
         if self.map_data is None:
-            return None
+            return self.current_room_aux_name or None
         for room in self.map_data.rooms:
             if room.room_id == self.current_room_id:
                 return room.display_name
+        return self.current_room_aux_name or None
+
+    def clear_task_details(self) -> None:
+        """Clear active robot-task detail fields."""
+        self.is_paused = False
+        self.cleaning_area = 0.0
+        self.cleaning_time = 0
+        self.task_progress_percent = None
+        self.task_elapsed_time = 0
+        self.task_remaining_time = 0
+        self.current_room_id = None
+        self.current_room_aux_name = ""
+
+    @staticmethod
+    def _task_progress_percent(value: Any) -> int | None:
+        """Return a percent for task progress encoded as percent or 0..1 float."""
+        if isinstance(value, float):
+            if 0.0 <= value <= 1.0:
+                return round(value * 100)
+            if 0.0 <= value <= 100.0:
+                return round(value)
+        progress = _optional_int(value)
+        if progress is not None and 0 <= progress <= 100:
+            return progress
+        progress_float = _to_float32(value)
+        if progress_float is None:
+            return None
+        if 0.0 <= progress_float <= 1.0:
+            return round(progress_float * 100)
+        if 0.0 <= progress_float <= 100.0:
+            return round(progress_float)
         return None
+
+    def _update_current_room(self, payload: dict[str, Any]) -> None:
+        """Parse scalar and nested current-room working-status fields."""
+        room = payload.get("6")
+        if not isinstance(room, dict):
+            room = payload.get("8")
+        if isinstance(room, dict):
+            room_id = _optional_int(room.get("1"))
+            if room_id is not None:
+                self.current_room_id = room_id or None
+            name = room.get("3")
+            if isinstance(name, (bytes, bytearray)):
+                self.current_room_aux_name = bytes(name).decode(
+                    "utf-8", errors="replace"
+                )
+            else:
+                self.current_room_aux_name = str(name) if name else ""
+                if (
+                    self.current_room_aux_name.startswith("b'")
+                    and self.current_room_aux_name.endswith("'")
+                ):
+                    self.current_room_aux_name = self.current_room_aux_name[2:-1]
+        else:
+            room_id = _optional_int(payload.get("6"))
+            if room_id is not None:
+                self.current_room_id = room_id or None
 
     def update_from_working_status(self, decoded: dict[str, Any]) -> None:
         """Update state from a decoded working_status message.
@@ -1092,8 +1217,29 @@ class NarwalState:
         not area — reading it as area is why the sensor was stuck at 1.8 m².
         """
         self.raw_working_status = decoded
+        reported_task_details: dict[str, Any] = {}
+        previous_task_details = (
+            self.task_progress_percent,
+            self.cleaning_area,
+            self.cleaning_time,
+            self.task_remaining_time,
+            self.current_room_id,
+            self.current_room_aux_name,
+        )
+        progress = self._task_progress_percent(decoded.get("1"))
+        if progress is not None:
+            self.task_progress_percent = max(0, min(100, progress))
+            reported_task_details["progress"] = self.task_progress_percent
+        remaining = _optional_int(decoded.get("4"))
+        if remaining is not None:
+            self.task_remaining_time = max(0, remaining)
+            reported_task_details["remaining"] = self.task_remaining_time
+        has_robot_side_drying = False
         if _has_dock_drying_timer_fields(decoded):
             timers = _dock_drying_timers(decoded)
+            has_robot_side_drying = bool(
+                timers.keys() & {DOCK_TASK_DRY_MOP, DOCK_TASK_DRY_DUST_BIN}
+            )
             self.dock_drying_tasks = timers
             self.has_dock_drying_timer_snapshot = True
             self.has_unmapped_dock_drying_timer = _has_unmapped_dock_drying_timer(
@@ -1109,6 +1255,8 @@ class NarwalState:
         if "3" in decoded:
             try:
                 self.cleaning_time = int(decoded["3"])
+                self.task_elapsed_time = self.cleaning_time
+                reported_task_details["elapsed"] = self.cleaning_time
                 active_payload = active_payload or self.cleaning_time > 0
             except (ValueError, TypeError):
                 pass
@@ -1116,29 +1264,97 @@ class NarwalState:
             area = _to_float32(decoded["2"])
             if area is not None and area >= 0:
                 self.cleaning_area = area
+                reported_task_details["area"] = self.cleaning_area
                 active_payload = active_payload or area > 0
-        if "6" in decoded:
-            # Field 6 = current target room_id (confirmed 2026-04-24 from live capture:
-            # value changed 4→1 as robot moved from Corridor to Living Room).
-            try:
-                room_id = int(decoded["6"])
-                self.current_room_id = room_id if room_id != 0 else None
-            except (ValueError, TypeError):
-                pass
-        if active_payload:
-            if self.working_status != WorkingStatus.CUSTOM_CLEANING:
-                self.working_status = WorkingStatus.CLEANING
-            self.last_active_working_status_time = time.monotonic()
-            self.clear_assumed_robot_clean()
-            self.is_paused = False
-            self.is_returning_to_dock = False
-            self.dock_sub_state = 0
+        if "6" in decoded or isinstance(decoded.get("8"), dict):
+            # Field 6 is a scalar room id on Flow 2 and a nested room detail
+            # message on other firmware; field 8 is the alternate nested shape.
+            self._update_current_room(decoded)
+            reported_task_details["room"] = (
+                self.current_room_id,
+                self.current_room_aux_name,
+            )
+        current_task_details = (
+            self.task_progress_percent,
+            self.cleaning_area,
+            self.cleaning_time,
+            self.task_remaining_time,
+            self.current_room_id,
+            self.current_room_aux_name,
+        )
+        task_details_changed = previous_task_details != current_task_details
+        # Clean counters can arrive late from the previous session. Fresh
+        # empty/wash telemetry is authoritative because raw clean commands
+        # cannot start robot work during either task.
+        has_blocking_station_task = (
+            self.station_activity in (1, 2, 3)
+            or self.dock_activity == 3
+            or has_robot_side_drying
+            or self.assumed_active_dock_task
+            in (DOCK_TASK_EMPTY_DUSTBIN, DOCK_TASK_WASH_MOP)
+        )
+        explicit_terminal_status = self.working_status in {
+            WorkingStatus.TASK_COMPLETED,
+            WorkingStatus.ERROR,
+        }
+        now = time.monotonic()
+        pending_candidate = self.pending_active_working_status
+        pending_candidate_fresh = (
+            pending_candidate is not None
+            and now - self.pending_active_working_status_time
+            <= _TERMINAL_WORKING_STATUS_TTL
+        )
+        confirmed_external_clean = (
+            active_payload
+            and not explicit_terminal_status
+            and self.has_recent_terminal_working_status
+            and pending_candidate_fresh
+            and pending_candidate is not None
+            and any(
+                key in pending_candidate and pending_candidate[key] != value
+                for key, value in reported_task_details.items()
+            )
+        )
+        has_terminal_robot_status = not self.has_assumed_robot_clean and (
+            explicit_terminal_status
+            or (
+                self.has_recent_terminal_working_status
+                and not confirmed_external_clean
+            )
+        )
+        if (
+            active_payload
+            and not has_blocking_station_task
+            and not has_terminal_robot_status
+        ):
+            if task_details_changed:
+                self.last_active_working_status_time = now
+                self.is_paused = False
+            self.last_terminal_working_status_time = 0.0
+            self.pending_active_working_status = None
+            self.pending_active_working_status_time = 0.0
             self.dock_activity = 0
             self.station_activity = 0
             self.clear_assumed_dock_task()
-            self.dock_presence = 2
-            self.dock_field11 = 1
-            self.dock_field47 = 2
+        elif has_terminal_robot_status:
+            if active_payload and not explicit_terminal_status:
+                if not pending_candidate_fresh:
+                    self.pending_active_working_status = dict(reported_task_details)
+                    self.pending_active_working_status_time = now
+                else:
+                    assert pending_candidate is not None
+                    pending_candidate.update(reported_task_details)
+            else:
+                self.pending_active_working_status = None
+                self.pending_active_working_status_time = 0.0
+            self.clear_task_details()
+
+    def _update_battery_level(self, raw_value: Any) -> None:
+        """Update battery level from base-status telemetry."""
+        bat = _to_float32(raw_value)
+        if bat is None:
+            return
+        self.battery_level = round(bat)
 
     def update_from_base_status(self, decoded: dict[str, Any]) -> None:
         """Update state from a decoded robot_base_status message.
@@ -1162,6 +1378,8 @@ class NarwalState:
         Note: field 32 mirrors field 3 exactly (redundant).
         """
         self.raw_base_status = decoded
+        if "2" in decoded:
+            self._update_battery_level(decoded["2"])
         # Field 11 = dock indicator (2=docked, 1=undocked)
         if "11" in decoded:
             try:
@@ -1190,10 +1408,40 @@ class NarwalState:
         field3 = decoded.get("3")
         if isinstance(field3, list):
             field3 = field3[0] if field3 else None
+        current_reports_docked = False
         if isinstance(field3, dict):
+            is_paused = bool(field3.get("2"))
+            current_presence = _optional_int(field3.get("3"))
+            current_sub_state = _optional_int(field3.get("10"))
+            current_field11 = _optional_int(decoded.get("11"))
+            current_field47 = _optional_int(decoded.get("47"))
+            if current_presence is not None:
+                self.dock_presence = current_presence
+            if current_sub_state is not None:
+                self.dock_sub_state = current_sub_state
+            current_reports_docked = (
+                current_presence in (1, 6)
+                or current_sub_state == 1
+                or (current_field11 is not None and current_field11 >= 2)
+                or current_field47 in (1, 3)
+            )
+            current_reports_off_dock = (
+                current_presence == 2
+                or current_sub_state == 2
+                or (current_field11 == 1 and current_field47 == 2)
+            )
+            if current_reports_docked or current_reports_off_dock:
+                if current_presence is None:
+                    self.dock_presence = 0
+                if current_sub_state is None:
+                    self.dock_sub_state = 0
+                if current_field11 is None:
+                    self.dock_field11 = 0
+                if current_field47 is None:
+                    self.dock_field47 = 0
             if "1" in field3:
                 try:
-                    self.working_status = WorkingStatus(int(field3["1"]))
+                    next_working_status = WorkingStatus(int(field3["1"]))
                 except (ValueError, TypeError):
                     raw_val = field3["1"]
                     if raw_val not in _WARNED_WORKING_STATUS:
@@ -1203,24 +1451,46 @@ class NarwalState:
                             "Please report this value at the GitHub repo. "
                             "(further occurrences of this value are suppressed)",
                             raw_val,
-                        )
-                    self.working_status = WorkingStatus.UNKNOWN
-                if self.working_status not in ACTIVE_CLEANING_STATUSES:
+                    )
+                    next_working_status = WorkingStatus.UNKNOWN
+                self.working_status = next_working_status
+                terminal_robot = self.working_status in {
+                    WorkingStatus.TASK_COMPLETED,
+                    WorkingStatus.ERROR,
+                }
+                terminal_dock = self.working_status in {
+                    WorkingStatus.DOCKED,
+                    WorkingStatus.CHARGED,
+                    WorkingStatus.DOCKED_V2,
+                }
+                if terminal_robot or (
+                    terminal_dock and not self.has_explicit_off_dock_signal
+                ):
+                    self.last_terminal_working_status_time = time.monotonic()
+                elif (
+                    terminal_dock
+                    or current_reports_off_dock
+                    or self.working_status in ACTIVE_CLEANING_STATUSES
+                ):
+                    self.last_terminal_working_status_time = 0.0
+                if (
+                    self.working_status not in ACTIVE_CLEANING_STATUSES
+                    and not is_paused
+                    and not self.has_assumed_robot_clean
+                ):
                     self.last_active_working_status_time = 0.0
+                    self.clear_task_details()
                 if self.working_status in {
                     WorkingStatus.TASK_COMPLETED,
                     WorkingStatus.ERROR,
                 }:
                     self.clear_assumed_robot_clean()
             # Sub-field 2: paused overlay (0 or absent = not paused, 1 = paused)
-            self.is_paused = bool(field3.get("2"))
+            self.is_paused = is_paused
             # Sub-field 7: returning to dock on old FW (value 1 = returning).
             # On newer FW, field 7 is repurposed (e.g. value 7 during cleaning).
             # Only treat value 1 as returning — other values are not the flag.
             self.is_returning_to_dock = field3.get("7") == 1
-            if "10" in field3:
-                with contextlib.suppress(ValueError, TypeError):
-                    self.dock_sub_state = int(field3["10"])
             if "12" in field3:
                 with contextlib.suppress(ValueError, TypeError):
                     self.dock_activity = int(field3["12"])
@@ -1230,9 +1500,6 @@ class NarwalState:
             if "18" in field3:
                 with contextlib.suppress(ValueError, TypeError):
                     self.station_activity = int(field3["18"])
-            if "3" in field3:
-                with contextlib.suppress(ValueError, TypeError):
-                    self.dock_presence = int(field3["3"])
             if self.working_status in ACTIVE_CLEANING_STATUSES:
                 self.clear_assumed_robot_clean()
                 if "10" not in field3:
@@ -1299,12 +1566,41 @@ class NarwalState:
                 "Please report this at the GitHub repo.",
                 type(field3).__name__, field3,
             )
-        if "2" in decoded:
-            # Field 2 = real-time battery SOC as float32 (batteryPercentage)
-            # (e.g. 1118175232 → 83.0%; bbp may return int or float)
-            bat = _to_float32(decoded["2"])
-            if bat is not None:
-                self.battery_level = round(bat)
+        if isinstance(field3, dict) and "1" in field3:
+            self._clear_assumed_robot_clean_on_terminal_base_status(
+                is_paused=bool(field3.get("2"))
+            )
+        standby_docked = (
+            isinstance(field3, dict)
+            and self.working_status == WorkingStatus.STANDBY
+            and not self.is_paused
+            and not self.has_assumed_robot_clean
+            and current_reports_docked
+        )
+        has_current_working_status = isinstance(field3, dict) and "1" in field3
+        terminal_docked = standby_docked or (
+            has_current_working_status
+            and self.working_status
+            in (
+                WorkingStatus.DOCKED,
+                WorkingStatus.CHARGED,
+                WorkingStatus.DOCKED_V2,
+            )
+        )
+        terminal_robot = has_current_working_status and self.working_status in (
+            WorkingStatus.TASK_COMPLETED,
+            WorkingStatus.ERROR,
+        )
+        if standby_docked:
+            self.last_terminal_working_status_time = time.monotonic()
+        if (
+            (terminal_robot or (terminal_docked and not self.has_explicit_off_dock_signal))
+            and not self.has_assumed_robot_clean
+        ):
+            # The paused overlay can remain set after docking. A terminal
+            # base-status packet is authoritative over retained task context.
+            self.last_active_working_status_time = 0.0
+            self.clear_task_details()
         self._update_consumables(decoded)
         if "13" in decoded:
             raw = decoded["13"]
@@ -1381,9 +1677,7 @@ class NarwalState:
         """
         self.raw_base_status = decoded
         if "2" in decoded:
-            bat = _to_float32(decoded["2"])
-            if bat is not None:
-                self.battery_level = round(bat)
+            self._update_battery_level(decoded["2"])
         self._update_consumables(decoded)
 
     def update_from_upgrade_status(self, decoded: dict[str, Any]) -> None:

--- a/tests/ha_stubs.py
+++ b/tests/ha_stubs.py
@@ -57,8 +57,15 @@ def install() -> None:
     ha_const.ATTR_ENTITY_ID = "entity_id"  # type: ignore[attr-defined]
     ha_const.PERCENTAGE = "%"  # type: ignore[attr-defined]
     ha_const.STATE_ON = "on"  # type: ignore[attr-defined]
-    ha_const.UnitOfArea = MagicMock()  # type: ignore[attr-defined]
-    ha_const.UnitOfTime = MagicMock()  # type: ignore[attr-defined]
+
+    class _UnitOfArea:
+        SQUARE_METERS = "m²"
+
+    class _UnitOfTime:
+        SECONDS = "s"
+
+    ha_const.UnitOfArea = _UnitOfArea  # type: ignore[attr-defined]
+    ha_const.UnitOfTime = _UnitOfTime  # type: ignore[attr-defined]
 
     class _EntityCategory:
         CONFIG = "config"
@@ -108,7 +115,7 @@ def install() -> None:
     # homeassistant.data_entry_flow
     ha_def = _mod("homeassistant.data_entry_flow", ha)
 
-    class _AbortFlow(Exception):
+    class _AbortFlow(Exception):  # noqa: N818
         def __init__(self, reason: str) -> None:
             self.reason = reason
             super().__init__(reason)
@@ -184,6 +191,7 @@ def install() -> None:
 
     ha_er = _mod("homeassistant.helpers.entity_registry", ha_helpers)
     ha_er.async_get = MagicMock()  # type: ignore[attr-defined]
+    ha_er.async_entries_for_config_entry = MagicMock(return_value=())  # type: ignore[attr-defined]
 
     ha_service = _mod("homeassistant.helpers.service", ha_helpers)
     ha_service.async_extract_entity_ids = MagicMock()  # type: ignore[attr-defined]
@@ -271,7 +279,7 @@ def install() -> None:
     class _Segment:
         """Stub for homeassistant.components.vacuum.Segment."""
 
-        def __init__(self, *, id: str, name: str, group: str | None = None) -> None:
+        def __init__(self, *, id: str, name: str, group: str | None = None) -> None:  # noqa: A002
             self.id = id
             self.name = name
             self.group = group

--- a/tests/test_clean_settings_entities.py
+++ b/tests/test_clean_settings_entities.py
@@ -165,8 +165,9 @@ def _state(
     state.has_recent_active_working_status = recent
     state.is_returning = returning
     state.is_cleaning = working_status == WorkingStatus.CLEANING and not returning
-    state.is_charging_to_resume = False
     state.is_station_active = False
+    state.has_unmapped_active_dock_task = False
+    state.assumed_active_dock_task = None
     state.map_data = None
     return state
 
@@ -231,8 +232,8 @@ class TestNarwalSelect:
         }
 
     async def test_water_applies_live_while_cleaning(self) -> None:
-        coord = _coordinator(state=MagicMock(is_cleaning=True))
-        coord.active_clean_work_mode = WorkMode.VACUUM_AND_MOP
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        coord.active_clean_work_mode = WorkMode.MOP
         coord.client.set_mop_humidity = AsyncMock(
             return_value=CommandResponse(result_code=CommandResult.SUCCESS)
         )
@@ -272,8 +273,8 @@ class TestNarwalSelect:
         assert water.current_option == "Wet"
 
     async def test_water_accepts_live_accepted_response(self) -> None:
-        coord = _coordinator(state=MagicMock(is_cleaning=True))
-        coord.active_clean_work_mode = WorkMode.VACUUM_AND_MOP
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        coord.active_clean_work_mode = WorkMode.MOP
         coord.client.set_mop_humidity = AsyncMock(
             return_value=CommandResponse(result_code=0)
         )
@@ -315,14 +316,12 @@ class TestNarwalSelect:
 
         coord.client.set_mop_humidity.assert_not_awaited()
 
-    async def test_live_water_hides_unknown_active_mode(self) -> None:
-        """A reload cannot expose water before the accepted task mode is known."""
+    async def test_live_water_rejects_unknown_active_mode(self) -> None:
+        """Unknown active mode must not expose a cross-mode water command."""
         coord = _coordinator(state=_state(WorkingStatus.CLEANING))
         coord.clean_settings.work_mode = WorkMode.MOP
         coord.active_clean_work_mode = None
-        coord.client.set_mop_humidity = AsyncMock(
-            return_value=CommandResponse(result_code=0)
-        )
+        coord.client.set_mop_humidity = AsyncMock()
         sel = NarwalSelect(coord, _DESCS["water"])
 
         assert not sel.available
@@ -350,8 +349,7 @@ class TestNarwalSelect:
         coord.client.set_mop_humidity.assert_awaited_once_with(MopHumidity.WET)
 
     async def test_rejected_live_water_change_does_not_update_settings(self) -> None:
-        coord = _coordinator(state=MagicMock(is_cleaning=True))
-        coord.active_clean_work_mode = WorkMode.VACUUM_AND_MOP
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
         coord.clean_settings.water = MopHumidity.NORMAL
         coord.client.set_mop_humidity = AsyncMock(
             return_value=CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
@@ -368,7 +366,7 @@ class TestNarwalSelect:
         assert coord.clean_settings.water == MopHumidity.NORMAL
 
     async def test_no_live_setter_when_not_cleaning(self) -> None:
-        coord = _coordinator(state=MagicMock(is_cleaning=False))
+        coord = _coordinator(state=_state())
         coord.client.set_mop_humidity = AsyncMock()
         sel = NarwalSelect(coord, _DESCS["water"])
         await sel.async_select_option("dry")
@@ -522,13 +520,11 @@ class TestLegacyNarwalSettingSelect:
 
         coord.client.set_fan_speed.assert_not_awaited()
 
-    async def test_legacy_live_suction_hides_unknown_active_mode(self) -> None:
+    async def test_legacy_live_suction_rejects_unknown_active_mode(self) -> None:
         coord = _coordinator(state=_state(WorkingStatus.CLEANING))
         coord.clean_settings.work_mode = WorkMode.VACUUM
         coord.active_clean_work_mode = None
-        coord.client.set_fan_speed = AsyncMock(
-            return_value=CommandResponse(result_code=0)
-        )
+        coord.client.set_fan_speed = AsyncMock()
         sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"])
 
         assert not sel.available
@@ -610,6 +606,22 @@ class TestLegacyNarwalSettingSelect:
         get_last_state.assert_not_awaited()
         assert coord.clean_settings.fan == FanLevel.SUPER
 
+    async def test_four_tier_suction_extra_restore_clamps_level_five(self) -> None:
+        coord = _coordinator(
+            settings=CleanSettings(fan=FanLevel.NORMAL),
+            product_key="qV6BujoYLz",
+        )
+        sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"])
+        extra = SettingRestoreData(value=int(FanLevel.SUPER))
+
+        with patch.object(
+            sel, "async_get_last_extra_data", AsyncMock(return_value=extra)
+        ):
+            await sel.async_added_to_hass()
+
+        assert coord.clean_settings.fan == FanLevel.DEEP
+        assert sel.current_option == "Super Powerful"
+
     async def test_unversioned_suction_restore_keeps_v105_meaning(self) -> None:
         coord = _coordinator(settings=CleanSettings(fan=FanLevel.NORMAL))
         sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"])
@@ -637,6 +649,23 @@ class TestLegacyNarwalSettingSelect:
             await sel.async_added_to_hass()
 
         assert coord.clean_settings.fan == FanLevel.DEEP
+
+    async def test_four_tier_unversioned_ultra_clamps_level_five(self) -> None:
+        coord = _coordinator(
+            settings=CleanSettings(fan=FanLevel.NORMAL),
+            product_key="qV6BujoYLz",
+        )
+        sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"])
+
+        with patch.object(
+            sel,
+            "async_get_last_state",
+            AsyncMock(return_value=MagicMock(state="Ultra")),
+        ):
+            await sel.async_added_to_hass()
+
+        assert coord.clean_settings.fan == FanLevel.DEEP
+        assert sel.current_option == "Super Powerful"
 
     async def test_select_option_refreshes_related_setting_entities(self) -> None:
         coord = _coordinator(state=_state())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -100,18 +100,24 @@ class TestNarwalClientInit:
             {"3": {"1": 1}, "11": 1, "47": 2, "2": 87.0}
         )
 
-        assert client.state.working_status == WorkingStatus.CLEANING
+        assert client.state.working_status == WorkingStatus.UNKNOWN
         assert client.state.battery_level == 87
         assert client.state.is_cleaning
 
-    def test_confirmed_dock_base_status_ends_active_metrics(self) -> None:
-        """Fresh dock indicators are trusted even after active task metrics."""
+    def test_confirmed_dock_base_status_waits_for_active_metrics_to_expire(self) -> None:
+        """Dock indicators win after fresh task-metric activity expires."""
         client = NarwalClient("10.0.0.1")
-        client._update_from_working_status_broadcast({"3": 120})
+        with patch("narwal_client.models.time.monotonic", return_value=100.0):
+            client._update_from_working_status_broadcast({"3": 120})
 
-        client._update_from_base_status_broadcast(
-            {"3": {"1": 10}, "11": 2, "47": 3}
-        )
+        docked = {"3": {"1": 10}, "11": 2, "47": 3}
+        with patch("narwal_client.models.time.monotonic", return_value=101.0):
+            client._update_from_base_status_broadcast(docked)
+            assert client.state.working_status == WorkingStatus.UNKNOWN
+            assert client.state.is_cleaning
+
+        with patch("narwal_client.models.time.monotonic", return_value=116.0):
+            client._update_from_base_status_broadcast(docked)
 
         assert client.state.working_status == WorkingStatus.DOCKED
         assert not client.state.has_recent_active_working_status
@@ -290,6 +296,9 @@ class TestWholeHouseStart:
         client = NarwalClient("127.0.0.1")
         client._ws = AsyncMock()
         client._connected.set()
+        client.state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.DOCKED), "10": 1}, "11": 2}
+        )
         return client
 
     @pytest.mark.asyncio
@@ -499,16 +508,28 @@ class TestWholeHouseStart:
         assert client.state.has_assumed_robot_clean
         mock_send.assert_awaited_once()
 
+    @pytest.mark.parametrize(
+        ("task", "fields"),
+        (
+            (DOCK_TASK_DRY_MOP, ("8", "9")),
+            (DOCK_TASK_DRY_DUST_BIN, ("10", "11")),
+            (DOCK_TASK_DRY_DOCK_BAG, ("12", "13")),
+        ),
+    )
     @pytest.mark.asyncio
-    async def test_start_rooms_allows_typed_dock_bag_drying(self) -> None:
-        """Dock-bag drying is the one known dock task compatible with robot start."""
+    async def test_start_rooms_allows_typed_drying(
+        self,
+        task: str,
+        fields: tuple[str, str],
+    ) -> None:
+        """Each typed drying task is compatible with robot start."""
         client = self._connected_client()
         client.state.map_data = MapData(map_id=1, rooms=[RoomInfo(room_id=2)])
         client.state.set_dock_drying_task(
-            DOCK_TASK_DRY_DOCK_BAG,
+            task,
             elapsed=60,
             target=180,
-            fields=("12", "13"),
+            fields=fields,
         )
         success = CommandResponse(result_code=CommandResult.SUCCESS)
 
@@ -818,6 +839,26 @@ class TestDockTaskCommands:
 
         assert result.result_code == CommandResult.NOT_APPLICABLE
         mock_status.assert_awaited_once_with(full_update=True)
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_direct_dock_command_rejects_retained_paused_clean(self) -> None:
+        """Expired metric freshness does not make a paused clean dock-idle."""
+        client = self._docked_client()
+        client.state.working_status = WorkingStatus.STANDBY
+        client.state.is_paused = True
+        client.state.cleaning_time = 120
+        client.state.task_elapsed_time = 120
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send:
+            result = await client.empty_dustbin()
+
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+        mock_status.assert_not_awaited()
         mock_send.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -1484,6 +1525,137 @@ class TestDockTaskCommands:
             await client._refresh_before_dock_stop(None)
 
         mock_status.assert_awaited_once_with(full_update=False)
+
+    def test_statusless_base_broadcast_preserves_fresh_clean_metrics(self) -> None:
+        """Battery-only telemetry cannot apply a cached terminal status."""
+        client = NarwalClient("127.0.0.1")
+        client.state.working_status = WorkingStatus.DOCKED
+        client.state.last_terminal_working_status_time = 0.0
+        client.state.update_from_working_status({"3": 120, "4": 600})
+
+        client._update_from_base_status_broadcast({"2": 75.0})
+
+        assert client.state.battery_level == 75
+        assert client.state.is_cleaning
+        assert client.state.task_elapsed_time == 120
+        assert client.state.task_remaining_time == 600
+
+    def test_external_start_survives_delayed_docked_base_broadcast(self) -> None:
+        """Fresh native task metrics outrank delayed dock confirmation."""
+        client = NarwalClient("127.0.0.1")
+        with patch("narwal_client.models.time.monotonic", return_value=100.0):
+            client.state.update_from_base_status(
+                {"3": {"1": int(WorkingStatus.DOCKED)}, "11": 2, "47": 3}
+            )
+        with patch("narwal_client.models.time.monotonic", return_value=101.0):
+            client.state.update_from_working_status({"1": 25, "3": 120, "6": 4})
+            assert not client.state.is_cleaning
+        with patch("narwal_client.models.time.monotonic", return_value=102.0):
+            client._update_from_base_status_broadcast(
+                {
+                    "3": {"1": int(WorkingStatus.DOCKED), "10": 1},
+                    "11": 2,
+                    "47": 3,
+                }
+            )
+            assert client.state.working_status == WorkingStatus.DOCKED
+            assert not client.state.is_cleaning
+        with patch("narwal_client.models.time.monotonic", return_value=102.5):
+            client.state.update_from_working_status({"3": 120})
+            assert not client.state.is_cleaning
+        with patch("narwal_client.models.time.monotonic", return_value=103.0):
+            client.state.update_from_working_status({"1": 26, "3": 121, "6": 4})
+            assert client.state.is_cleaning
+        with patch("narwal_client.models.time.monotonic", return_value=104.0):
+            client._update_from_base_status_broadcast(
+                {
+                    "3": {"1": int(WorkingStatus.DOCKED), "10": 1},
+                    "11": 2,
+                    "47": 3,
+                }
+            )
+            assert client.state.is_cleaning
+        assert client.state.task_progress_percent == 26
+        assert client.state.task_elapsed_time == 121
+        assert client.state.current_room_id == 4
+
+    def test_expired_external_start_candidate_requires_new_progression(self) -> None:
+        """An old candidate cannot confirm a later metric packet by itself."""
+        client = NarwalClient("127.0.0.1")
+        docked = {
+            "3": {"1": int(WorkingStatus.DOCKED), "10": 1},
+            "11": 2,
+            "47": 3,
+        }
+        with patch("narwal_client.models.time.monotonic", return_value=100.0):
+            client.state.update_from_base_status(docked)
+        with patch("narwal_client.models.time.monotonic", return_value=101.0):
+            client.state.update_from_working_status({"1": 25, "3": 120})
+        with patch("narwal_client.models.time.monotonic", return_value=500.0):
+            client._update_from_base_status_broadcast(docked)
+        with patch("narwal_client.models.time.monotonic", return_value=501.0):
+            client.state.update_from_working_status({"1": 26, "3": 121})
+            assert not client.state.is_cleaning
+        with patch("narwal_client.models.time.monotonic", return_value=502.0):
+            client.state.update_from_working_status({"1": 27, "3": 122})
+            assert client.state.is_cleaning
+
+    def test_repeated_final_metrics_cannot_mask_confirmed_docking(self) -> None:
+        """Unchanged final counters expire so repeated dock evidence can win."""
+        client = NarwalClient("127.0.0.1")
+        with patch("narwal_client.models.time.monotonic", return_value=100.0):
+            client.state.update_from_base_status(
+                {"3": {"1": int(WorkingStatus.CLEANING)}, "11": 1, "47": 2}
+            )
+            client.state.update_from_working_status({"1": 75, "3": 900, "6": 4})
+
+        docked = {
+            "3": {"1": int(WorkingStatus.DOCKED), "10": 1},
+            "11": 2,
+            "47": 3,
+        }
+        with patch("narwal_client.models.time.monotonic", return_value=101.0):
+            client._update_from_base_status_broadcast(docked)
+        assert client.state.is_cleaning
+
+        with patch("narwal_client.models.time.monotonic", return_value=105.0):
+            client.state.update_from_working_status({"1": 75, "3": 900, "6": 4})
+        with patch("narwal_client.models.time.monotonic", return_value=116.0):
+            client.state.update_from_working_status({"1": 75, "3": 900, "6": 4})
+            client._update_from_base_status_broadcast(docked)
+
+        assert client.state.working_status == WorkingStatus.DOCKED
+        assert client.state.is_docked
+        assert not client.state.is_cleaning
+
+    def test_statusless_pause_broadcast_applies_during_fresh_clean(self) -> None:
+        """A pause overlay remains authoritative without a coarse status enum."""
+        client = NarwalClient("127.0.0.1")
+        client.state.working_status = WorkingStatus.DOCKED
+        client.state.last_terminal_working_status_time = 0.0
+        client.state.update_from_working_status({"3": 120, "4": 600})
+
+        client._update_from_base_status_broadcast({"3": {"2": 1}})
+
+        assert client.state.is_paused
+        assert client.state.task_elapsed_time == 120
+        assert client.state.task_remaining_time == 600
+
+    def test_statusless_packet_does_not_reuse_standby_dock_evidence(self) -> None:
+        """Cached dock fields cannot make a status-less packet terminal."""
+        client = NarwalClient("127.0.0.1")
+        client.state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.STANDBY), "3": 6}}
+        )
+        client.state.last_terminal_working_status_time = 0.0
+        client.state.update_from_working_status({"3": 120, "4": 600})
+
+        client._update_from_base_status_broadcast({"3": {"7": 0}, "2": 80.0})
+
+        assert client.state.is_cleaning
+        assert client.state.task_elapsed_time == 120
+        assert client.state.task_remaining_time == 600
+        assert not client.state.has_recent_terminal_working_status
 
     @pytest.mark.asyncio
     async def test_stop_dock_task_rejects_ambiguous_generic_stop(self) -> None:

--- a/tests/test_client_rooms.py
+++ b/tests/test_client_rooms.py
@@ -7,13 +7,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import blackboxprotobuf
 import pytest
 
-from narwal_client.client import NarwalClient, RoomCleanSettings
+from narwal_client.client import NarwalClient, NarwalCommandError, RoomCleanSettings
 from narwal_client.const import (
     CleaningRoute,
     CommandResult,
     FanLevel,
     MopHumidity,
     MopStrengthLevel,
+    WorkingStatus,
     WorkMode,
 )
 from narwal_client.models import CommandResponse
@@ -161,6 +162,9 @@ class TestStartRooms:
     def _client(self) -> NarwalClient:
         client = NarwalClient("127.0.0.1")
         client._ws = AsyncMock()
+        client.state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.DOCKED), "10": 1}, "11": 2}
+        )
         client.state.map_data = MagicMock(map_id=1)
         return client
 
@@ -257,6 +261,19 @@ class TestStartRooms:
         assert result.result_code == CommandResult.NOT_APPLICABLE
 
     @pytest.mark.asyncio
+    async def test_map_fetch_error_returns_not_applicable(self) -> None:
+        """A failed map refresh bails out without sending a room-clean command."""
+        client = self._client()
+        client.state.map_data = None
+        with patch.object(client, "get_map", new_callable=AsyncMock) as mock_get_map, \
+             patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_get_map.side_effect = NarwalCommandError("no active map")
+            result = await client.start_rooms([5])
+        mock_get_map.assert_awaited_once()
+        mock_send.assert_not_awaited()
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+
+    @pytest.mark.asyncio
     async def test_not_ready_retries_while_docked(self) -> None:
         """NOT_READY on the dock retries clean/start_clean (dock settling)."""
         client = self._client()
@@ -272,16 +289,65 @@ class TestStartRooms:
         assert result is success
 
     @pytest.mark.asyncio
-    async def test_not_ready_off_dock_does_not_retry(self) -> None:
-        """NOT_READY off the dock surfaces as-is — start_clean needs the dock."""
+    async def test_off_dock_does_not_dispatch(self) -> None:
+        """An off-dock robot is rejected before dispatch."""
         client = self._client()
+        client.state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.STANDBY)}, "11": 1, "47": 2}
+        )
+        client.state.dock_presence = 2
+        client.state.dock_sub_state = 2
         assert not client.state.is_docked
-        not_ready = CommandResponse(result_code=CommandResult.NOT_READY)
         with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
-            mock_send.return_value = not_ready
             result = await client.start_rooms([5])
-        mock_send.assert_awaited_once()
-        assert result.result_code == CommandResult.NOT_READY
+        mock_send.assert_not_awaited()
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+
+    @pytest.mark.asyncio
+    async def test_active_clean_does_not_dispatch(self) -> None:
+        """A second start is rejected while robot cleaning is active."""
+        client = self._client()
+        client.state.working_status = WorkingStatus.CLEANING
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            result = await client.start_rooms([5])
+
+        mock_send.assert_not_awaited()
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+
+    @pytest.mark.asyncio
+    async def test_error_status_does_not_dispatch(self) -> None:
+        """An explicit robot error is rejected even without an error payload."""
+        client = self._client()
+        client.state.working_status = WorkingStatus.ERROR
+        client.state.error_code = 0
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            result = await client.start_rooms([5])
+
+        mock_send.assert_not_awaited()
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+
+    @pytest.mark.asyncio
+    async def test_state_change_during_map_fetch_does_not_dispatch(self) -> None:
+        """State is checked again after the asynchronous map fetch."""
+        client = self._client()
+        client.state.map_data = None
+
+        async def change_state_during_map_fetch():
+            client.state.working_status = WorkingStatus.CLEANING
+            return MagicMock(map_id=1)
+
+        with patch.object(
+            client,
+            "get_map",
+            new_callable=AsyncMock,
+            side_effect=change_state_during_map_fetch,
+        ), patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            result = await client.start_rooms([5])
+
+        mock_send.assert_not_awaited()
+        assert result.result_code == CommandResult.NOT_APPLICABLE
 
     @pytest.mark.asyncio
     async def test_conflict_surfaces_without_retry(self) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -25,6 +25,8 @@ from custom_components.narwal.coordinator import (  # noqa: E402
     CleanSettings,
     NarwalCoordinator,
     can_edit_pending_clean_settings,
+    can_pause_cleaning,
+    can_prepare_clean_start,
     can_start_cleaning,
     is_clean_session_context,
     is_live_clean_setting_available,
@@ -41,8 +43,24 @@ from custom_components.narwal.narwal_client import (  # noqa: E402
     WorkingStatus,
     WorkMode,
 )
+from custom_components.narwal.narwal_client.models import (  # noqa: E402
+    DOCK_TASK_DRY_DOCK_BAG,
+    DOCK_TASK_DRY_DUST_BIN,
+    DOCK_TASK_DRY_MOP,
+    DOCK_TASK_EMPTY_DUSTBIN,
+    DOCK_TASK_WASH_MOP,
+)
 
 UpdateFailed = sys.modules["homeassistant.helpers.update_coordinator"].UpdateFailed
+
+
+def test_pause_available_with_stale_unconfirmed_return_flag() -> None:
+    """A stale field 3.7 alone must not hide Pause during an active clean."""
+    state = NarwalState()
+    state.update_from_base_status({"3": {"1": 4, "7": 1}})
+    state.last_active_working_status_time = 0.0
+
+    assert can_pause_cleaning(state)
 
 
 class _RoomSelectionStore:
@@ -58,6 +76,14 @@ class _RoomSelectionStore:
     async def async_save(self, data: object) -> None:
         """Store data."""
         self.data = data
+
+
+def _docked_state() -> NarwalState:
+    """Return an idle on-dock state."""
+    state = NarwalState(working_status=WorkingStatus.DOCKED)
+    state.dock_presence = 6
+    state.dock_field11 = 2
+    return state
 
 
 def test_non_broadcast_product_key_configures_polling_client() -> None:
@@ -1167,6 +1193,261 @@ class TestCoordinatorResilience:
 
         assert not await coordinator.async_refresh_dock_status()
         assert seen == [False]
+
+    async def test_prepare_clean_start_stops_single_safe_dock_blocker(self) -> None:
+        """A clean-start intent clears one known safe dock blocker first."""
+        coordinator = self._make_coordinator()
+        state = _docked_state()
+        state.station_activity = 1
+        coordinator.client.state = state
+        coordinator.data = state
+        coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+        coordinator.async_set_updated_data = MagicMock()
+
+        async def stop_task(task: str | None = None) -> CommandResponse:
+            assert task == DOCK_TASK_EMPTY_DUSTBIN
+            state.station_activity = 0
+            return CommandResponse(result_code=CommandResult.SUCCESS)
+
+        coordinator.client.stop_dock_task = AsyncMock(side_effect=stop_task)
+
+        assert can_prepare_clean_start(state)
+        assert await coordinator.async_prepare_clean_start()
+
+        coordinator.client.stop_dock_task.assert_awaited_once_with(
+            DOCK_TASK_EMPTY_DUSTBIN
+        )
+        assert coordinator.async_refresh_dock_status.await_count == 2
+        assert can_start_cleaning(state)
+
+    async def test_prepare_clean_start_rejects_failed_initial_refresh(self) -> None:
+        """Preparation does not act when its initial state refresh fails."""
+        coordinator = self._make_coordinator()
+        coordinator.async_refresh_dock_status = AsyncMock(return_value=False)
+        coordinator.client.stop_dock_task = AsyncMock()
+
+        assert not await coordinator.async_prepare_clean_start()
+
+        coordinator.async_refresh_dock_status.assert_awaited_once()
+        coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_prepare_clean_start_rejects_failed_dock_stop(self) -> None:
+        """Preparation does not start after the dock rejects its required stop."""
+        coordinator = self._make_coordinator()
+        state = _docked_state()
+        state.station_activity = 1
+        coordinator.client.state = state
+        coordinator.data = state
+        coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+        coordinator.client.stop_dock_task = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.CONFLICT)
+        )
+
+        assert not await coordinator.async_prepare_clean_start()
+
+        coordinator.async_refresh_dock_status.assert_awaited_once()
+        coordinator.client.stop_dock_task.assert_awaited_once_with(
+            DOCK_TASK_EMPTY_DUSTBIN
+        )
+
+    async def test_prepare_clean_start_rejects_failed_post_stop_refresh(self) -> None:
+        """An accepted stop still requires authoritative refreshed state."""
+        coordinator = self._make_coordinator()
+        state = _docked_state()
+        state.station_activity = 1
+        coordinator.client.state = state
+        coordinator.data = state
+        coordinator.async_refresh_dock_status = AsyncMock(
+            side_effect=(True, False)
+        )
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator.client.stop_dock_task = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        assert not await coordinator.async_prepare_clean_start()
+
+        assert coordinator.async_refresh_dock_status.await_count == 2
+        coordinator.client.stop_dock_task.assert_awaited_once_with(
+            DOCK_TASK_EMPTY_DUSTBIN
+        )
+
+    @pytest.mark.parametrize(
+        ("task", "fields"),
+        [
+            (DOCK_TASK_DRY_MOP, ("8", "9")),
+            (DOCK_TASK_DRY_DUST_BIN, ("10", "11")),
+            (DOCK_TASK_DRY_DOCK_BAG, ("12", "13")),
+        ],
+    )
+    async def test_prepare_clean_start_keeps_typed_drying_task(
+        self,
+        task: str,
+        fields: tuple[str, str],
+    ) -> None:
+        """A new clean lets firmware hand off typed drying work."""
+        coordinator = self._make_coordinator()
+        state = _docked_state()
+        state.set_dock_drying_task(
+            task,
+            elapsed=60,
+            target=180,
+            fields=fields,
+        )
+        coordinator.client.state = state
+        coordinator.data = state
+        coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator.client.stop_dock_task = AsyncMock()
+
+        assert can_prepare_clean_start(state)
+        assert await coordinator.async_prepare_clean_start()
+        assert can_prepare_clean_start(state, allow_dock_stop=False)
+
+        coordinator.client.stop_dock_task.assert_not_awaited()
+        assert coordinator.async_refresh_dock_status.await_count == 1
+        assert can_start_cleaning(state)
+
+    async def test_prepare_clean_start_rejects_lingering_dock_task_after_stop(self) -> None:
+        """Accepted stop is not enough if refreshed telemetry still shows a task."""
+        coordinator = self._make_coordinator()
+        state = _docked_state()
+        state.station_activity = 1
+        coordinator.client.state = state
+        coordinator.data = state
+        coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator.client.stop_dock_task = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        assert can_prepare_clean_start(state)
+        assert not await coordinator.async_prepare_clean_start()
+
+        coordinator.client.stop_dock_task.assert_awaited_once_with(
+            DOCK_TASK_EMPTY_DUSTBIN
+        )
+        assert coordinator.async_refresh_dock_status.await_count == 2
+
+    async def test_prepare_clean_start_rejects_dock_stop_when_disabled(self) -> None:
+        """No-stop preparation mode should never cancel dock maintenance."""
+        coordinator = self._make_coordinator()
+        state = _docked_state()
+        state.station_activity = 2
+        coordinator.client.state = state
+        coordinator.data = state
+        coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+        coordinator.client.stop_dock_task = AsyncMock()
+
+        assert not can_prepare_clean_start(state, allow_dock_stop=False)
+        assert not await coordinator.async_prepare_clean_start(allow_dock_stop=False)
+
+        coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_prepare_clean_start_accepts_wash_follow_on_drying(self) -> None:
+        """Stopping a wash may hand off mop drying to the clean command."""
+        coordinator = self._make_coordinator()
+        state = _docked_state()
+        state.station_activity = 2
+        coordinator.client.state = state
+        coordinator.data = state
+        coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+        coordinator.async_set_updated_data = MagicMock()
+
+        async def stop_task(task: str | None = None) -> CommandResponse:
+            assert task == DOCK_TASK_WASH_MOP
+            state.station_activity = 0
+            state.set_dock_drying_task(
+                DOCK_TASK_DRY_MOP,
+                elapsed=0,
+                target=18000,
+                fields=("8", "9"),
+            )
+            return CommandResponse(result_code=CommandResult.SUCCESS)
+
+        coordinator.client.stop_dock_task = AsyncMock(side_effect=stop_task)
+
+        assert can_prepare_clean_start(state)
+        assert await coordinator.async_prepare_clean_start()
+
+        coordinator.client.stop_dock_task.assert_awaited_once_with(
+            DOCK_TASK_WASH_MOP
+        )
+        assert coordinator.async_refresh_dock_status.await_count == 2
+        assert state.active_dock_task_keys == (DOCK_TASK_DRY_MOP,)
+
+    async def test_prepare_clean_start_allows_multiple_typed_dryers(self) -> None:
+        """Multiple typed drying tasks can be handed off without pre-stops."""
+        coordinator = self._make_coordinator()
+        state = _docked_state()
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DUST_BIN,
+            elapsed=60,
+            target=180,
+            fields=("10", "11"),
+        )
+        coordinator.client.state = state
+        coordinator.data = state
+        coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+        coordinator.client.stop_dock_task = AsyncMock()
+
+        assert can_prepare_clean_start(state)
+        assert await coordinator.async_prepare_clean_start()
+
+        coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_prepare_clean_start_rejects_mixed_stop_and_dry_tasks(self) -> None:
+        """Mixed generic-stop and drying tasks remain ambiguous."""
+        coordinator = self._make_coordinator()
+        state = _docked_state()
+        state.station_activity = 1
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+        coordinator.client.state = state
+        coordinator.data = state
+        coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+        coordinator.client.stop_dock_task = AsyncMock()
+
+        assert not can_prepare_clean_start(state)
+        assert not await coordinator.async_prepare_clean_start()
+
+        coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_action_refresh_preserves_recent_active_working_status(self) -> None:
+        """Robot action gates avoid full base-status refresh while task data is fresh."""
+        coordinator = self._make_coordinator()
+        coordinator.client.state.update_from_working_status({"3": 120})
+        coordinator.client.get_status = AsyncMock(return_value=CommandResponse(data={}))
+        coordinator.async_set_updated_data = MagicMock()
+
+        assert await coordinator.async_refresh_action_status()
+
+        coordinator.client.get_status.assert_awaited_once_with(full_update=False)
+        coordinator.async_set_updated_data.assert_called_once_with(
+            coordinator.client.state
+        )
+        assert not coordinator._dock_status_refresh_failed
+
+    async def test_action_refresh_requires_dock_payload_when_full_update_needed(self) -> None:
+        """Without active task telemetry, action refresh needs real dock/base status."""
+        coordinator = self._make_coordinator()
+        coordinator.client.get_status = AsyncMock(return_value=CommandResponse(data={}))
+        coordinator.async_set_updated_data = MagicMock()
+
+        assert not await coordinator.async_refresh_action_status()
+
+        coordinator.client.get_status.assert_awaited_once_with(full_update=True)
+        assert coordinator._dock_status_refresh_failed
 
 
 class TestTopicSubscriptionRenewal:

--- a/tests/test_coordinator_map.py
+++ b/tests/test_coordinator_map.py
@@ -8,7 +8,7 @@ Covers MAP-04 (post-cleaning map refresh) validation gaps:
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 # Install HA stubs before any custom_components import
 import tests.ha_stubs  # noqa: E402
@@ -211,3 +211,51 @@ def test_remapping_does_not_start_a_cleaning_trail() -> None:
     camera._handle_coordinator_update()
 
     camera._reset_trail.assert_not_called()
+
+
+def test_metric_only_clean_starts_camera_trail_once() -> None:
+    """Fresh clean metrics drive the camera without rewriting coarse status."""
+    state = NarwalState(working_status=WorkingStatus.STANDBY)
+    state.update_from_working_status({"3": 120})
+    coordinator = MagicMock()
+    coordinator.client.state = state
+    camera = NarwalMapCamera.__new__(NarwalMapCamera)
+    camera.coordinator = coordinator
+    camera._last_cleaning_status = WorkingStatus.STANDBY
+    camera._reset_trail = MagicMock()
+    camera.async_write_ha_state = MagicMock()
+
+    camera._handle_coordinator_update()
+    camera._handle_coordinator_update()
+
+    assert state.working_status == WorkingStatus.STANDBY
+    camera._reset_trail.assert_called_once_with()
+
+
+def test_metric_only_pause_resume_keeps_existing_camera_trail() -> None:
+    """Pausing a metric-only clean must not turn resume into a new session."""
+    state = NarwalState(working_status=WorkingStatus.STANDBY)
+    with patch("narwal_client.models.time.monotonic", return_value=100.0):
+        state.update_from_working_status({"3": 120})
+    coordinator = MagicMock()
+    coordinator.client.state = state
+    camera = NarwalMapCamera.__new__(NarwalMapCamera)
+    camera.coordinator = coordinator
+    camera._last_cleaning_status = WorkingStatus.STANDBY
+    camera._reset_trail = MagicMock()
+    camera.async_write_ha_state = MagicMock()
+
+    with patch("narwal_client.models.time.monotonic", return_value=100.0):
+        camera._handle_coordinator_update()
+    state.is_paused = True
+    camera._handle_coordinator_update()
+    with patch("narwal_client.models.time.monotonic", return_value=116.0):
+        state.update_from_working_status({"3": 120})
+    assert state.is_paused
+    camera._handle_coordinator_update()
+    with patch("narwal_client.models.time.monotonic", return_value=117.0):
+        state.update_from_working_status({"3": 121})
+    assert not state.is_paused
+    camera._handle_coordinator_update()
+
+    camera._reset_trail.assert_called_once_with()

--- a/tests/test_dock_tasks.py
+++ b/tests/test_dock_tasks.py
@@ -17,6 +17,7 @@ from custom_components.narwal.dock_tasks import (  # noqa: E402
     can_start_dock_task,
     can_start_robot_clean,
     can_stop_dock_task,
+    dock_task_blocks_robot_return,
 )
 from custom_components.narwal.switch import (  # noqa: E402
     DOCK_TASK_SWITCHES,
@@ -112,6 +113,18 @@ def test_cleaning_state_hides_dock_start_controls() -> None:
     state.dock_field11 = 1
     state.dock_field47 = 2
 
+    assert not can_start_dock_task(state, DOCK_TASK_EMPTY_DUSTBIN)
+
+
+def test_retained_paused_context_hides_dock_start_controls() -> None:
+    """A paused clean remains robot work after live metric freshness expires."""
+    state = _docked_state()
+    state.working_status = WorkingStatus.STANDBY
+    state.is_paused = True
+    state.cleaning_time = 120
+    state.task_elapsed_time = 120
+
+    assert state.has_paused_clean_task_context
     assert not can_start_dock_task(state, DOCK_TASK_EMPTY_DUSTBIN)
 
 
@@ -343,6 +356,34 @@ async def test_active_dry_dust_bin_switch_stops_with_scoped_command() -> None:
     coordinator.client.stop_dock_task.assert_awaited_once_with(DOCK_TASK_DRY_DUST_BIN)
 
 
+async def test_switch_refreshes_before_stop_validation() -> None:
+    """A stale local status cannot reject a typed stop before refresh."""
+    state = _docked_state()
+    state.working_status = WorkingStatus.UNKNOWN
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_DUST_BIN,
+        elapsed=61,
+        target=180,
+        fields=("10", "11"),
+    )
+    coordinator = _coordinator(state)
+
+    async def refresh_dock_status() -> bool:
+        state.working_status = WorkingStatus.DOCKED
+        return True
+
+    coordinator.async_refresh_dock_status = AsyncMock(side_effect=refresh_dock_status)
+    coordinator.client.stop_dock_task = AsyncMock(
+        return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+    )
+    switch = NarwalDockTaskSwitch(coordinator, DOCK_TASK_SWITCHES[3])
+
+    await switch.async_turn_off()
+
+    coordinator.async_refresh_dock_status.assert_awaited()
+    coordinator.client.stop_dock_task.assert_awaited_once_with(DOCK_TASK_DRY_DUST_BIN)
+
+
 def test_multiple_tasks_only_allow_scoped_stop() -> None:
     """Generic stop is unavailable for ambiguous multi-task dock activity."""
     state = _docked_state()
@@ -447,20 +488,125 @@ def test_unmapped_coarse_activity_allows_scoped_dock_bag_stop() -> None:
     assert not can_stop_dock_task(state, DOCK_TASK_DRY_MOP)
 
 
-def test_robot_clean_start_allows_only_typed_dock_bag() -> None:
-    """Robot starts are blocked by dock work except typed dock-bag drying."""
+@pytest.mark.parametrize(
+    ("task", "fields"),
+    [
+        (DOCK_TASK_DRY_MOP, ("8", "9")),
+        (DOCK_TASK_DRY_DUST_BIN, ("10", "11")),
+        (DOCK_TASK_DRY_DOCK_BAG, ("12", "13")),
+    ],
+)
+def test_robot_clean_start_allows_typed_drying_tasks(
+    task: str,
+    fields: tuple[str, str],
+) -> None:
+    """Typed drying tasks can be handed off to the robot clean command."""
     state = _docked_state()
-    state.assume_dock_task(DOCK_TASK_DRY_DOCK_BAG)
+    state.assume_dock_task(task)
     assert not can_start_robot_clean(state)
 
     state = _docked_state()
+    state.set_dock_drying_task(
+        task,
+        elapsed=45,
+        target=180,
+        fields=fields,
+    )
+    assert can_start_robot_clean(state)
+
+
+def test_robot_clean_start_allows_multiple_typed_drying_tasks() -> None:
+    """Multiple typed drying timers can be handed off on clean start."""
+    state = _docked_state()
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_MOP,
+        elapsed=45,
+        target=180,
+        fields=("8", "9"),
+    )
     state.set_dock_drying_task(
         DOCK_TASK_DRY_DOCK_BAG,
         elapsed=45,
         target=180,
         fields=("12", "13"),
     )
+
     assert can_start_robot_clean(state)
+
+
+def test_robot_clean_start_rejects_typed_drying_with_unmapped_activity() -> None:
+    """Typed drying must not mask additional unmapped station work."""
+    state = _docked_state()
+    state.station_activity = 99
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_DOCK_BAG,
+        elapsed=45,
+        target=180,
+        fields=("12", "13"),
+    )
+
+    assert not can_start_robot_clean(state)
+
+
+def test_robot_return_allows_only_typed_dock_bag() -> None:
+    """Robot return is blocked by dock work except typed dock-bag drying."""
+    state = NarwalState(working_status=WorkingStatus.STANDBY)
+    state.station_activity = 4
+    assert dock_task_blocks_robot_return(state)
+
+    state = NarwalState(working_status=WorkingStatus.STANDBY)
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_DOCK_BAG,
+        elapsed=45,
+        target=180,
+        fields=("12", "13"),
+    )
+    assert not dock_task_blocks_robot_return(state)
+
+    state = NarwalState(working_status=WorkingStatus.STANDBY)
+    state.dock_presence = 6
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_MOP,
+        elapsed=45,
+        target=180,
+        fields=("8", "9"),
+    )
+    assert dock_task_blocks_robot_return(state)
+
+
+@pytest.mark.parametrize(
+    "task",
+    [
+        DOCK_TASK_EMPTY_DUSTBIN,
+        DOCK_TASK_WASH_MOP,
+        DOCK_TASK_DRY_MOP,
+        DOCK_TASK_DRY_DUST_BIN,
+    ],
+)
+def test_accepted_dock_task_blocks_robot_return_during_handoff(task: str) -> None:
+    """Accepted incompatible dock work blocks robot actions before telemetry."""
+    state = NarwalState(working_status=WorkingStatus.STANDBY)
+    state.assume_dock_task(task)
+
+    assert dock_task_blocks_robot_return(state)
+
+
+def test_accepted_dock_bag_dry_keeps_robot_return_compatible() -> None:
+    """The proven dock-bag exception applies during its telemetry handoff too."""
+    state = NarwalState(working_status=WorkingStatus.STANDBY)
+    state.assume_dock_task(DOCK_TASK_DRY_DOCK_BAG)
+
+    assert not dock_task_blocks_robot_return(state)
+
+
+def test_unmapped_dock_timer_blocks_robot_return_without_coarse_activity() -> None:
+    """Fresh unknown timer work blocks return despite an idle station field."""
+    state = NarwalState(working_status=WorkingStatus.STANDBY)
+    state.update_from_working_status({"14": 60, "15": 180})
+
+    assert state.has_unmapped_active_dock_task
+    assert not state.is_station_active
+    assert dock_task_blocks_robot_return(state)
 
 
 async def test_wash_mop_switch_uses_status_gated_command() -> None:

--- a/tests/test_fan_speed.py
+++ b/tests/test_fan_speed.py
@@ -34,7 +34,6 @@ def test_canonical_labels_map_to_the_proto_enum() -> None:
     assert FAN_SPEED_MAP["Quiet"] is FanLevel.MUTE
     assert FAN_SPEED_MAP["Standard"] is FanLevel.NORMAL
     assert FAN_SPEED_MAP["Strong"] is FanLevel.STRONG
-    # #70 capture: the app's top tier ("super puissant") sends tag 2 = 4.
     assert FAN_SPEED_MAP["Super Powerful"] is FanLevel.DEEP
     assert int(FAN_SPEED_MAP["Super Powerful"]) == 4
     assert FAN_SPEED_MAP["Ultra"] is FanLevel.SUPER
@@ -43,8 +42,8 @@ def test_canonical_labels_map_to_the_proto_enum() -> None:
 def test_pre_rename_labels_still_resolve() -> None:
     """Labels shipped through v1.0.3 keep working in existing automations."""
     assert FAN_SPEED_MAP["Super"] is FanLevel.DEEP
-    assert FAN_SPEED_MAP["Super powerful"] is FanLevel.DEEP
     assert FAN_SPEED_MAP["Ultra powerful"] is FanLevel.SUPER
+    assert FAN_SPEED_MAP["Super powerful"] is FanLevel.DEEP
 
 
 def test_lowercase_aliases_still_resolve() -> None:

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,89 @@
+"""Tests for Narwal config-entry migrations."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import tests.ha_stubs
+
+tests.ha_stubs.install()
+
+from custom_components.narwal import (  # noqa: E402
+    _async_remove_legacy_replaced_sensors,
+    async_migrate_entry,
+)
+from custom_components.narwal.const import CONF_DEVICE_ID  # noqa: E402
+
+
+async def test_migration_removes_legacy_replaced_sensor_registry_entries() -> None:
+    """Old standalone task sensors are removed once native entities replace them."""
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.version = 2
+    entry.minor_version = 1
+    entry.data = {CONF_DEVICE_ID: "test_device"}
+    entry.entry_id = "entry-id"
+
+    registry = MagicMock()
+    entity_ids_by_unique_id = {
+        "test_device_current_room": "sensor.test_current_room",
+        "test_device_task_status": "sensor.test_status",
+    }
+    registry.async_get_entity_id.side_effect = (
+        lambda _domain, _platform, unique_id: entity_ids_by_unique_id.get(unique_id)
+    )
+    registry.async_get.return_value = SimpleNamespace(platform="narwal")
+
+    with patch(
+        "custom_components.narwal.er.async_get",
+        return_value=registry,
+    ), patch("custom_components.narwal.er.async_entries_for_config_entry", return_value=()):
+        assert await async_migrate_entry(hass, entry)
+
+    registry.async_get_entity_id.assert_any_call(
+        "sensor",
+        "narwal",
+        "test_device_task_status",
+    )
+    registry.async_get_entity_id.assert_any_call(
+        "sensor",
+        "narwal",
+        "test_device_current_room",
+    )
+    assert registry.async_remove.call_count == 2
+    registry.async_remove.assert_any_call("sensor.test_current_room")
+    registry.async_remove.assert_any_call("sensor.test_status")
+    hass.config_entries.async_update_entry.assert_called_once_with(
+        entry,
+        minor_version=2,
+    )
+
+
+def test_legacy_replaced_sensor_cleanup_scans_config_entry_entities() -> None:
+    """Renamed legacy sensors are still removed by unique_id."""
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.data = {CONF_DEVICE_ID: "test_device"}
+    entry.entry_id = "entry-id"
+    stale = SimpleNamespace(
+        domain="sensor",
+        platform="narwal",
+        unique_id="test_device_task_progress",
+        entity_id="sensor.renamed_progress",
+    )
+
+    registry = MagicMock()
+    registry.async_get_entity_id.return_value = None
+    registry.async_get.return_value = stale
+
+    with patch(
+        "custom_components.narwal.er.async_get",
+        return_value=registry,
+    ), patch(
+        "custom_components.narwal.er.async_entries_for_config_entry",
+        return_value=(stale,),
+    ):
+        _async_remove_legacy_replaced_sensors(hass, entry)
+
+    registry.async_remove.assert_called_once_with("sensor.renamed_progress")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,6 +7,8 @@ import struct
 from dataclasses import replace
 from unittest.mock import patch
 
+import pytest
+
 from narwal_client.const import WorkingStatus
 from narwal_client.models import (
     DOCK_TASK_DRY_DOCK_BAG,
@@ -35,7 +37,7 @@ class TestNarwalState:
         assert not state.is_returning
 
     def test_update_from_working_status(self) -> None:
-        """working_status topic sets cleaning metrics and marks active cleaning."""
+        """working_status topic sets cleaning metrics without rewriting status."""
         state = NarwalState()
         # Field 2 = coveredArea (float32, m²); field 13 = totalDryStationBagTime, ignored.
         state.update_from_working_status(
@@ -43,7 +45,7 @@ class TestNarwalState:
         )
         assert state.cleaning_time == 120
         assert state.cleaning_area == 12.5
-        assert state.working_status == WorkingStatus.CLEANING
+        assert state.working_status == WorkingStatus.UNKNOWN
         assert state.has_recent_active_working_status
 
     def test_working_status_station_timers_do_not_mark_cleaning(self) -> None:
@@ -51,7 +53,33 @@ class TestNarwalState:
         state = NarwalState()
         state.update_from_working_status({"13": 18000})
         assert state.working_status == WorkingStatus.UNKNOWN
+        assert state.last_active_working_status_time == 0.0
         assert not state.has_recent_active_working_status
+
+    def test_robot_side_drying_ignores_stale_clean_counters(self) -> None:
+        """Mop and robot-bin drying timers override prior clean metrics."""
+        for payload in (
+            {"3": 120, "8": 60, "9": 180},
+            {"3": 120, "10": 60, "11": 180},
+        ):
+            state = NarwalState()
+            state.update_from_base_status(
+                {"3": {"1": 10, "3": 6}, "11": 2, "47": 3}
+            )
+
+            state.update_from_working_status(payload)
+
+            assert not state.has_recent_active_working_status
+
+    def test_dock_bag_drying_does_not_hide_live_clean_counters(self) -> None:
+        """Dock-bag drying may continue while the robot cleans off-dock."""
+        state = NarwalState()
+
+        state.update_from_working_status(
+            {"3": 120, "12": 60, "13": 180}
+        )
+
+        assert state.has_recent_active_working_status
 
     def test_working_status_maps_dock_task_timers(self) -> None:
         """Typed dock timer pairs expose task progress without marking cleaning."""
@@ -101,6 +129,80 @@ class TestNarwalState:
         assert state.working_status == WorkingStatus.DOCKED_V2
         assert state.has_explicit_off_dock_signal
         assert not state.is_docked
+
+    def test_off_dock_fields_prevent_false_terminal_metric_suppression(self) -> None:
+        """A coarse dock enum cannot suppress later live off-dock metrics."""
+        state = NarwalState()
+
+        state.update_from_base_status(
+            {"3": {"1": 10, "3": 6, "10": 1}, "11": 2, "47": 3}
+        )
+        assert state.last_terminal_working_status_time > 0
+
+        state.update_from_base_status({"3": {"1": 2}, "11": 1, "47": 2})
+        state.update_from_working_status({"3": 120})
+
+        assert state.has_explicit_off_dock_signal
+        assert state.has_recent_active_working_status
+        assert state.is_cleaning
+
+    def test_off_dock_standby_clears_terminal_metric_suppression(self) -> None:
+        """Explicit departure clears a prior terminal timestamp before metrics."""
+        state = NarwalState()
+        state.update_from_base_status(
+            {"3": {"1": 10, "3": 6, "10": 1}, "11": 2, "47": 3}
+        )
+        assert state.last_terminal_working_status_time > 0
+
+        state.update_from_base_status(
+            {"3": {"1": 1, "3": 2, "10": 2}, "11": 1, "47": 2}
+        )
+        state.update_from_working_status({"3": 120})
+
+        assert state.working_status == WorkingStatus.STANDBY
+        assert state.has_explicit_off_dock_signal
+        assert state.last_terminal_working_status_time == 0.0
+        assert state.has_recent_active_working_status
+        assert state.is_cleaning
+
+    def test_nested_off_dock_fields_apply_before_terminal_classification(self) -> None:
+        """Current nested presence overrides retained dock indicators."""
+        state = NarwalState()
+        state.update_from_base_status(
+            {"3": {"1": 10, "3": 6, "10": 1}, "11": 2, "47": 3}
+        )
+
+        state.update_from_base_status({"3": {"1": 2, "3": 2, "10": 2}})
+        state.update_from_working_status({"3": 120})
+
+        assert state.has_explicit_off_dock_signal
+        assert state.has_recent_active_working_status
+        assert state.is_cleaning
+
+    def test_sparse_docked_status_preserves_current_dock_evidence(self) -> None:
+        """Retained off-dock fields cannot erase a newer confirmed docking."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 4, "3": 2, "10": 2}})
+        state.update_from_base_status({"3": {"1": 10, "3": 6}})
+
+        state.update_from_base_status({"3": {"1": 2}})
+
+        assert not state.has_explicit_off_dock_signal
+        assert state.is_docked
+
+    def test_presence_only_departure_clears_retained_dock_evidence(self) -> None:
+        """Current nested departure wins over omitted prior dock fields."""
+        state = NarwalState()
+        state.update_from_base_status(
+            {"3": {"1": 10, "3": 6, "10": 1}, "11": 2, "47": 3}
+        )
+
+        state.update_from_base_status({"3": {"1": 2, "3": 2}})
+        state.update_from_working_status({"3": 120})
+
+        assert state.has_explicit_off_dock_signal
+        assert state.has_recent_active_working_status
+        assert state.is_cleaning
 
     def test_explicit_off_dock_fields_override_retained_dock_activity(self) -> None:
         """Coarse station activity cannot override current off-dock fields."""
@@ -173,6 +275,15 @@ class TestNarwalState:
         assert state.active_dock_task_keys == (DOCK_TASK_DRY_MOP,)
         assert not state.has_fresh_idle_dock_drying_snapshot
 
+    def test_recent_clean_metrics_preserve_fresh_emptying_activity(self) -> None:
+        """An intermediate empty phase remains active despite recent counters."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.update_from_working_status({"3": 60})
+        state.station_activity = 1
+
+        assert state.has_recent_active_working_status
+        assert state.is_station_active
+
     def test_unmapped_dock_timer_expires_by_freshness_window(self) -> None:
         """Unmapped timer fields stop blocking when their packet is stale."""
         state = NarwalState()
@@ -213,6 +324,74 @@ class TestNarwalState:
         assert state.is_docked
         assert state.working_status == WorkingStatus.DOCKED
 
+    def test_working_status_decodes_progress_and_remaining_time(self) -> None:
+        """working_status reports progress and remaining time for vacuum attrs."""
+        state = NarwalState()
+
+        state.update_from_working_status(
+            {"1": _float_to_uint32(0.64), "3": 120, "4": 600}
+        )
+
+        assert state.task_progress_percent == 64
+        assert state.cleaning_time == 120
+        assert state.task_elapsed_time == 120
+        assert state.task_remaining_time == 600
+
+    def test_non_cleaning_base_status_clears_stale_task_details(self) -> None:
+        """Progress/current-room fields from the prior clean should not leak."""
+        state = NarwalState()
+        state.task_progress_percent = 72
+        state.task_elapsed_time = 900
+        state.task_remaining_time = 300
+        state.current_room_id = 4
+        state.current_room_aux_name = "Kitchen"
+
+        state.update_from_base_status({"3": {"1": 10, "10": 1}})
+
+        assert state.task_progress_percent is None
+        assert state.task_elapsed_time == 0
+        assert state.task_remaining_time == 0
+        assert state.current_room_id is None
+        assert state.current_room_aux_name == ""
+
+    def test_terminal_docked_status_clears_stale_paused_context(self) -> None:
+        """A stale paused bit cannot keep a confirmed docked robot active."""
+        state = NarwalState()
+        state.last_active_working_status_time = 1.0
+        state.task_progress_percent = 72
+        state.task_elapsed_time = 900
+        state.current_room_id = 4
+
+        state.update_from_base_status(
+            {"3": {"1": 10, "2": 1, "10": 1}, "11": 2, "47": 3}
+        )
+
+        assert state.last_active_working_status_time == 0.0
+        assert not state.has_recent_active_working_status
+        assert state.task_progress_percent is None
+        assert state.task_elapsed_time == 0
+        assert state.current_room_id is None
+        assert state.is_docked
+
+    def test_off_dock_task_completed_clears_stale_paused_context(self) -> None:
+        """Completion cannot retain a resumable paused overlay off the dock."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.is_paused = True
+        state.cleaning_area = 25.5
+        state.cleaning_time = 900
+        state.task_elapsed_time = 900
+        state.dock_presence = 2
+
+        state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.TASK_COMPLETED), "2": 1, "3": 2}}
+        )
+
+        assert not state.is_paused
+        assert state.cleaning_area == 0.0
+        assert state.cleaning_time == 0
+        assert state.task_elapsed_time == 0
+        assert not state.has_paused_clean_task_context
+
     def test_working_status_clears_stale_dock_fields(self) -> None:
         """Fresh task metrics override stale dock indicators."""
         state = NarwalState(working_status=WorkingStatus.DOCKED)
@@ -225,10 +404,24 @@ class TestNarwalState:
 
         assert state.is_cleaning
         assert not state.is_docked
-        assert state.dock_sub_state == 0
-        assert state.dock_activity == 0
-        assert state.dock_field11 == 1
-        assert state.dock_field47 == 2
+        assert state.working_status == WorkingStatus.DOCKED
+
+    def test_recent_working_status_survives_stale_docked_base_packet(self) -> None:
+        """A delayed dock packet cannot erase a confirmed clean handoff."""
+        state = NarwalState(working_status=WorkingStatus.DOCKED)
+        state.assume_robot_clean()
+        state.update_from_working_status({"1": 25, "3": 120, "6": 4})
+
+        state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.DOCKED), "10": 1}, "11": 2, "47": 3}
+        )
+
+        assert state.has_recent_active_working_status
+        assert state.is_cleaning
+        assert not state.is_docked
+        assert state.task_progress_percent == 25
+        assert state.task_elapsed_time == 120
+        assert state.current_room_id == 4
 
     def test_update_from_base_status_cleaning(self) -> None:
         state = NarwalState()
@@ -303,19 +496,24 @@ class TestNarwalState:
 
         assert state.active_dock_task_keys == ()
 
-    def test_active_cleaning_clears_stale_station_activity(self) -> None:
-        """Cleaning telemetry clears coarse dock activity from prior station work."""
-        state = NarwalState()
-        state.station_activity = 1
-        state.dock_activity = 4
-        state.assume_dock_task(DOCK_TASK_EMPTY_DUSTBIN)
+    def test_stale_working_metrics_do_not_override_active_station_task(self) -> None:
+        """Historic clean counters cannot hide fresh emptying or washing."""
+        for station_activity, dock_activity, task in (
+            (1, 0, DOCK_TASK_EMPTY_DUSTBIN),
+            (2, 0, DOCK_TASK_WASH_MOP),
+            (0, 3, DOCK_TASK_WASH_MOP),
+        ):
+            state = NarwalState(working_status=WorkingStatus.DOCKED)
+            state.dock_presence = 6
+            state.station_activity = station_activity
+            state.dock_activity = dock_activity
 
-        state.update_from_working_status({"3": 120})
+            state.update_from_working_status({"3": 120})
 
-        assert state.station_activity == 0
-        assert state.dock_activity == 0
-        assert not state.is_station_active
-        assert state.active_dock_task_keys == ()
+            assert state.station_activity == station_activity
+            assert state.dock_activity == dock_activity
+            assert not state.has_recent_active_working_status
+            assert state.active_dock_task_keys == (task,)
 
     def test_active_base_status_clears_stale_station_activity(self) -> None:
         """Active robot base-status packets cannot keep stale dock switches on."""
@@ -357,7 +555,7 @@ class TestNarwalState:
         assert not state.has_dock_presence_signal
         assert state.dock_task_timer(DOCK_TASK_DRY_MOP) is not None
         assert state.active_dock_task_keys == (DOCK_TASK_DRY_MOP,)
-        assert state.blocks_robot_start_for_dock_task
+        assert not state.blocks_robot_start_for_dock_task
 
     def test_stale_dock_timer_does_not_remain_active(self) -> None:
         """Typed dock timers stop driving visible state after telemetry expires."""
@@ -394,21 +592,26 @@ class TestNarwalState:
         assert state.has_unmapped_active_dock_task
         assert state.blocks_robot_start_for_dock_task
 
-    def test_robot_start_blocked_by_dock_work_except_typed_dock_bag(self) -> None:
-        """Only typed dock-bag drying is compatible with a new robot clean."""
+    def test_robot_start_allows_only_typed_drying_work(self) -> None:
+        """Typed drying is compatible with a new robot clean."""
         state = NarwalState()
         state.update_from_base_status({"3": {"1": 10, "3": 6, "18": 1}, "11": 2})
         assert state.blocks_robot_start_for_dock_task
 
-        state = NarwalState()
-        state.update_from_base_status({"3": {"1": 10, "3": 6}, "11": 2})
-        state.set_dock_drying_task(
-            DOCK_TASK_DRY_DOCK_BAG,
-            elapsed=60,
-            target=180,
-            fields=("12", "13"),
-        )
-        assert not state.blocks_robot_start_for_dock_task
+        for task, fields in (
+            (DOCK_TASK_DRY_MOP, ("8", "9")),
+            (DOCK_TASK_DRY_DUST_BIN, ("10", "11")),
+            (DOCK_TASK_DRY_DOCK_BAG, ("12", "13")),
+        ):
+            state = NarwalState()
+            state.update_from_base_status({"3": {"1": 10, "3": 6}, "11": 2})
+            state.set_dock_drying_task(
+                task,
+                elapsed=60,
+                target=180,
+                fields=fields,
+            )
+            assert not state.blocks_robot_start_for_dock_task
 
         state.dock_drying_status_time -= 181
 
@@ -423,15 +626,62 @@ class TestNarwalState:
         assert state.active_dock_task_keys == (DOCK_TASK_DRY_DOCK_BAG,)
         assert state.blocks_robot_start_for_dock_task
 
-    def test_assumed_robot_clean_clears_on_active_telemetry(self) -> None:
-        """Accepted robot-start reservations stop once real cleaning status arrives."""
+    def test_assumed_robot_clean_waits_for_active_base_status(self) -> None:
+        """Working metrics do not expose a start to delayed dock packets."""
         state = NarwalState()
         state.assume_robot_clean()
 
         state.update_from_working_status({"3": 120})
 
-        assert not state.has_assumed_robot_clean
+        assert state.has_assumed_robot_clean
         assert state.is_cleaning
+
+        state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.CLEANING)}, "11": 1, "47": 2}
+        )
+
+        assert not state.has_assumed_robot_clean
+
+    def test_assumed_robot_clean_covers_slow_status_handoff(self) -> None:
+        """Accepted room starts may take over 30s to publish task telemetry."""
+        state = NarwalState()
+
+        with patch("narwal_client.models.time.monotonic", return_value=1000.0):
+            state.assume_robot_clean()
+        with patch("narwal_client.models.time.monotonic", return_value=1179.0):
+            assert state.has_assumed_robot_clean
+        with patch("narwal_client.models.time.monotonic", return_value=1181.0):
+            assert not state.has_assumed_robot_clean
+
+    def test_assumed_robot_clean_ignores_unknown_off_dock_handoff(self) -> None:
+        """UNKNOWN/off-dock base status can appear before task telemetry arrives."""
+        state = NarwalState()
+        state.assume_robot_clean()
+
+        state.update_from_base_status({"3": {"1": 0}, "11": 1, "47": 2})
+
+        assert state.has_assumed_robot_clean
+
+    def test_assumed_robot_clean_ignores_previous_docked_base_status(self) -> None:
+        """A stale dock status cannot erase an accepted start during handoff."""
+        state = NarwalState()
+        with patch("narwal_client.models.time.monotonic", return_value=1000.0):
+            state.assume_robot_clean()
+
+        with patch("narwal_client.models.time.monotonic", return_value=1059.0):
+            state.update_from_base_status({"3": {"1": 10, "10": 1}, "11": 2})
+            assert state.has_assumed_robot_clean
+
+    def test_assumed_robot_clean_clears_after_docked_handoff_grace(self) -> None:
+        """Current idle dock telemetry wins if an accepted start never begins."""
+        state = NarwalState()
+        with patch("narwal_client.models.time.monotonic", return_value=1000.0):
+            state.assume_robot_clean()
+
+        with patch("narwal_client.models.time.monotonic", return_value=1061.0):
+            state.update_from_base_status({"3": {"1": 10, "10": 1}, "11": 2})
+
+        assert not state.has_assumed_robot_clean
 
     def test_paused_context_handles_missing_task_metrics(self) -> None:
         """Paused context is safe before richer task metric fields exist."""
@@ -444,6 +694,95 @@ class TestNarwalState:
 
         assert state.has_paused_clean_task_context
 
+    @pytest.mark.parametrize(
+        "status",
+        (
+            WorkingStatus.DOCKED,
+            WorkingStatus.CHARGED,
+            WorkingStatus.DOCKED_V2,
+            WorkingStatus.TASK_COMPLETED,
+            WorkingStatus.ERROR,
+        ),
+    )
+    def test_terminal_status_ignores_late_active_metrics(
+        self, status: WorkingStatus
+    ) -> None:
+        """Late counters cannot reactivate a terminal robot state."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": int(status)}})
+
+        state.update_from_working_status({"2": 12.5, "3": 900})
+
+        assert not state.has_recent_active_working_status
+        assert not state.is_cleaning
+
+    def test_terminal_suppressed_metrics_cannot_revive_paused_context(self) -> None:
+        """A later pause bit cannot revive metrics rejected after docking."""
+        state = NarwalState()
+        state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.DOCKED), "10": 1}, "11": 2}
+        )
+
+        state.update_from_working_status({"1": 25, "2": 12.5, "3": 900, "6": 4})
+        state.update_from_base_status({"3": {"2": 1}})
+
+        assert state.task_progress_percent is None
+        assert state.task_elapsed_time == 0
+        assert state.current_room_id is None
+        assert not state.has_paused_clean_task_context
+
+    @pytest.mark.parametrize(
+        "status", (WorkingStatus.TASK_COMPLETED, WorkingStatus.ERROR)
+    )
+    def test_explicit_terminal_status_rejects_progressing_metrics(
+        self, status: WorkingStatus
+    ) -> None:
+        """Metric progression cannot override an explicit terminal robot state."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": int(status)}})
+
+        state.update_from_working_status({"1": 25, "3": 120})
+        state.update_from_working_status({"1": 26, "3": 121})
+
+        assert not state.has_recent_active_working_status
+        assert not state.is_cleaning
+
+    @pytest.mark.parametrize(
+        "dock_fields",
+        ({"11": 2}, {"11": 3}, {"47": 1}, {"47": 3}),
+    )
+    def test_docked_standby_ignores_late_active_metrics(
+        self, dock_fields: dict[str, int]
+    ) -> None:
+        """Legacy and newer docked STANDBY packets are terminal telemetry."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.update_from_working_status({"2": 12.5, "3": 900})
+        assert state.has_recent_active_working_status
+
+        state.update_from_base_status({"3": {"1": 1}, **dock_fields})
+        state.update_from_working_status({"2": 12.5, "3": 900})
+
+        assert state.working_status == WorkingStatus.STANDBY
+        assert state.is_docked
+        assert not state.has_recent_active_working_status
+        assert not state.is_cleaning
+
+    def test_task_completed_clears_metrics_after_accepted_start(self) -> None:
+        """Completion ends fresh metrics even during the accepted-start handoff."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        state.assume_robot_clean()
+        state.update_from_working_status({"2": 12.5, "3": 900})
+        assert state.has_assumed_robot_clean
+        assert state.is_cleaning
+
+        state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.TASK_COMPLETED)}}
+        )
+
+        assert not state.has_assumed_robot_clean
+        assert not state.has_recent_active_working_status
+        assert not state.is_cleaning
+
     def test_paused_context_ignores_stale_metrics_after_docking(self) -> None:
         """Docked API state ends stale paused overlays from the previous task."""
         state = NarwalState()
@@ -452,6 +791,17 @@ class TestNarwalState:
         state.current_room_id = 4
 
         assert not state.has_paused_clean_task_context
+
+    def test_paused_context_outranks_cached_dock_fields(self) -> None:
+        """Only a current terminal update may end retained paused context."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        state.is_paused = True
+        state.cleaning_time = 120
+        state.dock_presence = 6
+        state.dock_field11 = 2
+        state.dock_field47 = 3
+
+        assert state.has_paused_clean_task_context
 
     def test_dock_task_assumption_is_only_a_short_command_guard(self) -> None:
         """Dock task assumptions must not fabricate long-running device state."""
@@ -892,6 +1242,16 @@ class TestNarwalState:
         assert state.is_returning  # should be True via field 3.7
         assert not state.is_cleaning  # returning takes priority
 
+    def test_stale_return_flag_does_not_hide_active_clean(self) -> None:
+        """Field 3.7 alone is not an authoritative returning state."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 4, "7": 1}})
+        state.last_active_working_status_time = 0.0
+
+        assert state.is_returning_to_dock
+        assert not state.is_returning
+        assert state.is_cleaning
+
     def test_returning_clears_when_docked(self) -> None:
         """Returning flag clears when robot docks."""
         state = NarwalState()
@@ -1239,6 +1599,16 @@ class TestCurrentRoomTracking:
         state = NarwalState()
         state.update_from_working_status({"6": 0})
         assert state.current_room_id is None
+
+    def test_nested_current_room_details_supply_id_and_name(self) -> None:
+        """Nested firmware room details populate the fallback room name."""
+        state = NarwalState()
+
+        state.update_from_working_status({"6": {"1": 4, "3": b"Kitchen"}})
+
+        assert state.current_room_id == 4
+        assert state.current_room_aux_name == "Kitchen"
+        assert state.current_room_name == "Kitchen"
 
     def test_current_room_id_not_cleared_when_field6_absent(self) -> None:
         """If field 6 is not in the message, current_room_id is not cleared.

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,67 @@
+"""Tests for Narwal sensor entities."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import tests.ha_stubs
+
+tests.ha_stubs.install()
+
+from custom_components.narwal.sensor import (  # noqa: E402
+    SENSOR_DESCRIPTIONS,
+    NarwalSensor,
+)
+from narwal_client.const import WorkingStatus  # noqa: E402
+from narwal_client.models import NarwalState  # noqa: E402
+
+
+def _sensor(key: str, state: NarwalState) -> NarwalSensor:
+    """Create a NarwalSensor with mocked coordinator data."""
+    coordinator = MagicMock()
+    coordinator.data = state
+    coordinator.last_update_success = True
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.data = {"device_id": "test_device"}
+    coordinator.config_entry.title = "Narwal Test"
+    coordinator.client = MagicMock()
+    coordinator.client.state = state
+    coordinator.client.state.firmware_version = "1.0.0"
+    description = next(item for item in SENSOR_DESCRIPTIONS if item.key == key)
+    return NarwalSensor(coordinator, description)
+
+
+def test_current_room_is_not_a_standalone_sensor() -> None:
+    """Live task context is carried by the vacuum entity, not stale sensors."""
+    sensor_keys = {description.key for description in SENSOR_DESCRIPTIONS}
+    assert "current_room" not in sensor_keys
+    assert "map_metadata" not in sensor_keys
+    assert "status" not in sensor_keys
+    assert "task_progress" not in sensor_keys
+
+
+def test_cleaning_metrics_are_unavailable_when_idle() -> None:
+    """Cleaning metric sensors should not expose stale previous-clean values."""
+    state = NarwalState(working_status=WorkingStatus.DOCKED)
+    state.cleaning_area = 12.5
+    state.cleaning_time = 900
+    state.task_remaining_time = 300
+
+    assert not _sensor("cleaning_area", state).available
+    assert not _sensor("cleaning_time", state).available
+    assert not _sensor("remaining_time", state).available
+
+
+def test_cleaning_metrics_are_available_during_active_clean() -> None:
+    """Cleaning metric sensors expose current robot task values while active."""
+    state = NarwalState(working_status=WorkingStatus.CLEANING)
+    state.cleaning_area = 12.5
+    state.cleaning_time = 900
+    state.task_remaining_time = 300
+
+    assert _sensor("cleaning_area", state).available
+    assert _sensor("cleaning_area", state).native_value == 12.5
+    assert _sensor("cleaning_time", state).available
+    assert _sensor("cleaning_time", state).native_value == 900
+    assert _sensor("remaining_time", state).available
+    assert _sensor("remaining_time", state).native_value == 300

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -65,6 +65,13 @@ def _coordinator(
         return_value=CommandResponse(result_code=result_code)
     )
     coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+
+    async def prepare_clean_start(*, allow_dock_stop: bool = True) -> bool:
+        return coordinator.client.state.is_docked and (
+            allow_dock_stop or not coordinator.client.state.active_dock_task_keys
+        )
+
+    coordinator.async_prepare_clean_start = AsyncMock(side_effect=prepare_clean_start)
     coordinator.dock_action_lock = asyncio.Lock()
     coordinator.config_entry = MagicMock()
     coordinator.config_entry.data = {"product_key": product_key}
@@ -169,7 +176,7 @@ async def test_clean_rooms_service_starts_requested_rooms() -> None:
         await handler(call)
 
     extract_entity_ids.assert_awaited_once()
-    assert extract_entity_ids.await_args.args == (call,)
+    assert extract_entity_ids.await_args.args[0] is call
     coordinator.client.start_rooms.assert_awaited_once()
     assert coordinator.client.start_rooms.await_args.args[0] == [4, 7]
     assert coordinator.client.state.has_assumed_robot_clean
@@ -178,28 +185,30 @@ async def test_clean_rooms_service_starts_requested_rooms() -> None:
     coordinator.async_set_updated_data.assert_called_once_with(coordinator.client.state)
 
 
-async def test_clean_rooms_service_accepts_legacy_extract_signature() -> None:
-    """The service supports HA versions where extraction also takes hass."""
+async def test_clean_rooms_service_supports_legacy_entity_extractor() -> None:
+    """Target extraction remains compatible with older HA helper signatures."""
     coordinator = _coordinator()
     handler, registry = _register_clean_rooms_handler(coordinator)
     call = _clean_rooms_call()
-    extract_entity_ids = AsyncMock(
-        side_effect=[TypeError, ["vacuum.downstairs_narwal"]]
-    )
 
     with (
         patch(
             "custom_components.narwal.service.async_extract_entity_ids",
-            extract_entity_ids,
-        ),
+            new_callable=AsyncMock,
+            side_effect=[
+                TypeError("missing required positional argument: service_call"),
+                ["vacuum.downstairs_narwal"],
+            ],
+        ) as extract_entity_ids,
         patch("custom_components.narwal.er.async_get", return_value=registry),
     ):
         await handler(call)
 
+    assert len(extract_entity_ids.await_args_list) == 2
     assert extract_entity_ids.await_args_list[0].args == (call,)
-    legacy_args = extract_entity_ids.await_args_list[1].args
-    assert legacy_args[1] is call
-    assert legacy_args[0].data[DOMAIN]["entry-1"] is coordinator
+    assert len(extract_entity_ids.await_args_list[1].args) == 2
+    assert extract_entity_ids.await_args_list[1].args[1] is call
+    coordinator.client.start_rooms.assert_awaited_once()
 
 
 async def test_clean_rooms_service_accepts_async_accepted_response() -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -254,6 +254,37 @@ async def test_clean_rooms_service_uses_requested_settings_over_room_profiles() 
     assert kwargs["room_settings"][7].fan == FanLevel.STRONG
 
 
+@pytest.mark.parametrize(
+    ("product_key", "expected"),
+    [
+        ("QoEsI5qYXO", FanLevel.SUPER),
+        ("qV6BujoYLz", FanLevel.DEEP),
+    ],
+)
+async def test_clean_rooms_service_resolves_max_for_each_model(
+    product_key: str,
+    expected: FanLevel,
+) -> None:
+    """The max alias resolves through each model's visible tiers."""
+    coordinator = _coordinator(product_key=product_key)
+    handler, registry = _register_clean_rooms_handler(coordinator)
+    call = _clean_rooms_call()
+    call.data[FIELD_SUCTION] = "max"
+
+    with (
+        patch(
+            "custom_components.narwal.service.async_extract_entity_ids",
+            new_callable=AsyncMock,
+            return_value=["vacuum.downstairs_narwal"],
+        ),
+        patch("custom_components.narwal.er.async_get", return_value=registry),
+    ):
+        await handler(call)
+
+    room_settings = coordinator.client.start_rooms.await_args.kwargs["room_settings"]
+    assert all(settings.fan == expected for settings in room_settings.values())
+
+
 async def test_clean_rooms_service_rejects_unavailable_start() -> None:
     """The service enforces the same availability as the start entities."""
     coordinator = _coordinator(docked=False)

--- a/tests/test_vacuum_segments.py
+++ b/tests/test_vacuum_segments.py
@@ -391,6 +391,20 @@ class TestVacuumSupportedFeatures:
         assert features & VacuumEntityFeature.LOCATE
         assert features & VacuumEntityFeature.FAN_SPEED
 
+    def test_metric_only_clean_with_dock_bag_drying_keeps_stop(self) -> None:
+        """Fresh clean metrics identify robot work alongside compatible drying."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        state.update_from_working_status({"3": 120})
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
+        )
+        vac = _make_vacuum(state=state)
+
+        assert vac.supported_features & VacuumEntityFeature.STOP
+
     def test_intermediate_mop_wash_keeps_active_clean_stop(self) -> None:
         """Mapped station work cannot hide Stop for a current robot clean."""
         state = _active_clean_state()
@@ -1864,6 +1878,28 @@ class TestAsyncStop:
         await vac.async_stop()
 
         vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.stop.assert_awaited_once()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_stop_routes_metric_only_clean_with_dock_bag_to_robot(self) -> None:
+        """Fresh metrics keep robot STOP actionable during dock-bag drying."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        state.update_from_working_status({"3": 120})
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        await vac.async_stop()
+
         vac.coordinator.client.stop.assert_awaited_once()
         vac.coordinator.client.stop_dock_task.assert_not_awaited()
 

--- a/tests/test_vacuum_segments.py
+++ b/tests/test_vacuum_segments.py
@@ -23,7 +23,7 @@ from homeassistant.exceptions import HomeAssistantError  # noqa: E402
 from custom_components.narwal.coordinator import (  # noqa: E402
     CleanSettings,
     NarwalCoordinator,
-    is_clean_session_context,
+    can_prepare_clean_start,
 )
 from custom_components.narwal.vacuum import (  # noqa: E402
     FanSettingRestoreData,
@@ -33,12 +33,16 @@ from narwal_client import RoomCleanSettings  # noqa: E402
 from narwal_client.const import (  # noqa: E402
     CommandResult,
     FanLevel,
+    MopHumidity,
     WorkingStatus,
     WorkMode,
 )
 from narwal_client.models import (  # noqa: E402
     DOCK_TASK_DRY_DOCK_BAG,
+    DOCK_TASK_DRY_DUST_BIN,
     DOCK_TASK_DRY_MOP,
+    DOCK_TASK_EMPTY_DUSTBIN,
+    DOCK_TASK_WASH_MOP,
     CommandResponse,
     MapData,
     NarwalState,
@@ -46,6 +50,7 @@ from narwal_client.models import (  # noqa: E402
 )
 
 Segment = sys.modules["homeassistant.components.vacuum"].Segment
+VacuumActivity = sys.modules["homeassistant.components.vacuum"].VacuumActivity
 VacuumEntityFeature = sys.modules["homeassistant.components.vacuum"].VacuumEntityFeature
 
 
@@ -56,17 +61,22 @@ def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
     coordinator.data = state
     coordinator.config_entry = MagicMock()
     coordinator.config_entry.data = {"device_id": "test_dev_001"}
+    coordinator.config_entry.entry_id = "entry-1"
     coordinator.config_entry.title = "Narwal Test"
     coordinator.client = MagicMock()
     coordinator.client.state = client_state
     coordinator.client.state.firmware_version = "1.0.0"
     coordinator.client.get_map = AsyncMock(return_value=client_state.map_data)
     coordinator.last_update_success = True
+    coordinator.has_fresh_state = True
     coordinator.clean_settings = CleanSettings()
     coordinator.active_clean_work_mode = None
+    coordinator._room_selection_store_loaded = True
     coordinator.active_clean_setting.return_value = None
     coordinator.has_selected_clean_rooms.return_value = False
     coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+    coordinator.async_prepare_clean_start = AsyncMock(return_value=True)
+    coordinator.async_refresh_action_status = AsyncMock(return_value=True)
     coordinator.dock_action_lock = asyncio.Lock()
     coordinator.room_clean_settings_for_rooms = MagicMock(
         side_effect=lambda room_ids, **_kwargs: {
@@ -91,7 +101,7 @@ def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
     coordinator.clean_setting_applicability_mode = MagicMock(
         side_effect=lambda live=False: (
             coordinator.active_clean_work_mode
-            if live and is_clean_session_context(coordinator.data)
+            if live and coordinator.active_clean_work_mode is not None
             else coordinator.clean_settings.work_mode
         )
     )
@@ -100,9 +110,11 @@ def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
     vac.coordinator = coordinator
     vac._attr_unique_id = "test_dev_001"
     vac._attr_device_info = {}
+    vac.hass = MagicMock()
 
     # Stub StateVacuumEntity attributes
     vac.last_seen_segments = None
+    vac._last_reported_segment_signature = None
     vac.async_create_segments_issue = MagicMock()
     vac.async_write_ha_state = MagicMock()
 
@@ -122,6 +134,345 @@ def _docked_state() -> NarwalState:
     state.dock_presence = 6
     state.dock_field11 = 2
     return state
+
+
+class TestVacuumActivity:
+    """Tests for mapping Narwal task context to HA vacuum activity."""
+
+    def test_active_clean_details_remain_visible(self) -> None:
+        state = _active_clean_state()
+        state.task_progress_percent = 72
+        state.current_room_id = 4
+        state.current_room_aux_name = "Kitchen"
+        state.task_remaining_time = 300
+        state.cleaning_area = 12.5
+        state.cleaning_time = 900
+        vac = _make_vacuum(state=state)
+
+        attrs = vac.extra_state_attributes
+
+        assert attrs["progress"] == 72
+        assert attrs["status_summary"] == "Kitchen - 72%"
+        assert "charging_to_resume" not in attrs
+        assert "progress_display" not in attrs
+        assert "remaining_time" not in attrs
+        assert "current_room_id" not in attrs
+        assert attrs["current_room"] == "Kitchen"
+        assert "active_room_ids" not in attrs
+        assert "cleaning_area" not in attrs
+        assert "cleaning_time" not in attrs
+
+    @pytest.mark.parametrize("transition", ("paused", "returning"))
+    def test_transition_status_takes_priority_over_retained_metrics(
+        self,
+        transition: str,
+    ) -> None:
+        state = _active_clean_state()
+        state.task_progress_percent = 72
+        state.current_room_aux_name = "Kitchen"
+        if transition == "paused":
+            state.is_paused = True
+        else:
+            state.is_returning_to_dock = True
+            state.dock_sub_state = 2
+        vac = _make_vacuum(state=state)
+
+        assert vac.extra_state_attributes["status_summary"] == transition.title()
+
+    def test_stale_clean_details_hidden_after_clean_ends(self) -> None:
+        state = NarwalState(working_status=WorkingStatus.CHARGED)
+        state.task_progress_percent = 72
+        state.current_room_id = 4
+        state.current_room_aux_name = "Kitchen"
+        state.cleaning_area = 12.5
+        state.cleaning_time = 900
+        vac = _make_vacuum(state=state)
+
+        attrs = vac.extra_state_attributes
+
+        assert attrs["task_status"] == "docked"
+        assert "progress" not in attrs
+        assert "remaining_time" not in attrs
+        assert "current_room_id" not in attrs
+        assert "current_room" not in attrs
+        assert "active_room_ids" not in attrs
+        assert "cleaning_area" not in attrs
+        assert "cleaning_time" not in attrs
+
+    def test_unknown_off_dock_status_reports_conservative_cleaning(self) -> None:
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 0}, "11": 1, "47": 2})
+        vac = _make_vacuum(state=state)
+
+        assert state.working_status == WorkingStatus.UNKNOWN
+        assert not state.is_cleaning
+        assert vac.activity == VacuumActivity.CLEANING
+        assert vac.extra_state_attributes["task_status"] == "unknown"
+
+    def test_task_completed_reports_returning_status(self) -> None:
+        """Task-completed transition agrees with the HA returning activity."""
+        state = NarwalState(working_status=WorkingStatus.TASK_COMPLETED)
+        vac = _make_vacuum(state=state)
+
+        assert vac.activity == VacuumActivity.RETURNING
+        assert vac.extra_state_attributes["task_status"] == "returning"
+        assert vac.extra_state_attributes["status_summary"] == "Returning"
+
+    def test_assumed_clean_reports_active_during_start_handoff(self) -> None:
+        """An accepted start remains visible until native task telemetry arrives."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 0}, "11": 1, "47": 2})
+        state.assume_robot_clean()
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+        attrs = vac.extra_state_attributes
+
+        assert vac.activity == VacuumActivity.CLEANING
+        assert attrs["task_status"] == "cleaning"
+        assert attrs["status_summary"] == "Cleaning"
+        assert "progress" not in attrs
+        assert "current_room" not in attrs
+        assert features & VacuumEntityFeature.STOP
+
+    def test_station_activity_alone_does_not_report_robot_docked(self) -> None:
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        state.dock_presence = 2
+        state.dock_field11 = 1
+        state.dock_field47 = 2
+        state.station_activity = 4
+        vac = _make_vacuum(state=state)
+
+        assert not state.is_docked
+        assert state.is_station_active
+        assert vac.activity == VacuumActivity.IDLE
+        assert vac.extra_state_attributes["task_status"] == "station_active"
+
+    def test_paused_remapping_reports_paused_task_status(self) -> None:
+        """The paused overlay takes precedence over the remapping label."""
+        state = NarwalState(working_status=WorkingStatus.REMAPPING)
+        state.is_paused = True
+        state.task_elapsed_time = 60
+        vac = _make_vacuum(state=state)
+
+        assert vac.activity == VacuumActivity.PAUSED
+        assert vac.extra_state_attributes["task_status"] == "paused"
+
+
+class TestVacuumSupportedFeatures:
+    """Tests for dynamically exposed native HA vacuum features."""
+
+    def test_idle_docked_exposes_start_features(self) -> None:
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 10, "10": 1}, "11": 2})
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+
+        assert features & VacuumEntityFeature.STATE
+        assert features & VacuumEntityFeature.START
+        assert features & VacuumEntityFeature.FAN_SPEED
+        assert features & VacuumEntityFeature.CLEAN_AREA
+        assert features & VacuumEntityFeature.RETURN_HOME
+        assert not features & VacuumEntityFeature.STOP
+        assert not features & VacuumEntityFeature.PAUSE
+
+    def test_stale_dock_state_keeps_refreshable_start_features(self) -> None:
+        """Start services remain reachable so handlers can refresh dock state."""
+        state = _docked_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.has_fresh_state = False
+
+        features = vac.supported_features
+
+        assert features & VacuumEntityFeature.START
+        assert features & VacuumEntityFeature.CLEAN_AREA
+
+    def test_failed_selection_restore_hides_start_without_cached_map(self) -> None:
+        """Do not advertise START when its room selection is non-authoritative."""
+        state = _docked_state()
+        state.map_data = None
+        vac = _make_vacuum(state=state)
+        vac.coordinator._room_selection_store_loaded = False
+
+        features = vac.supported_features
+
+        assert not features & VacuumEntityFeature.START
+
+    def test_stale_dock_state_keeps_live_robot_controls(self) -> None:
+        """Fresh active-task context remains controllable after a dock poll failure."""
+        state = _active_clean_state()
+        state.update_from_working_status({"3": 120})
+        vac = _make_vacuum(state=state)
+        vac.coordinator.has_fresh_state = False
+
+        features = vac.supported_features
+
+        assert features & VacuumEntityFeature.PAUSE
+        assert features & VacuumEntityFeature.STOP
+        assert features & VacuumEntityFeature.RETURN_HOME
+        assert features & VacuumEntityFeature.FAN_SPEED
+
+    def test_docked_v2_with_off_dock_fields_exposes_return_home_not_start(self) -> None:
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 2}, "11": 1, "47": 2})
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+
+        assert vac.activity == VacuumActivity.IDLE
+        assert features & VacuumEntityFeature.RETURN_HOME
+        assert not features & VacuumEntityFeature.START
+        assert not features & VacuumEntityFeature.CLEAN_AREA
+
+    def test_active_clean_exposes_active_native_features(self) -> None:
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+
+        assert features & VacuumEntityFeature.STATE
+        assert features & VacuumEntityFeature.PAUSE
+        assert features & VacuumEntityFeature.STOP
+        assert features & VacuumEntityFeature.RETURN_HOME
+        assert features & VacuumEntityFeature.FAN_SPEED
+        assert not features & VacuumEntityFeature.START
+        assert not features & VacuumEntityFeature.CLEAN_AREA
+
+    def test_active_clean_with_unknown_mode_hides_fan_speed(self) -> None:
+        """A reconnect cannot advertise suction until the task mode is known."""
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.clean_setting_applicability_mode.side_effect = None
+        vac.coordinator.clean_setting_applicability_mode.return_value = None
+
+        assert not vac.supported_features & VacuumEntityFeature.FAN_SPEED
+
+    def test_unmapped_dock_phase_keeps_stop_during_robot_clean(self) -> None:
+        """Ambiguous station telemetry must not mask the robot's stop action."""
+        state = _active_clean_state()
+        state.dock_activity = 99
+        vac = _make_vacuum(state=state)
+
+        assert vac.supported_features & VacuumEntityFeature.STOP
+
+    def test_off_dock_dock_bag_drying_exposes_return_home(self) -> None:
+        """Dock-bag drying can continue while an off-dock robot returns home."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
+        )
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+
+        assert features & VacuumEntityFeature.RETURN_HOME
+        assert not features & VacuumEntityFeature.STOP
+
+    def test_active_clean_with_dock_bag_drying_keeps_robot_controls(self) -> None:
+        """A compatible dock task must not hide controls for an active off-dock clean."""
+        state = _active_clean_state()
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
+        )
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+
+        assert features & VacuumEntityFeature.PAUSE
+        assert features & VacuumEntityFeature.STOP
+        assert features & VacuumEntityFeature.RETURN_HOME
+        assert features & VacuumEntityFeature.LOCATE
+        assert features & VacuumEntityFeature.FAN_SPEED
+
+    def test_intermediate_mop_wash_keeps_active_clean_stop(self) -> None:
+        """Mapped station work cannot hide Stop for a current robot clean."""
+        state = _active_clean_state()
+        state.station_activity = 2
+        vac = _make_vacuum(state=state)
+
+        assert state.active_dock_task_keys == (DOCK_TASK_WASH_MOP,)
+        assert vac.supported_features & VacuumEntityFeature.STOP
+
+    def test_off_dock_mop_drying_hides_return_home(self) -> None:
+        """Mop drying still blocks return-home until hardware proves otherwise."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        state.dock_presence = 6
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+
+        assert not features & VacuumEntityFeature.RETURN_HOME
+
+    def test_stoppable_dock_task_exposes_start_features(self) -> None:
+        """Start stays exposed when it can first clear a safe dock blocker."""
+        state = _docked_state()
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+
+        assert can_prepare_clean_start(state)
+        assert features & VacuumEntityFeature.START
+        assert features & VacuumEntityFeature.CLEAN_AREA
+
+    def test_mixed_selected_room_profiles_expose_start_feature(self) -> None:
+        """Native START remains available for a valid mixed-room custom task."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=11), RoomInfo(room_id=12)],
+        )
+        vac = _make_vacuum(state=state)
+        features = vac.supported_features
+
+        assert features & VacuumEntityFeature.START
+        assert features & VacuumEntityFeature.CLEAN_AREA
+
+    def test_empty_cached_map_hides_start_feature(self) -> None:
+        """Native START is hidden when the cached map has no cleanable rooms."""
+        state = _docked_state()
+        state.map_data = MapData(map_id=2, rooms=[RoomInfo(room_id=0)])
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+
+        assert not features & VacuumEntityFeature.START
+        assert features & VacuumEntityFeature.CLEAN_AREA
+
+    def test_recent_clean_with_unstoppable_dock_task_hides_stop(self) -> None:
+        """Retained clean metrics must not expose generic stop over dry dust-bin."""
+        state = NarwalState(working_status=WorkingStatus.CHARGED)
+        state.update_from_working_status({"3": 120})
+        state.dock_presence = 1
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DUST_BIN,
+            elapsed=60,
+            target=180,
+            fields=("10", "11"),
+        )
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+
+        assert not features & VacuumEntityFeature.STOP
 
 
 class TestAsyncGetSegments:
@@ -311,11 +662,13 @@ class TestAsyncCleanSegments:
 
         assert "Room clean failed" not in caplog.text
 
-    async def test_rejects_room_clean_when_dock_task_is_active(self) -> None:
-        """Room clean requests are blocked before dispatch during dock work."""
+    async def test_rejects_room_clean_when_start_planner_fails(self) -> None:
+        """Room clean requests are blocked when the start planner fails closed."""
         state = _docked_state()
+        state.map_data = MapData(map_id=2, rooms=[RoomInfo(room_id=11)])
         state.station_activity = 1
         vac = _make_vacuum(state=state)
+        vac.coordinator.async_prepare_clean_start = AsyncMock(return_value=False)
         vac.coordinator.client.robot_awake = True
         vac.coordinator.client.start_rooms = AsyncMock()
 
@@ -323,6 +676,7 @@ class TestAsyncCleanSegments:
             await vac.async_clean_segments(["11"])
 
         vac.coordinator.client.start_rooms.assert_not_awaited()
+        vac.coordinator.async_prepare_clean_start.assert_awaited_once()
 
     async def test_accepted_room_clean_reserves_robot_start_context(self) -> None:
         """Accepted room-start commands block immediate dock starts."""
@@ -366,6 +720,62 @@ class TestAsyncCleanSegments:
             vac.coordinator.client.start_rooms.await_args.kwargs["room_settings"]
             == room_settings
         )
+
+    async def test_mixed_segment_modes_prepare_dock_then_start(self) -> None:
+        """A mixed-room custom task uses the normal dock-start preparation path."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=11), RoomInfo(room_id=12)],
+        )
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        room_settings = {
+            11: RoomCleanSettings(work_mode=WorkMode.MOP),
+            12: RoomCleanSettings(work_mode=WorkMode.VACUUM),
+        }
+        vac.coordinator.room_clean_settings_for_rooms = MagicMock(
+            return_value=room_settings
+        )
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_clean_segments(["11", "12"])
+
+        vac.coordinator.async_prepare_clean_start.assert_awaited_once()
+        assert (
+            vac.coordinator.client.start_rooms.await_args.kwargs["room_settings"]
+            == room_settings
+        )
+
+    async def test_segment_clean_without_map_fails_before_dock_prepare(self) -> None:
+        """Segment commands do not use stale HA segment cache as command input."""
+        state = _docked_state()
+        state.map_data = None
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+        vac = _make_vacuum(state=state)
+        vac.last_seen_segments = [Segment(id="11", name="Bathroom")]
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.get_map = AsyncMock()
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="Narwal map is not available"):
+            await vac.async_clean_segments(["11"])
+
+        vac.coordinator.async_prepare_clean_start.assert_not_awaited()
+        vac.coordinator.client.start_rooms.assert_not_awaited()
 
     async def test_rejected_room_clean_raises_service_error(self) -> None:
         """Rejected clean/start_clean responses fail the HA service call."""
@@ -489,6 +899,8 @@ class TestDockTaskRobotActionGates:
         state = NarwalState(working_status=WorkingStatus.CLEANING)
         vac = _make_vacuum(state)
         vac.coordinator.active_clean_work_mode = None
+        vac.coordinator.clean_setting_applicability_mode.side_effect = None
+        vac.coordinator.clean_setting_applicability_mode.return_value = None
 
         assert not vac.supported_features & VacuumEntityFeature.FAN_SPEED
 
@@ -530,12 +942,28 @@ class TestDockTaskRobotActionGates:
     def test_active_dock_task_hides_robot_actions(self) -> None:
         vac = self._active_dock_vacuum()
 
-        assert not vac.supported_features & VacuumEntityFeature.START
+        # Start remains available because the vacuum contract can stop this
+        # task during preflight before dispatching the clean.
+        assert vac.supported_features & VacuumEntityFeature.START
         assert not vac.supported_features & VacuumEntityFeature.STOP
         assert not vac.supported_features & VacuumEntityFeature.PAUSE
         assert not vac.supported_features & VacuumEntityFeature.RETURN_HOME
         assert not vac.supported_features & VacuumEntityFeature.LOCATE
-        assert not vac.supported_features & VacuumEntityFeature.CLEAN_AREA
+        assert vac.supported_features & VacuumEntityFeature.CLEAN_AREA
+
+    async def test_intermediate_emptying_hides_and_rejects_pause(self) -> None:
+        """Fresh emptying telemetry wins over recent robot clean counters."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.update_from_working_status({"3": 60})
+        state.station_activity = 1
+        vac = _make_vacuum(state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.pause = AsyncMock()
+
+        assert not vac.supported_features & VacuumEntityFeature.PAUSE
+        with pytest.raises(HomeAssistantError):
+            await vac.async_pause()
+        vac.coordinator.client.pause.assert_not_awaited()
 
     @pytest.mark.parametrize(
         ("method_name", "client_method"),
@@ -554,10 +982,22 @@ class TestDockTaskRobotActionGates:
         command = AsyncMock()
         setattr(vac.coordinator.client, client_method, command)
 
-        with pytest.raises(HomeAssistantError, match="Narwal dock task is active"):
+        with pytest.raises(HomeAssistantError):
             await getattr(vac, method_name)()
 
         command.assert_not_awaited()
+
+    async def test_locate_aborts_when_action_status_refresh_fails(self) -> None:
+        """Locate cannot race dock work from a stale idle snapshot."""
+        vac = _make_vacuum(_docked_state())
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.async_refresh_action_status = AsyncMock(return_value=False)
+        vac.coordinator.client.locate = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="status could not be refreshed"):
+            await vac.async_locate()
+
+        vac.coordinator.client.locate.assert_not_awaited()
 
 
 class TestVacuumFanSpeed:
@@ -583,11 +1023,65 @@ class TestVacuumFanSpeed:
 
         assert vac.coordinator.clean_settings.fan == FanLevel.UNSPECIFIED
 
+    async def test_restore_raw_fan_value_survives_label_rename(self) -> None:
+        """Versioned restore data takes precedence over the display label."""
+        vac = _make_vacuum(state=_docked_state())
+        extra = FanSettingRestoreData(value=int(FanLevel.SUPER))
+
+        with (
+            patch.object(
+                vac, "async_get_last_extra_data", AsyncMock(return_value=extra)
+            ),
+            patch.object(
+                vac,
+                "async_get_last_state",
+                AsyncMock(return_value=MagicMock(attributes={"fan_speed": "Ultra"})),
+            ),
+        ):
+            await vac.async_added_to_hass()
+
+        assert vac.coordinator.clean_settings.fan == FanLevel.SUPER
+
+    async def test_restore_clamps_level_five_on_four_tier_model(self) -> None:
+        """A stale persisted tier cannot leave an unsupported pending value."""
+        vac = _make_vacuum(state=_docked_state())
+        vac.coordinator.config_entry.data["product_key"] = "qV6BujoYLz"
+        extra = FanSettingRestoreData(value=int(FanLevel.SUPER))
+
+        with patch.object(
+            vac, "async_get_last_extra_data", AsyncMock(return_value=extra)
+        ):
+            await vac.async_added_to_hass()
+
+        assert vac.coordinator.clean_settings.fan == FanLevel.DEEP
+        assert vac.fan_speed == "Super Powerful"
+
+    async def test_unversioned_ultra_preserves_level(self) -> None:
+        """An unversioned Ultra state restores its existing enum 5 meaning."""
+        vac = _make_vacuum(state=_docked_state())
+
+        with patch.object(
+            vac,
+            "async_get_last_state",
+            AsyncMock(return_value=MagicMock(attributes={"fan_speed": "Ultra"})),
+        ):
+            await vac.async_added_to_hass()
+
+        assert vac.coordinator.clean_settings.fan == FanLevel.SUPER
+
+    def test_fan_restore_data_records_stable_robot_value(self) -> None:
+        vac = _make_vacuum(state=_docked_state())
+        vac.coordinator.clean_settings.fan = FanLevel.DEEP
+
+        assert vac.extra_restore_state_data.as_dict() == {
+            "version": 1,
+            "value": int(FanLevel.DEEP),
+        }
+
     async def test_live_fan_change_applies_while_paused(self) -> None:
         state = _active_clean_state()
         state.is_paused = True
         vac = _make_vacuum(state=state)
-        vac.coordinator.active_clean_work_mode = WorkMode.VACUUM
         vac.coordinator.client.set_fan_speed = AsyncMock(
             return_value=CommandResponse(result_code=0)
         )
@@ -680,6 +1174,30 @@ class TestVacuumFanSpeed:
 
         vac.coordinator.client.set_fan_speed.assert_not_awaited()
 
+    async def test_live_fan_change_rejects_unknown_active_mode(self) -> None:
+        """A reconnect must not expose suction without the active task mode."""
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.clean_setting_applicability_mode.side_effect = None
+        vac.coordinator.clean_setting_applicability_mode.return_value = None
+        vac.coordinator.client.set_fan_speed = AsyncMock()
+
+        with pytest.raises(Exception, match="fan speed cannot be changed|mop-only"):
+            await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_not_awaited()
+
+    async def test_unknown_fan_speed_raises(self) -> None:
+        """Unsupported suction labels must not silently no-op."""
+        state = NarwalState(working_status=WorkingStatus.CHARGED)
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.set_fan_speed = AsyncMock()
+
+        with pytest.raises(Exception, match="Unsupported Narwal fan speed"):
+            await vac.async_set_fan_speed("Turbo")
+
+        vac.coordinator.client.set_fan_speed.assert_not_awaited()
+
     async def test_fan_change_rejected_in_mop_only_mode(self) -> None:
         state = _active_clean_state()
         vac = _make_vacuum(state=state)
@@ -694,7 +1212,6 @@ class TestVacuumFanSpeed:
     async def test_rejected_live_fan_change_does_not_update_settings(self) -> None:
         state = _active_clean_state()
         vac = _make_vacuum(state=state)
-        vac.coordinator.active_clean_work_mode = WorkMode.VACUUM
         vac.coordinator.client.set_fan_speed = AsyncMock(
             return_value=CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
         )
@@ -737,6 +1254,53 @@ class TestCheckSegmentChanges:
 
         vac.async_create_segments_issue.assert_called_once()
 
+    def test_segment_change_reports_once_per_signature(self) -> None:
+        """Repeated coordinator updates for one mismatch do not spam repairs/logs."""
+        rooms_old = [
+            Segment(id="1", name="Kitchen"),
+            Segment(id="2", name="Bathroom"),
+        ]
+        rooms_new = [
+            RoomInfo(room_id=1, name="Kitchen", room_sub_type=4, category=1),
+            RoomInfo(room_id=3, name="Study", room_sub_type=5, category=1),
+        ]
+        state = NarwalState()
+        state.map_data = MapData(rooms=rooms_new)
+        vac = _make_vacuum(state=state)
+        vac.last_seen_segments = rooms_old
+
+        vac._check_segment_changes()
+        vac._check_segment_changes()
+
+        vac.async_create_segments_issue.assert_called_once()
+
+    def test_segment_change_reports_again_after_matching_snapshot(self) -> None:
+        """A resolved mismatch clears the debounce for future room changes."""
+        rooms_old = [
+            Segment(id="1", name="Kitchen"),
+            Segment(id="2", name="Bathroom"),
+        ]
+        changed = [
+            RoomInfo(room_id=1, name="Kitchen", room_sub_type=4, category=1),
+            RoomInfo(room_id=3, name="Study", room_sub_type=5, category=1),
+        ]
+        matching = [
+            RoomInfo(room_id=1, name="Kitchen", room_sub_type=4, category=1),
+            RoomInfo(room_id=2, name="Bathroom", room_sub_type=6, category=1),
+        ]
+        state = NarwalState()
+        state.map_data = MapData(rooms=changed)
+        vac = _make_vacuum(state=state)
+        vac.last_seen_segments = rooms_old
+
+        vac._check_segment_changes()
+        state.map_data = MapData(rooms=matching)
+        vac._check_segment_changes()
+        state.map_data = MapData(rooms=changed)
+        vac._check_segment_changes()
+
+        assert vac.async_create_segments_issue.call_count == 2
+
     def test_no_change_when_same_rooms(self) -> None:
         """Does NOT call async_create_segments_issue when rooms match."""
         rooms_old = [
@@ -771,12 +1335,10 @@ class TestCheckSegmentChanges:
 class TestAsyncStartWholeHouse:
     """async_start runs a room-selection aware clean via clean/start_clean."""
 
-    async def test_paused_returning_standby_resumes_existing_clean(self) -> None:
-        """Paused return context takes precedence over a stale status enum."""
-        state = NarwalState(working_status=WorkingStatus.CLEANING)
+    async def test_paused_standby_resumes_existing_clean(self) -> None:
+        """Retained paused task context takes precedence over a stale status enum."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
         state.is_paused = True
-        state.is_returning_to_dock = True
-        state.dock_sub_state = 2
         state.task_elapsed_time = 60
         state.dock_presence = 2
         vac = _make_vacuum(state=state)
@@ -915,6 +1477,7 @@ class TestAsyncStartWholeHouse:
             rooms=[RoomInfo(room_id=1), RoomInfo(room_id=2)],
         )
         vac = _make_vacuum(state=state)
+        vac.coordinator.has_selected_clean_rooms.return_value = True
         vac.coordinator.selected_clean_room_ids_for = MagicMock(return_value=[2])
         vac.coordinator.client.robot_awake = True
         vac.coordinator.client.start_rooms = AsyncMock(
@@ -1006,17 +1569,48 @@ class TestAsyncStartWholeHouse:
         )
         assert vac.coordinator.client.start_rooms.await_args.args[0] == [5]
 
-    async def test_whole_house_start_passes_room_profiles(self) -> None:
-        """Whole-house start uses room-specific profiles for each room."""
+    async def test_start_rejects_stale_room_selection(self) -> None:
+        """A vanished selected room must not expand into a whole-map clean."""
         state = _docked_state()
         state.map_data = MapData(
             map_id=2,
             rooms=[RoomInfo(room_id=1), RoomInfo(room_id=2)],
         )
-        profile = RoomCleanSettings(fan=FanLevel.STRONG)
+        vac = _make_vacuum(state=state)
+        vac.coordinator.selected_clean_rooms = {None: {99}}
+        vac.coordinator.room_settings_map_id.return_value = None
+        vac.coordinator.selected_clean_room_ids_for = MagicMock(
+            side_effect=lambda room_ids, **kwargs: (
+                NarwalCoordinator.selected_clean_room_ids_for(
+                    vac.coordinator,
+                    room_ids,
+                    **kwargs,
+                )
+            )
+        )
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="selection is not available"):
+            await vac.async_start()
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+        assert vac.coordinator.selected_clean_rooms == {None: {99}}
+
+    async def test_whole_house_start_preserves_room_profiles(self) -> None:
+        """No room selection still applies each configured room profile."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=1), RoomInfo(room_id=2)],
+        )
+        profiles = {
+            1: RoomCleanSettings(work_mode=WorkMode.VACUUM, fan=FanLevel.STRONG),
+            2: RoomCleanSettings(work_mode=WorkMode.MOP, water=MopHumidity.WET),
+        }
         vac = _make_vacuum(state=state)
         vac.coordinator.room_clean_settings_for_rooms = MagicMock(
-            return_value={1: profile, 2: RoomCleanSettings()}
+            return_value=profiles
         )
         vac.coordinator.client.robot_awake = True
         vac.coordinator.client.start_rooms = AsyncMock(
@@ -1025,13 +1619,65 @@ class TestAsyncStartWholeHouse:
 
         await vac.async_start()
 
+        vac.coordinator.room_clean_settings_for_rooms.assert_called_once_with(
+            [1, 2], map_id=vac.coordinator.room_settings_map_id.return_value
+        )
         kwargs = vac.coordinator.client.start_rooms.await_args.kwargs
-        assert kwargs["room_settings"] == {1: profile, 2: RoomCleanSettings()}
+        assert kwargs["room_settings"] == profiles
+
+    async def test_start_refreshes_action_status_before_resume(self) -> None:
+        """Resume uses the action refresh path before deciding the command."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.is_paused = True
+        state.task_progress_percent = 40
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.resume = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        await vac.async_start()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.resume.assert_awaited_once()
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_start_aborts_when_action_status_refresh_fails(self) -> None:
+        """Start cannot route from a stale robot snapshot."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.is_paused = True
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.async_refresh_action_status = AsyncMock(return_value=False)
+        vac.coordinator.client.resume = AsyncMock()
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="status could not be refreshed"):
+            await vac.async_start()
+
+        vac.coordinator.client.resume.assert_not_awaited()
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_start_aborts_when_map_refresh_fails(self) -> None:
+        """A cached whole-floor map cannot authorize a new clean."""
+        state = _docked_state()
+        state.map_data = MapData(map_id=2, rooms=[RoomInfo(room_id=1)])
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.get_map = AsyncMock(side_effect=RuntimeError("offline"))
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="map could not be refreshed"):
+            await vac.async_start()
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
 
     async def test_whole_house_without_map_raises(self) -> None:
         """With no map rooms available, no ambiguous start command is sent."""
         state = _docked_state()  # no map_data
         vac = _make_vacuum(state=state)
+        vac.last_seen_segments = [Segment(id="1", name="Bedroom")]
         vac.coordinator.client.robot_awake = True
         vac.coordinator.client.get_map = AsyncMock()  # does not populate map_data
         vac.coordinator.client.start = AsyncMock(
@@ -1044,6 +1690,7 @@ class TestAsyncStartWholeHouse:
 
         vac.coordinator.client.start.assert_not_awaited()
         vac.coordinator.client.start_rooms.assert_not_called()
+        vac.coordinator.async_prepare_clean_start.assert_not_awaited()
 
     async def test_rejected_whole_house_start_raises_service_error(self) -> None:
         """Rejected whole-house starts fail the HA service call."""
@@ -1057,6 +1704,40 @@ class TestAsyncStartWholeHouse:
 
         with pytest.raises(HomeAssistantError, match="Narwal start command failed"):
             await vac.async_start()
+
+    async def test_mixed_whole_house_modes_prepare_dock_then_start(self) -> None:
+        """Whole-house custom profiles use the normal dock preparation path."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=11), RoomInfo(room_id=12)],
+        )
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        room_settings = {
+            11: RoomCleanSettings(work_mode=WorkMode.MOP),
+            12: RoomCleanSettings(work_mode=WorkMode.VACUUM),
+        }
+        vac.coordinator.room_clean_settings_for_rooms = MagicMock(
+            return_value=room_settings
+        )
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_start()
+
+        vac.coordinator.async_prepare_clean_start.assert_awaited_once()
+        assert (
+            vac.coordinator.client.start_rooms.await_args.kwargs["room_settings"]
+            == room_settings
+        )
 
 
 async def test_fan_restore_prefers_pending_value_over_active_room_display() -> None:
@@ -1109,7 +1790,41 @@ class TestAsyncStop:
 
         vac.coordinator.client.stop.assert_awaited_once()
 
-    async def test_stop_routes_dock_only_task_through_dock_policy(self) -> None:
+    def test_stale_clean_metrics_do_not_expose_robot_stop_during_station_task(
+        self,
+    ) -> None:
+        """Late clean counters cannot make vacuum STOP target dock work."""
+        for station_activity, dock_activity, task in (
+            (1, 0, DOCK_TASK_EMPTY_DUSTBIN),
+            (2, 0, DOCK_TASK_WASH_MOP),
+            (0, 3, DOCK_TASK_WASH_MOP),
+        ):
+            state = _docked_state()
+            state.station_activity = station_activity
+            state.dock_activity = dock_activity
+            state.update_from_working_status({"3": 120})
+            vac = _make_vacuum(state=state)
+
+            assert state.active_dock_task_keys == (task,)
+            assert not vac.supported_features & VacuumEntityFeature.STOP
+
+    async def test_old_firmware_wash_rejects_vacuum_stop(self) -> None:
+        """A field 3.12 wash signal cannot make vacuum STOP target dock work."""
+        state = _docked_state()
+        state.dock_activity = 3
+        state.update_from_working_status({"3": 120})
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock()
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="no active robot task"):
+            await vac.async_stop()
+
+        vac.coordinator.client.stop.assert_not_awaited()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_stop_rejects_dock_only_task(self) -> None:
         state = NarwalState(working_status=WorkingStatus.DOCKED)
         state.dock_presence = 6
         state.set_dock_drying_task(
@@ -1121,14 +1836,80 @@ class TestAsyncStop:
         vac = _make_vacuum(state=state)
         vac.coordinator.client.robot_awake = True
         vac.coordinator.client.stop = AsyncMock()
-        vac.coordinator.client.stop_dock_task = AsyncMock(
-            return_value=CommandResponse(result_code=0)
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="no active robot task"):
+            await vac.async_stop()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.stop.assert_not_awaited()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_stop_routes_active_clean_with_dock_bag_to_robot_stop(self) -> None:
+        """Drying the dock bag does not make robot STOP ambiguous while cleaning."""
+        state = _active_clean_state()
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
         )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+        vac.coordinator.client.stop_dock_task = AsyncMock()
 
         await vac.async_stop()
 
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.stop.assert_awaited_once()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_stop_routes_active_clean_with_mop_wash_to_robot_stop(self) -> None:
+        """Stop cancels the clean, not its mapped intermediate station phase."""
+        state = _active_clean_state()
+        state.station_activity = 2
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        await vac.async_stop()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.stop.assert_awaited_once()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_stop_rejects_refresh_transition_to_dock_only_work(self) -> None:
+        """Vacuum STOP cannot cross the robot/dock boundary after a refresh."""
+        vac = _make_vacuum(state=_active_clean_state())
+        vac.coordinator.client.robot_awake = True
+        docked = _docked_state()
+        docked.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+
+        async def refresh() -> bool:
+            vac.coordinator.client.state = docked
+            return True
+
+        vac.coordinator.async_refresh_action_status = AsyncMock(side_effect=refresh)
+        vac.coordinator.client.stop = AsyncMock()
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        assert vac.supported_features & VacuumEntityFeature.STOP
+        with pytest.raises(HomeAssistantError, match="no active robot task"):
+            await vac.async_stop()
+
         vac.coordinator.client.stop.assert_not_awaited()
-        vac.coordinator.client.stop_dock_task.assert_awaited_once_with()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
 
     async def test_stop_rejects_ambiguous_dock_only_task(self) -> None:
         state = NarwalState(working_status=WorkingStatus.DOCKED)
@@ -1150,15 +1931,17 @@ class TestAsyncStop:
         vac.coordinator.client.stop = AsyncMock()
         vac.coordinator.client.stop_dock_task = AsyncMock()
 
-        with pytest.raises(HomeAssistantError, match="cannot be stopped safely"):
+        with pytest.raises(HomeAssistantError, match="no active robot task"):
             await vac.async_stop()
 
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
         vac.coordinator.client.stop.assert_not_awaited()
         vac.coordinator.client.stop_dock_task.assert_not_awaited()
 
     async def test_stop_preserves_robot_stop_during_unmapped_dock_activity(self) -> None:
         """An unmapped dock phase must not hide stop for a real robot clean."""
         state = NarwalState(working_status=WorkingStatus.CLEANING)
+
         state.dock_activity = 99
         vac = _make_vacuum(state=state)
         vac.coordinator.client.robot_awake = True
@@ -1169,5 +1952,256 @@ class TestAsyncStop:
 
         await vac.async_stop()
 
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
         vac.coordinator.client.stop.assert_awaited_once()
         vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_stop_rejects_dry_dust_task(self) -> None:
+        state = NarwalState(working_status=WorkingStatus.DOCKED)
+        state.dock_presence = 6
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DUST_BIN,
+            elapsed=60,
+            target=180,
+            fields=("10", "11"),
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock()
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="no active robot task"):
+            await vac.async_stop()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.stop.assert_not_awaited()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_stop_rejects_recent_clean_with_unstoppable_dry_dust(self) -> None:
+        """Recent clean metrics must not route dry dust-bin through generic stop."""
+        state = NarwalState(working_status=WorkingStatus.CHARGED)
+        state.update_from_working_status({"3": 120})
+        state.dock_presence = 1
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DUST_BIN,
+            elapsed=60,
+            target=180,
+            fields=("10", "11"),
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock()
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="no active robot task"):
+            await vac.async_stop()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.stop.assert_not_awaited()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_stop_rejects_unmapped_dock_only_task(self) -> None:
+        state = NarwalState(working_status=WorkingStatus.DOCKED)
+        state.dock_presence = 6
+        state.dock_activity = 99
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock()
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="no active robot task"):
+            await vac.async_stop()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.stop.assert_not_awaited()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_stop_rejects_unmapped_task_with_late_clean_metrics(self) -> None:
+        """Late terminal counters cannot route an unknown station force-end."""
+        state = NarwalState(working_status=WorkingStatus.CHARGED)
+        state.update_from_working_status({"3": 120})
+        state.dock_presence = 6
+        state.dock_activity = 99
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock()
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="no active robot task"):
+            await vac.async_stop()
+
+        vac.coordinator.client.stop.assert_not_awaited()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_robot_stop_refreshes_action_status_before_stop(self) -> None:
+        """Robot stop revalidates active task status under the action lock."""
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_stop()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.stop.assert_awaited_once()
+
+    async def test_stop_aborts_when_action_status_refresh_fails(self) -> None:
+        """A stale snapshot cannot choose between robot and dock force-end."""
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.async_refresh_action_status = AsyncMock(return_value=False)
+        vac.coordinator.client.stop = AsyncMock()
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="status could not be refreshed"):
+            await vac.async_stop()
+
+        vac.coordinator.client.stop.assert_not_awaited()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_pause_refreshes_action_status_before_pause(self) -> None:
+        """Pause revalidates active task status under the action lock."""
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.pause = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_pause()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.pause.assert_awaited_once()
+
+    async def test_pause_aborts_when_action_status_refresh_fails(self) -> None:
+        """Pause cannot use stale clean state after a failed refresh."""
+        vac = _make_vacuum(state=_active_clean_state())
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.async_refresh_action_status = AsyncMock(return_value=False)
+        vac.coordinator.client.pause = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="status could not be refreshed"):
+            await vac.async_pause()
+
+        vac.coordinator.client.pause.assert_not_awaited()
+
+    async def test_return_home_refreshes_action_status_before_return(self) -> None:
+        """Return-to-base revalidates dock and robot status under the action lock."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.return_to_base = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_return_to_base()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.return_to_base.assert_awaited_once()
+
+    async def test_return_home_refreshes_then_noops_when_already_docked(self) -> None:
+        """An unconditional return-home automation confirms the idle dock first."""
+        vac = _make_vacuum(state=_docked_state())
+        vac.coordinator.client.return_to_base = AsyncMock()
+
+        await vac.async_return_to_base()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.return_to_base.assert_not_awaited()
+
+    async def test_return_home_detects_external_start_after_cached_dock(self) -> None:
+        """A cached dock snapshot cannot hide a clean started outside HA."""
+        vac = _make_vacuum(state=_docked_state())
+        vac.coordinator.client.robot_awake = True
+        off_dock = NarwalState(working_status=WorkingStatus.CLEANING)
+
+        async def refresh() -> bool:
+            vac.coordinator.client.state = off_dock
+            return True
+
+        vac.coordinator.async_refresh_action_status = AsyncMock(side_effect=refresh)
+        vac.coordinator.client.return_to_base = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_return_to_base()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.return_to_base.assert_awaited_once()
+
+    async def test_return_home_refreshes_stale_cached_dock_state(self) -> None:
+        """A stale dock snapshot cannot suppress a required return command."""
+        vac = _make_vacuum(state=_docked_state())
+        vac.coordinator.has_fresh_state = False
+        vac.coordinator.client.robot_awake = True
+        off_dock = NarwalState(working_status=WorkingStatus.STANDBY)
+
+        async def refresh() -> bool:
+            vac.coordinator.client.state = off_dock
+            return True
+
+        vac.coordinator.async_refresh_action_status = AsyncMock(side_effect=refresh)
+        vac.coordinator.client.return_to_base = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_return_to_base()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.return_to_base.assert_awaited_once()
+
+    async def test_return_home_refreshes_assumed_clean_from_docked_state(self) -> None:
+        """An accepted start cannot be mistaken for an idle dock no-op."""
+        cached = _docked_state()
+        cached.assume_robot_clean()
+        vac = _make_vacuum(state=cached)
+        vac.coordinator.client.robot_awake = True
+        off_dock = NarwalState(working_status=WorkingStatus.CLEANING)
+
+        async def refresh() -> bool:
+            vac.coordinator.client.state = off_dock
+            return True
+
+        vac.coordinator.async_refresh_action_status = AsyncMock(side_effect=refresh)
+        vac.coordinator.client.return_to_base = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_return_to_base()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.return_to_base.assert_awaited_once()
+
+    async def test_return_home_is_noop_when_refresh_discovers_docked(self) -> None:
+        """A state transition to idle-docked still satisfies return-home."""
+        vac = _make_vacuum(state=NarwalState(working_status=WorkingStatus.STANDBY))
+        vac.coordinator.client.robot_awake = True
+        docked = _docked_state()
+
+        async def refresh() -> bool:
+            vac.coordinator.client.state = docked
+            return True
+
+        vac.coordinator.async_refresh_action_status = AsyncMock(side_effect=refresh)
+        vac.coordinator.client.return_to_base = AsyncMock()
+
+        await vac.async_return_to_base()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.return_to_base.assert_not_awaited()
+
+    async def test_return_home_aborts_when_action_status_refresh_fails(self) -> None:
+        """Return-to-base cannot use stale dock state after a failed refresh."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.async_refresh_action_status = AsyncMock(return_value=False)
+        vac.coordinator.client.return_to_base = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="status could not be refreshed"):
+            await vac.async_return_to_base()
+
+        vac.coordinator.client.return_to_base.assert_not_awaited()

--- a/tests/test_vacuum_segments.py
+++ b/tests/test_vacuum_segments.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -18,12 +18,24 @@ import tests.ha_stubs  # noqa: E402
 
 tests.ha_stubs.install()
 
-from homeassistant.components.vacuum import VacuumEntityFeature  # noqa: E402
 from homeassistant.exceptions import HomeAssistantError  # noqa: E402
 
-from custom_components.narwal.coordinator import CleanSettings  # noqa: E402
-from custom_components.narwal.vacuum import NarwalVacuum  # noqa: E402
-from narwal_client.const import CommandResult, WorkingStatus  # noqa: E402
+from custom_components.narwal.coordinator import (  # noqa: E402
+    CleanSettings,
+    NarwalCoordinator,
+    is_clean_session_context,
+)
+from custom_components.narwal.vacuum import (  # noqa: E402
+    FanSettingRestoreData,
+    NarwalVacuum,
+)
+from narwal_client import RoomCleanSettings  # noqa: E402
+from narwal_client.const import (  # noqa: E402
+    CommandResult,
+    FanLevel,
+    WorkingStatus,
+    WorkMode,
+)
 from narwal_client.models import (  # noqa: E402
     DOCK_TASK_DRY_DOCK_BAG,
     DOCK_TASK_DRY_MOP,
@@ -34,6 +46,7 @@ from narwal_client.models import (  # noqa: E402
 )
 
 Segment = sys.modules["homeassistant.components.vacuum"].Segment
+VacuumEntityFeature = sys.modules["homeassistant.components.vacuum"].VacuumEntityFeature
 
 
 def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
@@ -50,8 +63,38 @@ def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
     coordinator.client.get_map = AsyncMock(return_value=client_state.map_data)
     coordinator.last_update_success = True
     coordinator.clean_settings = CleanSettings()
+    coordinator.active_clean_work_mode = None
+    coordinator.active_clean_setting.return_value = None
+    coordinator.has_selected_clean_rooms.return_value = False
     coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
     coordinator.dock_action_lock = asyncio.Lock()
+    coordinator.room_clean_settings_for_rooms = MagicMock(
+        side_effect=lambda room_ids, **_kwargs: {
+            room_id: RoomCleanSettings() for room_id in room_ids
+        }
+    )
+    coordinator.selected_clean_room_ids_for = MagicMock(
+        side_effect=lambda room_ids, **_kwargs: list(room_ids)
+    )
+    coordinator.shared_room_clean_work_mode = MagicMock(
+        side_effect=lambda room_settings: next(
+            iter({settings.work_mode for settings in room_settings.values()}), None
+        )
+    )
+    coordinator.record_accepted_clean_start = MagicMock(
+        side_effect=lambda room_settings: setattr(
+            coordinator,
+            "active_clean_work_mode",
+            next(iter({settings.work_mode for settings in room_settings.values()})),
+        )
+    )
+    coordinator.clean_setting_applicability_mode = MagicMock(
+        side_effect=lambda live=False: (
+            coordinator.active_clean_work_mode
+            if live and is_clean_session_context(coordinator.data)
+            else coordinator.clean_settings.work_mode
+        )
+    )
 
     vac = NarwalVacuum.__new__(NarwalVacuum)
     vac.coordinator = coordinator
@@ -64,6 +107,13 @@ def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
     vac.async_write_ha_state = MagicMock()
 
     return vac
+
+
+def _active_clean_state() -> NarwalState:
+    """Return a state whose working_status still looks like active cleaning."""
+    state = NarwalState()
+    state.working_status = WorkingStatus.CLEANING_ALT
+    return state
 
 
 def _docked_state() -> NarwalState:
@@ -210,6 +260,40 @@ class TestAsyncCleanSegments:
             water=settings.water,
             mop_strength=settings.mop_strength,
             passes=settings.passes,
+            route=settings.route,
+            room_settings={
+                11: RoomCleanSettings(),
+                9: RoomCleanSettings(),
+            },
+        )
+        assert state.has_assumed_robot_clean
+        vac.async_write_ha_state.assert_called_once()
+
+    async def test_deduplicates_segment_ids_without_changing_order(self) -> None:
+        """Repeated HA segment IDs produce one ordered clean item per room."""
+        state = _docked_state()
+        state.map_data = MapData(rooms=[RoomInfo(room_id=11), RoomInfo(room_id=9)])
+        vac = _make_vacuum(state=state)
+        settings = vac.coordinator.clean_settings
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+        vac.coordinator.client.robot_awake = True
+
+        await vac.async_clean_segments(["11", "9", "11"])
+
+        vac.coordinator.client.start_rooms.assert_awaited_once_with(
+            [11, 9],
+            work_mode=settings.work_mode,
+            fan=settings.fan,
+            water=settings.water,
+            mop_strength=settings.mop_strength,
+            passes=settings.passes,
+            route=settings.route,
+            room_settings={
+                11: RoomCleanSettings(),
+                9: RoomCleanSettings(),
+            },
         )
 
     async def test_segment_clean_accepted_response_does_not_warn(self, caplog) -> None:
@@ -253,6 +337,35 @@ class TestAsyncCleanSegments:
         await vac.async_clean_segments(["11"])
 
         assert state.has_assumed_robot_clean
+        vac.coordinator.record_accepted_clean_start.assert_called_once()
+
+    async def test_mixed_room_modes_start_as_one_custom_task(self) -> None:
+        """Mixed room profiles dispatch together without flattening their modes."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=11), RoomInfo(room_id=12)],
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        room_settings = {
+            11: RoomCleanSettings(work_mode=WorkMode.MOP),
+            12: RoomCleanSettings(work_mode=WorkMode.VACUUM),
+        }
+        vac.coordinator.room_clean_settings_for_rooms = MagicMock(
+            return_value=room_settings
+        )
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_clean_segments(["11", "12"])
+
+        vac.coordinator.client.start_rooms.assert_awaited_once()
+        assert (
+            vac.coordinator.client.start_rooms.await_args.kwargs["room_settings"]
+            == room_settings
+        )
 
     async def test_rejected_room_clean_raises_service_error(self) -> None:
         """Rejected clean/start_clean responses fail the HA service call."""
@@ -274,7 +387,7 @@ class TestAsyncCleanSegments:
         vac = _make_vacuum(state=state)
         vac.coordinator.client.robot_awake = True
         vac.coordinator.client.start_rooms = AsyncMock(
-            return_value=MagicMock(result_code=0, success=True)
+            return_value=CommandResponse(result_code=0)
         )
         await vac.coordinator.dock_action_lock.acquire()
 
@@ -331,23 +444,75 @@ class TestAsyncCleanSegments:
         vac.coordinator.client.get_map.assert_awaited_once()
         vac.coordinator.client.start_rooms.assert_awaited_once()
 
+    async def test_segment_validation_rejects_failed_map_refresh(self) -> None:
+        """A cached room cannot authorize cleaning after refresh failure."""
+        state = _docked_state()
+        state.map_data = MapData(map_id=2, rooms=[RoomInfo(room_id=11)])
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.get_map = AsyncMock(side_effect=RuntimeError("offline"))
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="map could not be refreshed"):
+            await vac.async_clean_segments(["11"])
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
     async def test_empty_cached_room_table_defers_validation_to_client(self) -> None:
         """A payloadless cached map must not reject every known HA segment."""
         state = _docked_state()
         state.map_data = MapData()
         vac = _make_vacuum(state=state)
         vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.get_map = AsyncMock(
+            side_effect=lambda: setattr(
+                state,
+                "map_data",
+                MapData(map_id=2, rooms=[RoomInfo(room_id=11)]),
+            )
+        )
         vac.coordinator.client.start_rooms = AsyncMock(
             return_value=CommandResponse(result_code=CommandResult.SUCCESS)
         )
 
         await vac.async_clean_segments(["11"])
 
+        vac.coordinator.client.get_map.assert_awaited_once()
         vac.coordinator.client.start_rooms.assert_awaited_once()
 
 
 class TestDockTaskRobotActionGates:
     """Dock work must not leak unsafe robot controls through the vacuum."""
+
+    def test_unknown_active_mode_hides_native_fan_control(self) -> None:
+        """A reload cannot advertise suction before task mode is reconstructed."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        vac = _make_vacuum(state)
+        vac.coordinator.active_clean_work_mode = None
+
+        assert not vac.supported_features & VacuumEntityFeature.FAN_SPEED
+
+    def test_idle_mop_mode_hides_native_fan_control(self) -> None:
+        """Feature advertisement matches the pending fan command handler."""
+        vac = _make_vacuum(_docked_state())
+        vac.coordinator.clean_settings.work_mode = WorkMode.MOP
+
+        assert not vac.supported_features & VacuumEntityFeature.FAN_SPEED
+
+    def test_selected_rooms_hide_pending_native_fan_control(self) -> None:
+        """Room profiles, not the whole-floor fan command, own selected jobs."""
+        vac = _make_vacuum(_docked_state())
+        vac.coordinator.has_selected_clean_rooms.return_value = True
+
+        assert not vac.supported_features & VacuumEntityFeature.FAN_SPEED
+
+    def test_unread_profiles_hide_new_clean_actions(self) -> None:
+        """Advertised actions must agree with profile-authority guards."""
+        vac = _make_vacuum(_docked_state())
+        vac.coordinator._room_profile_store_loaded = False
+
+        assert not vac.supported_features & VacuumEntityFeature.START
+        assert not vac.supported_features & VacuumEntityFeature.CLEAN_AREA
 
     @staticmethod
     def _active_dock_vacuum() -> NarwalVacuum:
@@ -394,6 +559,151 @@ class TestDockTaskRobotActionGates:
 
         command.assert_not_awaited()
 
+
+class TestVacuumFanSpeed:
+    def test_fan_speed_reports_active_room_profile(self) -> None:
+        """The vacuum entity reports the dispatched room fan while cleaning."""
+        vac = _make_vacuum(state=_active_clean_state())
+        vac.coordinator.clean_settings.fan = FanLevel.NORMAL
+        vac.coordinator.active_clean_setting.return_value = FanLevel.STRONG
+
+        assert vac.fan_speed == "Strong"
+
+    async def test_restore_none_fan_speed_as_ai_suction(self) -> None:
+        """HA persists AI fan_speed as None; restore it as FanLevel.UNSPECIFIED."""
+        vac = _make_vacuum(state=_docked_state())
+        vac.coordinator.clean_settings.fan = FanLevel.NORMAL
+
+        with patch.object(
+            vac,
+            "async_get_last_state",
+            AsyncMock(return_value=MagicMock(attributes={"fan_speed": None})),
+        ):
+            await vac.async_added_to_hass()
+
+        assert vac.coordinator.clean_settings.fan == FanLevel.UNSPECIFIED
+
+    async def test_live_fan_change_applies_while_paused(self) -> None:
+        state = _active_clean_state()
+        state.is_paused = True
+        vac = _make_vacuum(state=state)
+        vac.coordinator.active_clean_work_mode = WorkMode.VACUUM
+        vac.coordinator.client.set_fan_speed = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+
+        await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_awaited_once_with(FanLevel.STRONG)
+        assert vac.coordinator.clean_settings.fan == FanLevel.STRONG
+        vac.coordinator.set_active_clean_setting.assert_called_once_with(
+            "fan", FanLevel.STRONG
+        )
+
+    async def test_fan_change_stages_when_unavailable_idle(self) -> None:
+        """Idle pending fan changes do not need a live coordinator connection."""
+        state = _docked_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.last_update_success = False
+        vac.coordinator.client.set_fan_speed = AsyncMock()
+
+        await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_not_awaited()
+        assert vac.coordinator.clean_settings.fan == FanLevel.STRONG
+
+    async def test_fan_change_rejected_when_entity_unavailable(self) -> None:
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.last_update_success = False
+        vac.coordinator.client.set_fan_speed = AsyncMock()
+
+        with pytest.raises(Exception, match="fan speed cannot be changed"):
+            await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_not_awaited()
+
+    async def test_live_fan_change_uses_active_room_mode(self) -> None:
+        """Live fan gating follows the accepted room mode, not pending global mode."""
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.clean_settings.work_mode = WorkMode.MOP
+        vac.coordinator.active_clean_work_mode = WorkMode.VACUUM
+        vac.coordinator.client.set_fan_speed = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+
+        await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_awaited_once_with(FanLevel.STRONG)
+        assert vac.coordinator.clean_settings.fan == FanLevel.STRONG
+
+    async def test_selected_rooms_block_pending_native_fan_change(self) -> None:
+        """The vacuum service cannot alter global fallback for selected rooms."""
+        vac = _make_vacuum(state=_docked_state())
+        vac.coordinator.has_selected_clean_rooms.return_value = True
+        vac.coordinator.clean_settings.fan = FanLevel.NORMAL
+
+        with pytest.raises(HomeAssistantError, match="cannot be changed"):
+            await vac.async_set_fan_speed("Strong")
+
+        assert vac.coordinator.clean_settings.fan == FanLevel.NORMAL
+
+    async def test_selected_rooms_keep_live_fan_change_runtime_only(self) -> None:
+        """A selected-room task accepts live suction without changing defaults."""
+        vac = _make_vacuum(state=_active_clean_state())
+        vac.coordinator.has_selected_clean_rooms.return_value = True
+        vac.coordinator.active_clean_work_mode = WorkMode.VACUUM
+        vac.coordinator.clean_settings.fan = FanLevel.NORMAL
+        vac.coordinator.client.set_fan_speed = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+
+        await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_awaited_once_with(FanLevel.STRONG)
+        vac.coordinator.set_active_clean_setting.assert_called_once_with(
+            "fan", FanLevel.STRONG
+        )
+        assert vac.coordinator.clean_settings.fan == FanLevel.NORMAL
+
+    async def test_live_fan_change_rejects_active_mop_mode(self) -> None:
+        """Pending vacuum mode must not expose fan control for an active mop-only task."""
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.clean_settings.work_mode = WorkMode.VACUUM
+        vac.coordinator.active_clean_work_mode = WorkMode.MOP
+        vac.coordinator.client.set_fan_speed = AsyncMock()
+
+        with pytest.raises(Exception, match="fan speed cannot be changed|mop-only"):
+            await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_not_awaited()
+
+    async def test_fan_change_rejected_in_mop_only_mode(self) -> None:
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.clean_settings.work_mode = WorkMode.MOP
+        vac.coordinator.client.set_fan_speed = AsyncMock()
+
+        with pytest.raises(Exception, match="mop-only mode"):
+            await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_not_awaited()
+
+    async def test_rejected_live_fan_change_does_not_update_settings(self) -> None:
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.active_clean_work_mode = WorkMode.VACUUM
+        vac.coordinator.client.set_fan_speed = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        )
+        vac.coordinator.clean_settings.fan = FanLevel.NORMAL
+
+        with pytest.raises(Exception, match="set fan speed failed"):
+            await vac.async_set_fan_speed("Strong")
+
+        assert vac.coordinator.clean_settings.fan == FanLevel.NORMAL
 
 class TestCheckSegmentChanges:
     """Tests for _check_segment_changes."""
@@ -459,10 +769,121 @@ class TestCheckSegmentChanges:
 
 
 class TestAsyncStartWholeHouse:
-    """async_start runs a whole-house clean via start_rooms(all rooms), not the saved plan."""
+    """async_start runs a room-selection aware clean via clean/start_clean."""
+
+    async def test_paused_returning_standby_resumes_existing_clean(self) -> None:
+        """Paused return context takes precedence over a stale status enum."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.is_paused = True
+        state.is_returning_to_dock = True
+        state.dock_sub_state = 2
+        state.task_elapsed_time = 60
+        state.dock_presence = 2
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.resume = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        await vac.async_start()
+
+        vac.coordinator.client.resume.assert_awaited_once()
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_rejected_resume_fails_native_start(self) -> None:
+        """A rejected resume cannot be reported to HA as a successful start."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.is_paused = True
+        state.task_elapsed_time = 60
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.resume = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        )
+
+        with pytest.raises(HomeAssistantError, match="resume failed"):
+            await vac.async_start()
+
+    @pytest.mark.parametrize(
+        "working_status", (WorkingStatus.ERROR, WorkingStatus.TASK_COMPLETED)
+    )
+    async def test_terminal_status_does_not_resume_stale_paused_context(
+        self, working_status: WorkingStatus
+    ) -> None:
+        """A terminal packet takes precedence over its stale paused overlay."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.assume_robot_clean()
+        state.update_from_base_status(
+            {"3": {"1": int(working_status), "2": 1}}
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.resume = AsyncMock()
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError):
+            await vac.async_start()
+
+        vac.coordinator.client.resume.assert_not_awaited()
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_hardware_fault_does_not_resume_stale_paused_context(self) -> None:
+        """ErrorCode telemetry blocks resume even with a non-error status enum."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.assume_robot_clean()
+        state.update_from_base_status(
+            {"1": {"1": 2105}, "3": {"1": int(WorkingStatus.STANDBY), "2": 1}}
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.resume = AsyncMock()
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError):
+            await vac.async_start()
+
+        vac.coordinator.client.resume.assert_not_awaited()
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_terminal_transition_clears_future_stale_resume_context(self) -> None:
+        """A later paused standby cannot revive a completed accepted start."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.assume_robot_clean()
+        state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.TASK_COMPLETED)}}
+        )
+        state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.DOCKED), "10": 1}, "11": 2}
+        )
+        state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.STANDBY), "2": 1, "10": 1}, "11": 2}
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.resume = AsyncMock()
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError):
+            await vac.async_start()
+
+        assert not state.has_assumed_robot_clean
+        vac.coordinator.client.resume.assert_not_awaited()
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_unread_room_profiles_block_native_start(self) -> None:
+        """A start cannot substitute defaults for unread durable profiles."""
+        vac = _make_vacuum(state=_docked_state())
+        vac.coordinator._room_profile_store_loaded = False
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="not restored"):
+            await vac.async_start()
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
 
     async def test_enumerates_all_rooms(self, caplog) -> None:
-        """Whole-house start passes every room id to clean/start_clean, skipping plan/start."""
+        """With no selected rooms, start passes every room id to clean/start_clean."""
         state = _docked_state()
         state.map_data = MapData(map_id=2, rooms=[
             RoomInfo(room_id=1), RoomInfo(room_id=2), RoomInfo(room_id=0),  # 0 filtered
@@ -479,12 +900,136 @@ class TestAsyncStartWholeHouse:
 
         vac.coordinator.client.start_rooms.assert_awaited_once()
         assert vac.coordinator.client.start_rooms.await_args.args[0] == [1, 2]
+        vac.coordinator.selected_clean_room_ids_for.assert_called_once_with(
+            [1, 2], map_id=vac.coordinator.room_settings_map_id.return_value
+        )
         vac.coordinator.client.start.assert_not_called()
         assert "Start command was rejected" not in caplog.text
         assert state.has_assumed_robot_clean
 
-    async def test_falls_back_to_saved_plan_without_map(self) -> None:
-        """With no map rooms available, falls back to the saved-plan start()."""
+    async def test_start_uses_selected_rooms(self) -> None:
+        """Selected room switches narrow the native vacuum start command."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=1), RoomInfo(room_id=2)],
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.selected_clean_room_ids_for = MagicMock(return_value=[2])
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+
+        await vac.async_start()
+
+        vac.coordinator.selected_clean_room_ids_for.assert_called_once_with(
+            [1, 2], map_id=vac.coordinator.room_settings_map_id.return_value
+        )
+        vac.coordinator.room_clean_settings_for_rooms.assert_called_once_with(
+            [2], map_id=vac.coordinator.room_settings_map_id.return_value
+        )
+        vac.coordinator.client.start_rooms.assert_awaited_once()
+        assert vac.coordinator.client.start_rooms.await_args.args[0] == [2]
+
+    async def test_start_rejects_non_authoritative_room_selection(self) -> None:
+        """A failed selection restore cannot broaden START to every room."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=1), RoomInfo(room_id=2)],
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.selected_clean_room_ids_for = MagicMock(return_value=[])
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="selection is not available"):
+            await vac.async_start()
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_start_rejects_explicit_selection_without_map_identity(self) -> None:
+        """An unidentified refreshed map cannot broaden a scoped selection."""
+        state = _docked_state()
+        state.map_data = MapData(
+            rooms=[RoomInfo(room_id=4), RoomInfo(room_id=5)],
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.selected_clean_rooms = {"100": {4}}
+        vac.coordinator.room_settings_map_id.return_value = None
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="selection is not available"):
+            await vac.async_start()
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_start_scopes_selection_to_map_fetched_after_start(self) -> None:
+        """START resolves selection against the freshly fetched map identity."""
+        state = _docked_state()
+        state.map_data = MapData(map_id=100, rooms=[RoomInfo(room_id=4)])
+        vac = _make_vacuum(state=state)
+        vac.coordinator.selected_clean_rooms = {"100": {4}, "200": {5}}
+        vac.coordinator.room_settings_map_id = MagicMock(
+            side_effect=lambda map_data=None: (
+                str(map_data.map_id) if map_data is not None else None
+            )
+        )
+        vac.coordinator.selected_clean_room_ids_for = MagicMock(
+            side_effect=lambda room_ids, **kwargs: (
+                NarwalCoordinator.selected_clean_room_ids_for(
+                    vac.coordinator,
+                    room_ids,
+                    **kwargs,
+                )
+            )
+        )
+
+        async def get_map() -> None:
+            state.map_data = MapData(
+                map_id=200,
+                rooms=[RoomInfo(room_id=4), RoomInfo(room_id=5)],
+            )
+
+        vac.coordinator.client.get_map = AsyncMock(side_effect=get_map)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+
+        await vac.async_start()
+
+        vac.coordinator.selected_clean_room_ids_for.assert_called_once_with(
+            [4, 5], map_id="200"
+        )
+        assert vac.coordinator.client.start_rooms.await_args.args[0] == [5]
+
+    async def test_whole_house_start_passes_room_profiles(self) -> None:
+        """Whole-house start uses room-specific profiles for each room."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=1), RoomInfo(room_id=2)],
+        )
+        profile = RoomCleanSettings(fan=FanLevel.STRONG)
+        vac = _make_vacuum(state=state)
+        vac.coordinator.room_clean_settings_for_rooms = MagicMock(
+            return_value={1: profile, 2: RoomCleanSettings()}
+        )
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_start()
+
+        kwargs = vac.coordinator.client.start_rooms.await_args.kwargs
+        assert kwargs["room_settings"] == {1: profile, 2: RoomCleanSettings()}
+
+    async def test_whole_house_without_map_raises(self) -> None:
+        """With no map rooms available, no ambiguous start command is sent."""
         state = _docked_state()  # no map_data
         vac = _make_vacuum(state=state)
         vac.coordinator.client.robot_awake = True
@@ -494,9 +1039,10 @@ class TestAsyncStartWholeHouse:
         )
         vac.coordinator.client.start_rooms = AsyncMock()
 
-        await vac.async_start()
+        with pytest.raises(HomeAssistantError, match="room map is not available"):
+            await vac.async_start()
 
-        vac.coordinator.client.start.assert_awaited_once()
+        vac.coordinator.client.start.assert_not_awaited()
         vac.coordinator.client.start_rooms.assert_not_called()
 
     async def test_rejected_whole_house_start_raises_service_error(self) -> None:
@@ -513,8 +1059,55 @@ class TestAsyncStartWholeHouse:
             await vac.async_start()
 
 
+async def test_fan_restore_prefers_pending_value_over_active_room_display() -> None:
+    """An active room's displayed fan must not replace the pending default."""
+    vac = _make_vacuum(state=_docked_state())
+    extra = FanSettingRestoreData(value=int(FanLevel.DEEP))
+
+    with (
+        patch.object(
+            vac,
+            "async_get_last_state",
+            AsyncMock(return_value=MagicMock(attributes={"fan_speed": "Strong"})),
+        ),
+        patch.object(
+            vac,
+            "async_get_last_extra_data",
+            AsyncMock(return_value=extra),
+        ),
+    ):
+        await vac.async_added_to_hass()
+
+    assert vac.coordinator.clean_settings.fan == FanLevel.DEEP
+
+
+def test_fan_extra_restore_data_records_pending_value() -> None:
+    """Vacuum restore data is sourced from the pending global setting."""
+    vac = _make_vacuum(state=_active_clean_state())
+    vac.coordinator.clean_settings.fan = FanLevel.NORMAL
+    vac.coordinator.active_clean_setting.return_value = FanLevel.STRONG
+
+    assert vac.extra_restore_state_data.as_dict()["value"] == int(FanLevel.NORMAL)
+
+
 class TestAsyncStop:
     """Tests for stop routing between robot and dock task contexts."""
+
+    async def test_paused_standby_stops_existing_clean(self) -> None:
+        """Stop honors retained paused task context after a stale status enum."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        state.is_paused = True
+        state.task_elapsed_time = 60
+        state.dock_presence = 2
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_stop()
+
+        vac.coordinator.client.stop.assert_awaited_once()
 
     async def test_stop_routes_dock_only_task_through_dock_policy(self) -> None:
         state = NarwalState(working_status=WorkingStatus.DOCKED)


### PR DESCRIPTION
## Summary
- make Narwal vacuum `supported_features` reflect commands usable in the current robot/dock state
- make native `vacuum.start` apply selected-room profiles, or every known room profile when none are selected
- expose clean progress, current room, active rooms, charge-to-resume, and task summary as vacuum attributes
- remove/migrate stale standalone task/status sensor entities replaced by the vacuum contract
- keep elapsed/remaining clean-time sensors available only while they describe the current task
- reject stale explicit room selections without weakening whole-map starts
- persist pending vacuum suction by its raw protocol value
- hide mode-specific runtime controls when the accepted task mode is incompatible or unknown

## Why
Standard HA vacuum cards should not need Narwal-specific derived visibility logic. Robot task context belongs on the vacuum entity, and controls should appear only when the integration can send that command safely.

The native Start command preserves the room profiles from #87. With no selected rooms it sends every known room and its configured profile; with explicit selections it fails closed if those selections no longer resolve. Dock tasks that block cleaning are prepared before dispatch.

`max` suction resolves to the highest tier exposed by the configured model. This PR deliberately retains the labels and enum meanings shipped in v1.0.5; an observed app-label difference does not have complete five-tier `CleanParam` captures and is kept out of this upstream change.

## Command availability

- `START` and `CLEAN_AREA` are advertised when an idle docked robot can prepare a clean, including when preflight can stop one supported drying task, or when a paused clean can resume. They are withdrawn during active cleaning, returning, blocking dock work, errors, or unresolved stale selections.
- `STOP` is advertised only for a live robot cleaning context. It is not used as a generic dock-task stop.
- `PAUSE` is advertised during active cleaning or remapping when the robot is not already paused and dock work does not block robot movement.
- `RETURN_HOME` is advertised when an off-dock robot can safely return. It remains advertised as an idempotent no-op while already docked and idle so unconditional automations do not fail; it is withdrawn while returning or while active dock work blocks robot commands.
- `LOCATE` is advertised unless active dock work blocks robot commands.
- `FAN_SPEED` is advertised while configuring a compatible pending clean or during a live task whose accepted mode supports suction.

## Removed sensor unique IDs
The config-entry migration removes these superseded sensor registry entries, where `<device_id>` is the configured Narwal device id:

- `<device_id>_base_station_cleaning_filter_used_hours`
- `<device_id>_current_room`
- `<device_id>_map_metadata`
- `<device_id>_status`
- `<device_id>_task_progress`
- `<device_id>_task_status`

Their current task/status values move to vacuum attributes or the remaining task-scoped metric sensors.

## Runtime validation
On Flow 2 hardware running v01.09.09.05, native Start launched a seven-room custom task with five vacuum-only rooms and two vacuum-and-mop rooms. The device accepted the mixed task and Home Assistant exposed its active cleaning state, current room, and progress.

Live cross-mode probes confirmed that the robot accepts `Quiet` suction during a mop-only task and `Wet` water during a vacuum-only task. The known live protocols provide no confirmed fan-off or water-off command, so those controls remain unavailable for incompatible modes and after a reconnect where the accepted task mode cannot be recovered.

## Stack
Depends on #87; #85 and #86 are already merged. This branch is stacked in the fork; until those land, GitHub may show earlier commits in this diff too. The vacuum-contract series is two commits ending at `85337f9`.