### PR TITLE
feat(map): retain native Narwal trajectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Shipped in v1.0.2 ([#50](https://github.com/sjmotew/NarwalIntegration/pull/50)) 
 ### Live Map
 - Color-coded floor plan with room labels (all rooms — user-named and auto-generated)
 - Furniture/obstacle overlay from the robot's stored map data
-- Dock marker and live robot trail during cleaning (~1.5s refresh)
+- Dock marker and Narwal-native live robot trail from `display_map` during cleaning
 - Carpet-map debug image as a second camera ([#67](https://github.com/sjmotew/NarwalIntegration/pull/67), v1.0.2)
 - Display toggles for room labels, furniture and furniture labels ([#62](https://github.com/sjmotew/NarwalIntegration/pull/62), v1.0.2)
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Shipped in v1.0.2 ([#50](https://github.com/sjmotew/NarwalIntegration/pull/50)) 
 - Battery level, cleaning time, firmware version
 - Docked status (binary sensor), charging state (Charging / Fully Charged / Not Charging)
 - Cleaning area — reports real covered area as of v1.0.1 ([#51](https://github.com/sjmotew/NarwalIntegration/pull/51))
-- Current room being cleaned ([#24](https://github.com/sjmotew/NarwalIntegration/pull/24), v1.0.2)
+- Current room and task progress on the vacuum entity during active cleans
 - Last clean result — why the previous task ended ([#53](https://github.com/sjmotew/NarwalIntegration/pull/53), v1.0.2)
 - Dust bag health and detergent remaining ([#52](https://github.com/sjmotew/NarwalIntegration/pull/52), v1.0.2)
 - Station and consumable binary sensors — clean water tank, sewage tank, dust box, dust bag, station bag, error ([#52](https://github.com/sjmotew/NarwalIntegration/pull/52), v1.0.2)
@@ -247,7 +247,7 @@ Home Assistant shows the option when the entity's domain is `vacuum` and it adve
 - **Check the entity is not `unavailable`.** The row is gated on a live state object, so it will not render while the robot is unreachable.
 - Requires **Home Assistant 2026.3+**, when area mapping was introduced.
 
-Room names come from the robot's map — rooms you named in the Narwal app keep those names, and the rest use the shared room-type table corrected in [#48](https://github.com/sjmotew/NarwalIntegration/pull/48). **Name your rooms in the Narwal app before mapping**: the mapping keys on segment *id*, so renaming later is safe, but naming first means your HA areas, the robot's map and `sensor.current_room` all read the same words.
+Room names come from the robot's map — rooms you named in the Narwal app keep those names, and the rest use the shared room-type table corrected in [#48](https://github.com/sjmotew/NarwalIntegration/pull/48). **Name your rooms in the Narwal app before mapping**: the mapping keys on segment *id*, so renaming later is safe, but naming first means your HA areas, the robot's map and the vacuum entity's current-room attribute all read the same words.
 
 `cleaning_area_id` accepts an **ordered list**, so you can clean several rooms in one job and the robot follows the order you picked.
 
@@ -413,7 +413,7 @@ Camera snapshot and LED entities will be added once the AES decryption key is ex
 | [#73](https://github.com/sjmotew/NarwalIntegration/issues/73) | **v1.0.3** — renews the broadcast subscription before it lapses, so `working_status` and `display_map` keep arriving and the entity stops freezing at `docked` |
 | [#62](https://github.com/sjmotew/NarwalIntegration/pull/62) | Map rendering options as switches — room labels, furniture, furniture labels |
 | [#61](https://github.com/sjmotew/NarwalIntegration/pull/61) | Dock ambient light entity, on models that have one |
-| [#24](https://github.com/sjmotew/NarwalIntegration/pull/24) | `sensor.current_room` — the room being cleaned right now |
+| [#24](https://github.com/sjmotew/NarwalIntegration/pull/24) | Current-room telemetry for the room being cleaned right now |
 | [#53](https://github.com/sjmotew/NarwalIntegration/pull/53) / [#54](https://github.com/sjmotew/NarwalIntegration/pull/54) | Last-clean-result sensor; consumable maintenance and replacement alerts |
 | [#52](https://github.com/sjmotew/NarwalIntegration/pull/52) | `base_status` field audit; station and consumable diagnostics |
 | [#67](https://github.com/sjmotew/NarwalIntegration/pull/67) | Carpet-map camera image; `working_status 7` mapped to remapping |

--- a/custom_components/narwal/__init__.py
+++ b/custom_components/narwal/__init__.py
@@ -23,15 +23,16 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import service
 
 from .const import (
+    CONF_DEVICE_ID,
     CONF_MODEL,
     CONF_PRODUCT_KEY,
     DOMAIN,
     PLATFORMS,
     SERVICE_CLEAN_ROOMS,
     configured_model_name,
-    fan_speed_list_for,
+    fan_speed_map_for,
 )
-from .coordinator import NarwalCoordinator, can_start_cleaning
+from .coordinator import NarwalCoordinator, can_prepare_clean_start
 from .narwal_client import (
     CleaningRoute,
     CommandResult,
@@ -47,6 +48,16 @@ _LOGGER = logging.getLogger(__name__)
 
 NarwalConfigEntry: TypeAlias = ConfigEntry[NarwalCoordinator]
 
+_CONFIG_ENTRY_MINOR_VERSION = 2
+_LEGACY_REPLACED_SENSOR_SUFFIXES = (
+    "base_station_cleaning_filter_used_hours",
+    "current_room",
+    "map_metadata",
+    "status",
+    "task_progress",
+    "task_status",
+)
+
 FIELD_ROOMS = "rooms"
 FIELD_MODE = "mode"
 FIELD_SUCTION = "suction"
@@ -61,16 +72,18 @@ WORK_MODE_OPTIONS: dict[str, WorkMode] = {
     "vacuum_then_mop": WorkMode.VACUUM_THEN_MOP,
     "vacuum_and_mop": WorkMode.VACUUM_AND_MOP,
 }
-SUCTION_OPTIONS: dict[str, FanLevel] = {
-    "ai": FanLevel.UNSPECIFIED,
-    "quiet": FanLevel.MUTE,
-    "standard": FanLevel.NORMAL,
-    "strong": FanLevel.STRONG,
-    "super": FanLevel.DEEP,
-    "ultra": FanLevel.SUPER,
-    "super_powerful": FanLevel.DEEP,
-    "ultra_powerful": FanLevel.SUPER,
-}
+SUCTION_OPTIONS = (
+    "ai",
+    "quiet",
+    "standard",
+    "normal",
+    "strong",
+    "ultra",
+    "super",
+    "ultra_powerful",
+    "super_powerful",
+    "max",
+)
 WATER_OPTIONS: dict[str, MopHumidity] = {
     "dry": MopHumidity.DRY,
     "normal": MopHumidity.NORMAL,
@@ -103,6 +116,34 @@ CLEAN_ROOMS_SCHEMA = vol.Schema(
         vol.Optional(FIELD_ROUTE): vol.In(ROUTE_OPTIONS),
     }
 )
+
+SUCTION_OPTION_LABELS: dict[str, str] = {
+    "quiet": "Quiet",
+    "standard": "Standard",
+    "normal": "Standard",
+    "strong": "Strong",
+    "ultra": "Ultra",
+    "ultra_powerful": "Ultra",
+    "super": "Super",
+    "super_powerful": "Super",
+    "max": "Super",
+}
+
+
+def _suction_for_coordinator(
+    coordinator: NarwalCoordinator,
+    option: str,
+) -> FanLevel:
+    """Return the model-valid suction level for a service option."""
+    if option == "ai":
+        return FanLevel.UNSPECIFIED
+    label = SUCTION_OPTION_LABELS[option]
+    fan_map = fan_speed_map_for(coordinator.config_entry.data, include_aliases=False)
+    if label not in fan_map:
+        raise HomeAssistantError(
+            f"{label} suction is not supported by this Narwal model"
+        )
+    return fan_map[label]
 
 
 def _domain_data(hass: HomeAssistant) -> dict[str, NarwalCoordinator]:
@@ -322,7 +363,6 @@ def _async_register_services(hass: HomeAssistant) -> None:
         coordinator = coordinators[0]
 
         work_mode = WORK_MODE_OPTIONS[call.data[FIELD_MODE]]
-        fan = SUCTION_OPTIONS[call.data[FIELD_SUCTION]]
         water = WATER_OPTIONS[call.data[FIELD_WATER]]
         mop_strength = MOP_STRENGTH_OPTIONS[call.data[FIELD_MOP_STRENGTH]]
         passes = call.data[FIELD_PASSES]
@@ -338,12 +378,7 @@ def _async_register_services(hass: HomeAssistant) -> None:
         if not room_ids:
             raise HomeAssistantError("At least one room must be selected")
 
-        if fan is FanLevel.SUPER and "Ultra" not in fan_speed_list_for(
-            coordinator.config_entry.data
-        ):
-            raise HomeAssistantError(
-                "Ultra suction is not supported by this Narwal model"
-            )
+        fan = _suction_for_coordinator(coordinator, call.data[FIELD_SUCTION])
         route = ROUTE_OPTIONS.get(route_label, coordinator.clean_settings.route)
         requested_settings = RoomCleanSettings(
             work_mode=work_mode,
@@ -362,7 +397,9 @@ def _async_register_services(hass: HomeAssistant) -> None:
         async with coordinator.dock_action_lock:
             if not await coordinator.async_refresh_dock_status():
                 raise HomeAssistantError("Narwal status could not be refreshed")
-            if not can_start_cleaning(coordinator.client.state):
+            if not can_prepare_clean_start(coordinator.client.state):
+                raise HomeAssistantError("Narwal room clean cannot be started right now")
+            if not await coordinator.async_prepare_clean_start():
                 raise HomeAssistantError("Narwal room clean cannot be started right now")
 
             client = coordinator.client
@@ -418,7 +455,9 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
-    """Migrate old config entries to version 2 (add product_key)."""
+    """Migrate old config entries and remove replaced status sensors."""
+    update_kwargs: dict[str, object] = {}
+
     if config_entry.version < 2:
         _LOGGER.info(
             "Migrating Narwal config entry from version %d to 2",
@@ -429,15 +468,65 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             new_data[CONF_PRODUCT_KEY] = "QoEsI5qYXO"
         if CONF_MODEL not in new_data:
             new_data[CONF_MODEL] = "Narwal Flow"
-        hass.config_entries.async_update_entry(
-            config_entry, data=new_data, version=2,
-        )
+        update_kwargs["data"] = new_data
+        update_kwargs["version"] = 2
         _LOGGER.info("Migration complete: product_key=%s", new_data[CONF_PRODUCT_KEY])
+
+    if getattr(config_entry, "minor_version", 1) < _CONFIG_ENTRY_MINOR_VERSION:
+        _async_remove_legacy_replaced_sensors(hass, config_entry)
+        update_kwargs["minor_version"] = _CONFIG_ENTRY_MINOR_VERSION
+
+    if update_kwargs:
+        hass.config_entries.async_update_entry(config_entry, **update_kwargs)
     return True
+
+
+def _async_remove_legacy_replaced_sensors(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+) -> None:
+    """Remove old sensors now represented by native entities or attributes."""
+    device_id = config_entry.data.get(CONF_DEVICE_ID)
+    if not device_id:
+        return
+
+    registry = er.async_get(hass)
+    unique_ids = {
+        f"{device_id}_{suffix}" for suffix in _LEGACY_REPLACED_SENSOR_SUFFIXES
+    }
+    entity_ids: set[str] = set()
+
+    for unique_id in unique_ids:
+        entity_id = registry.async_get_entity_id(
+            "sensor",
+            DOMAIN,
+            unique_id,
+        )
+        if entity_id is not None:
+            entity_ids.add(entity_id)
+
+    for entry in er.async_entries_for_config_entry(
+        registry,
+        config_entry.entry_id,
+    ):
+        if (
+            entry.domain == "sensor"
+            and entry.platform == DOMAIN
+            and entry.unique_id in unique_ids
+        ):
+            entity_ids.add(entry.entity_id)
+
+    for entity_id in sorted(entity_ids):
+        registry_entry = registry.async_get(entity_id)
+        if registry_entry is None or registry_entry.platform != DOMAIN:
+            continue
+        _LOGGER.info("Removing legacy Narwal sensor %s", entity_id)
+        registry.async_remove(entity_id)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: NarwalConfigEntry) -> bool:
     """Set up Narwal from a config entry."""
+    _async_remove_legacy_replaced_sensors(hass, entry)
     coordinator = NarwalCoordinator(hass, entry)
     try:
         await coordinator.async_setup()

--- a/custom_components/narwal/__init__.py
+++ b/custom_components/narwal/__init__.py
@@ -440,6 +440,7 @@ def _async_register_services(hass: HomeAssistant) -> None:
             coordinator.clean_settings.route = requested_settings.route
             coordinator.record_accepted_clean_start(room_settings)
             client.state.assume_robot_clean()
+            await coordinator.async_clear_map_display_cache()
             coordinator.async_set_updated_data(client.state)
 
     hass.services.async_register(

--- a/custom_components/narwal/__init__.py
+++ b/custom_components/narwal/__init__.py
@@ -124,9 +124,9 @@ SUCTION_OPTION_LABELS: dict[str, str] = {
     "strong": "Strong",
     "ultra": "Ultra",
     "ultra_powerful": "Ultra",
-    "super": "Super",
-    "super_powerful": "Super",
-    "max": "Super",
+    "super": "Super Powerful",
+    "super_powerful": "Super Powerful",
+    "max": "Super Powerful",
 }
 
 
@@ -137,8 +137,10 @@ def _suction_for_coordinator(
     """Return the model-valid suction level for a service option."""
     if option == "ai":
         return FanLevel.UNSPECIFIED
-    label = SUCTION_OPTION_LABELS[option]
     fan_map = fan_speed_map_for(coordinator.config_entry.data, include_aliases=False)
+    if option == "max":
+        return list(fan_map.values())[-1]
+    label = SUCTION_OPTION_LABELS[option]
     if label not in fan_map:
         raise HomeAssistantError(
             f"{label} suction is not supported by this Narwal model"

--- a/custom_components/narwal/camera.py
+++ b/custom_components/narwal/camera.py
@@ -290,11 +290,17 @@ class NarwalMapCamera(NarwalEntity, Camera):
         # Detect cleaning session transitions — clear trail on new session
         current_status = state.working_status
         was_cleaning = self._last_cleaning_status in _CLEANING_TRAIL_STATUSES
-        is_cleaning = current_status in _CLEANING_TRAIL_STATUSES
+        is_cleaning = (
+            state.is_cleaning and current_status != WorkingStatus.REMAPPING
+        )
         if is_cleaning and not was_cleaning:
             _LOGGER.info("New cleaning session — clearing trail and vision obstacles")
             self._reset_trail()
-        if current_status != WorkingStatus.UNKNOWN:
+        if is_cleaning:
+            self._last_cleaning_status = WorkingStatus.CLEANING
+        elif state.has_paused_clean_task_context:
+            self._last_cleaning_status = WorkingStatus.CLEANING
+        elif current_status != WorkingStatus.UNKNOWN:
             self._last_cleaning_status = current_status
 
         if _DEBUG_VIEW:

--- a/custom_components/narwal/camera.py
+++ b/custom_components/narwal/camera.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-import io
+import asyncio
+import contextlib
 import logging
 import math
 import time
@@ -22,9 +23,14 @@ from .const import (
     MAP_ROTATION_DEFAULT,
     MAP_ZOOM_DEFAULT,
 )
-from .coordinator import NarwalCoordinator
+from .coordinator import (
+    NATIVE_TRAJECTORY_MAX_POINTS,
+    NATIVE_TRAJECTORY_RECENT_TAIL_POINTS,
+    NarwalCoordinator,
+)
 from .entity import NarwalEntity
 from .narwal_client.const import WorkingStatus
+from .narwal_client.models import overlay_to_grid
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,29 +38,11 @@ _LOGGER = logging.getLogger(__name__)
 # but PIL rendering is CPU-bound — no need to render every broadcast).
 _MIN_RENDER_INTERVAL = 2
 
-# Trail recording (used in both debug and normal modes)
-_TRAIL_MAX_POINTS = 50000  # full cleaning session worth
-_TRAIL_RECORD_INTERVAL = 3  # seconds between trail point recordings
-_TRAIL_MIN_GRID_DELTA = 0.25
-_TRAIL_MAX_GRID_JUMP_FRACTION = 0.18
-_TRAIL_MAX_GRID_JUMP_MIN = 24.0
-
-# Debug view: blank canvas with robot dot + trail.
-# Set to False to use the real map renderer instead.
-_DEBUG_VIEW = False
-_DEBUG_CANVAS_SIZE = 600  # pixels
-_DEBUG_TRAIL_MAX = _TRAIL_MAX_POINTS
-_DEBUG_RECORD_INTERVAL = _TRAIL_RECORD_INTERVAL
-
-_CLEANING_TRAIL_STATUSES = frozenset(
-    {
-        WorkingStatus.CLEANING_V2,
-        WorkingStatus.CLEANING,
-        WorkingStatus.CLEANING_ALT,
-        WorkingStatus.CUSTOM_CLEANING,
-    }
-)
-
+# Native trajectory points can repeat across display_map frames because field 2 is
+# the accumulated Narwal trajectory. Deduplicate tiny adjacent moves only.
+_NATIVE_TRAIL_MIN_GRID_DELTA = 0.25
+_NATIVE_TRAIL_MAX_POINTS = NATIVE_TRAJECTORY_MAX_POINTS
+_NATIVE_TRAIL_RECENT_TAIL_POINTS = NATIVE_TRAJECTORY_RECENT_TAIL_POINTS
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -109,6 +97,7 @@ class NarwalMapCamera(NarwalEntity, Camera):
     """Camera entity that streams the vacuum's map as MJPEG."""
 
     _attr_name = "Map"
+    _attr_frame_interval = _MIN_RENDER_INTERVAL
     _attr_is_streaming = True
 
     def __init__(self, coordinator: NarwalCoordinator) -> None:
@@ -121,6 +110,8 @@ class NarwalMapCamera(NarwalEntity, Camera):
         self._cache_key: tuple = ()
         self._last_render_time: float = 0.0
         self._render_count: int = 0
+        self._pending_render: tuple[object, tuple] | None = None
+        self._render_task: asyncio.Task[None] | None = None
         # Cached base map (PIL Image) — only re-rendered when static map changes
         self._base_map_image = None  # PIL Image or None
         self._base_map_ts: int = 0  # created_at of the static map used for base
@@ -130,17 +121,11 @@ class NarwalMapCamera(NarwalEntity, Camera):
             MAP_OPTION_DEFAULTS[CONF_SHOW_FURNITURE_LABELS],
         )
         self._room_label_points: list[tuple[str, float, float]] = []
-        # Trail state — accumulated grid-coordinate positions during cleaning
-        self._trail: list[tuple[float, float]] = []
-        self._last_trail_record: float = 0.0
-        self._last_cleaning_status: WorkingStatus = WorkingStatus.UNKNOWN
-        # Debug view state — full session trail with growing viewport
-        self._dock_pos: tuple[float, float] | None = None
-        self._vp_min_x: float = 0.0
-        self._vp_max_x: float = 0.0
-        self._vp_min_y: float = 0.0
-        self._vp_max_y: float = 0.0
-        self._vp_initialized: bool = False
+
+    @property
+    def extra_state_attributes(self) -> dict[str, int]:
+        """Expose a changing value so HA publishes each rendered frame."""
+        return {"render_count": self._render_count}
 
     def _map_option(self, key: str) -> bool:
         """Return a persisted map display option."""
@@ -192,94 +177,145 @@ class NarwalMapCamera(NarwalEntity, Camera):
             request, self.async_camera_image, "image/png", _MIN_RENDER_INTERVAL,
         )
 
-    @property
-    def extra_state_attributes(self) -> dict[str, str | int]:
-        """Expose render count so HA detects state changes for MJPEG refresh."""
-        return {"render_count": self._render_count}
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel queued map rendering before removing the camera entity."""
+        self._pending_render = None
+        render_task = self._render_task
+        if render_task is not None and not render_task.done():
+            render_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await render_task
+        self._render_task = None
+        await super().async_will_remove_from_hass()
 
-    def _reset_debug_trail(self) -> None:
-        """Clear trail and viewport for a new cleaning session."""
-        self._trail.clear()
-        self._dock_pos = None
-        self._vp_initialized = False
-        self._last_trail_record = 0.0
+    @staticmethod
+    def _native_trajectory_grid_points(
+        points: list[tuple[float, float]],
+        static_map,
+    ) -> list[tuple[float, float]]:
+        """Return in-bounds grid points from Narwal's native trajectory."""
+        converted: list[tuple[float, float]] = []
+        pending_break = False
 
-    def _record_debug_position(self, x: float, y: float) -> None:
-        """Record a position and expand viewport bounds."""
-        now = time.monotonic()
+        for raw_x, raw_y in NarwalMapCamera._native_trajectory_render_points(points):
+            if not math.isfinite(raw_x) or not math.isfinite(raw_y):
+                pending_break = bool(converted)
+                continue
+            grid_x = overlay_to_grid(raw_x, static_map.origin_x)
+            grid_y = overlay_to_grid(raw_y, static_map.origin_y)
+            if grid_x is None or grid_y is None:
+                continue
+            if (
+                grid_x < 0
+                or grid_y < 0
+                or grid_x >= static_map.width
+                or grid_y >= static_map.height
+            ):
+                _LOGGER.debug(
+                    "Skipping native Narwal trail point outside map bounds: "
+                    "%.1f, %.1f (%dx%d)",
+                    grid_x,
+                    grid_y,
+                    static_map.width,
+                    static_map.height,
+                )
+                pending_break = bool(converted)
+                continue
+            point = (grid_x, grid_y)
+            if pending_break:
+                converted.append((float("nan"), float("nan")))
+                pending_break = False
+            if converted and math.hypot(
+                point[0] - converted[-1][0],
+                point[1] - converted[-1][1],
+            ) < _NATIVE_TRAIL_MIN_GRID_DELTA:
+                continue
+            converted.append(point)
+        return converted
 
-        if self._dock_pos is None:
-            self._dock_pos = (x, y)
-            self._trail.append((x, y))
-            self._last_trail_record = now
-        elif (
-            now - self._last_trail_record >= _DEBUG_RECORD_INTERVAL
-            and len(self._trail) < _DEBUG_TRAIL_MAX
-        ):
-            self._trail.append((x, y))
-            self._last_trail_record = now
-
-        if not self._vp_initialized:
-            self._vp_min_x = x
-            self._vp_max_x = x
-            self._vp_min_y = y
-            self._vp_max_y = y
-            self._vp_initialized = True
-        else:
-            if x < self._vp_min_x:
-                self._vp_min_x = x
-            if x > self._vp_max_x:
-                self._vp_max_x = x
-            if y < self._vp_min_y:
-                self._vp_min_y = y
-            if y > self._vp_max_y:
-                self._vp_max_y = y
-
-    def _reset_trail(self) -> None:
-        """Clear trail for a new cleaning session."""
-        self._trail.clear()
-        self._last_trail_record = 0.0
-
-    def _record_trail_position(
-        self,
-        grid_x: float,
-        grid_y: float,
-        map_width: int,
-        map_height: int,
-    ) -> None:
-        """Record a grid-coordinate position to the cleaning trail."""
-        if not math.isfinite(grid_x) or not math.isfinite(grid_y):
+    @staticmethod
+    def _native_trajectory_render_points(
+        points: list[tuple[float, float]],
+    ):
+        """Yield render-capped trajectory points while preserving the latest tail."""
+        if len(points) <= _NATIVE_TRAIL_MAX_POINTS:
+            yield from points
             return
-        if grid_x < 0 or grid_y < 0 or grid_x >= map_width or grid_y >= map_height:
-            _LOGGER.debug(
-                "Skipping Narwal trail point outside map bounds: %.1f, %.1f (%dx%d)",
-                grid_x,
-                grid_y,
-                map_width,
-                map_height,
+
+        tail_size = min(_NATIVE_TRAIL_RECENT_TAIL_POINTS, _NATIVE_TRAIL_MAX_POINTS)
+        tail_start = len(points) - tail_size
+        prefix_slots = _NATIVE_TRAIL_MAX_POINTS - tail_size
+        if prefix_slots <= 0:
+            yield from points[-_NATIVE_TRAIL_MAX_POINTS:]
+            return
+
+        span = max(tail_start - 1, 0)
+        slots = max(prefix_slots - 1, 1)
+        selected_indices: set[int] = set()
+        for slot in range(prefix_slots):
+            selected_indices.add(round(slot * span / slots))
+        selected_indices.update(range(tail_start, len(points)))
+        selected_indices.update(
+            index
+            for index, point in enumerate(points)
+            if not math.isfinite(point[0]) or not math.isfinite(point[1])
+        )
+        for index in sorted(selected_indices):
+            yield points[index]
+
+    @staticmethod
+    def _trajectory_cache_key(
+        display,
+    ) -> tuple[int, int, int] | tuple[()]:
+        """Return a compact cache key for native trajectory changes."""
+        if display is None:
+            return ()
+        return display.trajectory_signature
+
+    @classmethod
+    def _render_overlay_image(
+        cls,
+        base_map_image,
+        static_map,
+        display,
+        map_rotation: int,
+        map_zoom: float,
+        room_label_points: list[tuple[str, float, float]],
+    ) -> bytes | None:
+        """Render dynamic map overlays in an executor thread."""
+        from .narwal_client.map_renderer import render_overlay
+
+        native_trail = None
+        if display and display.has_trajectory:
+            native_trail = cls._native_trajectory_grid_points(
+                display.trajectory_render_points(),
+                static_map,
             )
-            return
 
-        now = time.monotonic()
-        if now - self._last_trail_record >= _TRAIL_RECORD_INTERVAL:
-            if len(self._trail) < _TRAIL_MAX_POINTS:
-                if self._trail:
-                    last_x, last_y = self._trail[-1]
-                    distance = math.hypot(grid_x - last_x, grid_y - last_y)
-                    if distance < _TRAIL_MIN_GRID_DELTA:
-                        self._last_trail_record = now
-                        return
-                    max_jump = max(
-                        _TRAIL_MAX_GRID_JUMP_MIN,
-                        min(map_width, map_height) * _TRAIL_MAX_GRID_JUMP_FRACTION,
-                    )
-                    if distance > max_jump:
-                        _LOGGER.debug(
-                            "Splitting Narwal trail at large jump: %.1f grid px",
-                            distance,
-                        )
-                self._trail.append((grid_x, grid_y))
-            self._last_trail_record = now
+        robot_x = None
+        robot_y = None
+        robot_heading = None
+        if display:
+            grid_pos = display.to_grid_coords(
+                static_map.resolution, static_map.origin_x, static_map.origin_y,
+            )
+            if grid_pos is not None:
+                robot_x, robot_y = grid_pos
+                robot_heading = display.robot_heading
+
+        return render_overlay(
+            base_map_image,
+            static_map.height,
+            robot_x,
+            robot_y,
+            robot_heading,
+            native_trail,
+            map_rotation,
+            map_zoom,
+            room_label_points,
+            static_map.dock_x,
+            static_map.dock_y,
+        )
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -287,132 +323,90 @@ class NarwalMapCamera(NarwalEntity, Camera):
         state = self.coordinator.client.state
         display = state.map_display_data
 
-        # Detect cleaning session transitions — clear trail on new session
-        current_status = state.working_status
-        was_cleaning = self._last_cleaning_status in _CLEANING_TRAIL_STATUSES
-        is_cleaning = (
-            state.is_cleaning and current_status != WorkingStatus.REMAPPING
-        )
-        if is_cleaning and not was_cleaning:
-            _LOGGER.info("New cleaning session — clearing trail and vision obstacles")
-            self._reset_trail()
-        if is_cleaning:
-            self._last_cleaning_status = WorkingStatus.CLEANING
-        elif state.has_paused_clean_task_context:
-            self._last_cleaning_status = WorkingStatus.CLEANING
-        elif current_status != WorkingStatus.UNKNOWN:
-            self._last_cleaning_status = current_status
+        static_map = state.map_data
+        if not static_map or not static_map.compressed_map:
+            self.async_write_ha_state()
+            return
+        if static_map.width <= 0 or static_map.height <= 0:
+            self.async_write_ha_state()
+            return
 
-        if _DEBUG_VIEW:
-            if not display or (display.robot_x == 0.0 and display.robot_y == 0.0):
-                self.async_write_ha_state()
-                return
-            self._record_debug_position(display.robot_x, display.robot_y)
-            new_key = (display.robot_x, display.robot_y, display.robot_heading)
+        static_ts = static_map.created_at or 0
+        map_options_key = (
+            self._map_option(CONF_SHOW_ROOM_LABELS),
+            self._map_option(CONF_SHOW_FURNITURE),
+            self._map_option(CONF_SHOW_FURNITURE_LABELS),
+        )
+        view_options_key = (self._map_rotation(), self._map_zoom())
+        if display:
+            new_key = (
+                static_ts,
+                map_options_key,
+                view_options_key,
+                display.robot_x,
+                display.robot_y,
+                display.robot_heading,
+                self._trajectory_cache_key(display),
+            )
         else:
-            static_map = state.map_data
-            if not static_map or not static_map.compressed_map:
-                self.async_write_ha_state()
-                return
-            if static_map.width <= 0 or static_map.height <= 0:
-                self.async_write_ha_state()
-                return
-
-            # Record trail in grid coordinates only while actively cleaning.
-            if (
-                is_cleaning
-                and display
-                and not (display.robot_x == 0.0 and display.robot_y == 0.0)
-            ):
-                grid_pos = display.to_grid_coords(
-                    static_map.resolution, static_map.origin_x, static_map.origin_y,
-                )
-                if grid_pos is not None:
-                    self._record_trail_position(
-                        grid_pos[0],
-                        grid_pos[1],
-                        static_map.width,
-                        static_map.height,
-                    )
-
-            static_ts = static_map.created_at or 0
-            trail_len = len(self._trail)
-            map_options_key = (
-                self._map_option(CONF_SHOW_ROOM_LABELS),
-                self._map_option(CONF_SHOW_FURNITURE),
-                self._map_option(CONF_SHOW_FURNITURE_LABELS),
-            )
-            view_options_key = (self._map_rotation(), self._map_zoom())
-            if display:
-                new_key = (
-                    static_ts,
-                    map_options_key,
-                    view_options_key,
-                    display.robot_x,
-                    display.robot_y,
-                    display.robot_heading,
-                    trail_len,
-                )
-            else:
-                new_key = (static_ts, map_options_key, view_options_key)
-
-        now = time.monotonic()
-        since_render = now - self._last_render_time if self._last_render_time else 999
-        options_changed = (
-            not _DEBUG_VIEW
-            and bool(self._cache_key)
-            and (
-                self._cache_key[1] != map_options_key
-                or self._cache_key[2] != view_options_key
-            )
-        )
+            new_key = (static_ts, map_options_key, view_options_key)
 
         if new_key == self._cache_key and self._cached_image:
+            if self._render_task is not None and not self._render_task.done():
+                self._pending_render = (display, new_key)
             self.async_write_ha_state()
             return
 
-        if (
-            self._cached_image
-            and since_render < _MIN_RENDER_INTERVAL
-            and not options_changed
-        ):
-            self.async_write_ha_state()
-            return
+        self._schedule_render(display, new_key)
+        self.async_write_ha_state()
 
-        self.hass.async_create_task(self._async_render(display, new_key))
+    def _render_options_changed(self, new_key: tuple) -> bool:
+        """Return True when map display options changed and should bypass throttle."""
+        return (
+            bool(self._cache_key)
+            and len(self._cache_key) > 2
+            and len(new_key) > 2
+            and (
+                self._cache_key[1] != new_key[1]
+                or self._cache_key[2] != new_key[2]
+            )
+        )
+
+    def _schedule_render(self, display, new_key: tuple) -> None:
+        """Queue the latest render request, coalescing while a render is active."""
+        self._pending_render = (display, new_key)
+        if self._render_task is not None and not self._render_task.done():
+            return
+        self._render_task = self.hass.async_create_task(self._async_render_pending())
+
+    async def _async_render_pending(self) -> None:
+        """Render queued map updates sequentially, preserving the newest request."""
+        try:
+            while self._pending_render is not None:
+                display, new_key = self._pending_render
+                self._pending_render = None
+                since_render = (
+                    time.monotonic() - self._last_render_time
+                    if self._last_render_time
+                    else 999
+                )
+                if (
+                    self._cached_image
+                    and since_render < _MIN_RENDER_INTERVAL
+                    and not self._render_options_changed(new_key)
+                ):
+                    await asyncio.sleep(_MIN_RENDER_INTERVAL - since_render)
+                    if self._pending_render is not None:
+                        display, new_key = self._pending_render
+                        self._pending_render = None
+                if new_key == self._cache_key and self._cached_image:
+                    continue
+                await self._async_render(display, new_key)
+        finally:
+            self._render_task = None
 
     async def _async_render(self, display, new_key) -> None:
         """Render the map image in an executor thread."""
-        if _DEBUG_VIEW and display:
-            trail = list(self._trail)
-            dock = self._dock_pos
-            viewport = None
-            if self._vp_initialized:
-                viewport = (
-                    self._vp_min_x, self._vp_min_y,
-                    self._vp_max_x, self._vp_max_y,
-                )
-            try:
-                png_bytes = await self.hass.async_add_executor_job(
-                    _render_debug_view,
-                    display.robot_x,
-                    display.robot_y,
-                    display.robot_heading,
-                    trail,
-                    dock,
-                    viewport,
-                )
-                if png_bytes:
-                    self._cached_image = png_bytes
-                    self._cache_key = new_key
-                    self._last_render_time = time.monotonic()
-                    self._render_count += 1
-            except Exception:
-                _LOGGER.exception("Failed to render debug view")
-            self.async_write_ha_state()
-            return
-
-        # --- Normal map render path (with cached base + overlay) ---
         state = self.coordinator.client.state
         static_map = state.map_data
         if not static_map:
@@ -421,7 +415,6 @@ class NarwalMapCamera(NarwalEntity, Camera):
 
         from .narwal_client.map_renderer import (
             render_base_map,
-            render_overlay,
             room_label_points,
         )
 
@@ -469,76 +462,25 @@ class NarwalMapCamera(NarwalEntity, Camera):
                     static_map.height,
                     room_names,
                 )
-                _LOGGER.info("Base map rendered (ts=%d, %dx%d)", static_ts, static_map.width, static_map.height)
+                _LOGGER.info(
+                    "Base map rendered (ts=%d, %dx%d)",
+                    static_ts,
+                    static_map.width,
+                    static_map.height,
+                )
             else:
                 self.async_write_ha_state()
                 return
 
-        # Compute robot grid position
-        robot_x = None
-        robot_y = None
-        robot_heading = None
-        if display:
-            grid_pos = display.to_grid_coords(
-                static_map.resolution, static_map.origin_x, static_map.origin_y,
-            )
-            if grid_pos is not None:
-                robot_x, robot_y = grid_pos
-                robot_heading = display.robot_heading
-                # Log transform details periodically for debugging position offset
-                if self._render_count % 30 == 0:
-                    try:
-                        # Compare display_map dock ref (field 5) with static map dock
-                        dock_ref_grid_x = dock_ref_grid_y = None
-                        if display.dock_ref_x != 0.0 or display.dock_ref_y != 0.0:
-                            dock_ref_grid_x = display.dock_ref_x - static_map.origin_x
-                            dock_ref_grid_y = display.dock_ref_y - static_map.origin_y
-                        # Room lookup at robot grid position
-                        from .narwal_client.map_renderer import lookup_room_at_grid
-                        robot_rid, robot_room = lookup_room_at_grid(
-                            static_map.compressed_map, static_map.width, static_map.height,
-                            int(robot_x), int(robot_y),
-                        )
-                        dock_rid, dock_room = (-1, "n/a")
-                        if static_map.dock_x is not None and static_map.dock_y is not None:
-                            dock_rid, dock_room = lookup_room_at_grid(
-                                static_map.compressed_map, static_map.width, static_map.height,
-                                int(static_map.dock_x), int(static_map.dock_y),
-                            )
-                        _LOGGER.debug(
-                            "POSITION DIAG: robot_raw=(%.2f, %.2f) robot_grid=(%.1f, %.1f) robot_room=%s(id=%d) "
-                            "| dock_ref_raw=(%.2f, %.2f) dock_ref_grid=(%.1f, %.1f) "
-                            "| static_dock_grid=(%.1f, %.1f) dock_room=%s(id=%d) "
-                            "| res=%d origin=(%d, %d) map=%dx%d",
-                            display.robot_x, display.robot_y,
-                            robot_x, robot_y, robot_room, robot_rid,
-                            display.dock_ref_x, display.dock_ref_y,
-                            dock_ref_grid_x or 0, dock_ref_grid_y or 0,
-                            static_map.dock_x or 0, static_map.dock_y or 0,
-                            dock_room, dock_rid,
-                            static_map.resolution,
-                            static_map.origin_x, static_map.origin_y,
-                            static_map.width, static_map.height,
-                        )
-                    except Exception:
-                        _LOGGER.debug("POSITION DIAG failed", exc_info=True)
-
-        trail = list(self._trail) if self._trail else None
-
         try:
             png_bytes = await self.hass.async_add_executor_job(
-                render_overlay,
+                self._render_overlay_image,
                 self._base_map_image,
-                static_map.height,
-                robot_x,
-                robot_y,
-                robot_heading,
-                trail,
+                static_map,
+                display,
                 self._map_rotation(),
                 self._map_zoom(),
                 self._room_label_points,
-                static_map.dock_x,
-                static_map.dock_y,
             )
 
             if png_bytes:
@@ -551,133 +493,3 @@ class NarwalMapCamera(NarwalEntity, Camera):
             _LOGGER.exception("Failed to render map overlay")
 
         self.async_write_ha_state()
-
-
-def _render_debug_view(
-    robot_x: float,
-    robot_y: float,
-    robot_heading: float,
-    trail: list[tuple[float, float]],
-    dock_pos: tuple[float, float] | None = None,
-    viewport: tuple[float, float, float, float] | None = None,
-) -> bytes:
-    """Render a blank canvas with full cleaning trail, dock marker, and robot dot."""
-    from PIL import Image, ImageDraw, ImageFont
-
-    size = _DEBUG_CANVAS_SIZE
-    img = Image.new("RGB", (size, size), (20, 20, 30))
-    draw = ImageDraw.Draw(img)
-
-    if viewport:
-        min_x, min_y, max_x, max_y = viewport
-    elif trail:
-        all_x = [p[0] for p in trail]
-        all_y = [p[1] for p in trail]
-        min_x, max_x = min(all_x), max(all_x)
-        min_y, max_y = min(all_y), max(all_y)
-    else:
-        min_x = robot_x - 250
-        max_x = robot_x + 250
-        min_y = robot_y - 250
-        max_y = robot_y + 250
-
-    padding = 100
-    range_x = max(max_x - min_x, 200) + padding * 2
-    range_y = max(max_y - min_y, 200) + padding * 2
-    center_x = (min_x + max_x) / 2
-    center_y = (min_y + max_y) / 2
-
-    margin = 50
-    usable = size - margin * 2
-    scale = usable / max(range_x, range_y)
-
-    def to_px(cx: float, cy: float) -> tuple[int, int]:
-        px = int((cx - center_x) * scale + size / 2)
-        py = int(-(cy - center_y) * scale + size / 2)
-        return px, py
-
-    grid_interval = 100
-    grid_start_x = int(center_x - range_x / 2)
-    grid_start_x = grid_start_x - (grid_start_x % grid_interval)
-    grid_start_y = int(center_y - range_y / 2)
-    grid_start_y = grid_start_y - (grid_start_y % grid_interval)
-
-    grid_color = (35, 35, 45)
-    for gx in range(grid_start_x, int(center_x + range_x / 2) + grid_interval, grid_interval):
-        px, _ = to_px(gx, 0)
-        if 0 <= px < size:
-            draw.line([(px, 0), (px, size)], fill=grid_color)
-    for gy in range(grid_start_y, int(center_y + range_y / 2) + grid_interval, grid_interval):
-        _, py = to_px(0, gy)
-        if 0 <= py < size:
-            draw.line([(0, py), (size, py)], fill=grid_color)
-
-    if trail:
-        n = len(trail)
-        if n > 3000:
-            step = max(n // 2000, 2)
-            bulk = trail[: n - 200 : step]
-            recent = trail[n - 200 :]
-            render_trail = bulk + recent
-        else:
-            render_trail = trail
-
-        recent_start = max(len(render_trail) - 200, 0)
-        for i in range(len(render_trail) - 1):
-            if i >= recent_start:
-                color = (30, 120, 255)
-            else:
-                color = (15, 60, 130)
-            x1, y1 = to_px(render_trail[i][0], render_trail[i][1])
-            x2, y2 = to_px(render_trail[i + 1][0], render_trail[i + 1][1])
-            draw.line([(x1, y1), (x2, y2)], fill=color, width=2)
-
-    try:
-        font = ImageFont.load_default()
-    except Exception:
-        font = None
-
-    if dock_pos:
-        dx, dy = to_px(dock_pos[0], dock_pos[1])
-        r = 8
-        draw.ellipse(
-            [dx - r, dy - r, dx + r, dy + r],
-            fill=(255, 140, 0),
-            outline=(255, 200, 100),
-        )
-        draw.text((dx + 12, dy - 6), "DOCK", fill=(255, 140, 0), font=font)
-
-    rx, ry = to_px(robot_x, robot_y)
-    dot_r = 7
-    draw.ellipse(
-        [rx - dot_r, ry - dot_r, rx + dot_r, ry + dot_r],
-        fill=(0, 255, 80),
-        outline=(150, 255, 180),
-    )
-
-    heading_rad = math.radians(robot_heading)
-    hx = rx + int(18 * math.cos(heading_rad))
-    hy = ry - int(18 * math.sin(heading_rad))
-    draw.line([(rx, ry), (hx, hy)], fill=(0, 255, 80), width=2)
-
-    text_color = (180, 180, 190)
-    dim_color = (100, 100, 120)
-    y_text = 5
-    draw.text((5, y_text), f"pos: ({robot_x:.1f}, {robot_y:.1f}) cm", fill=text_color, font=font)
-    y_text += 15
-    draw.text((5, y_text), f"trail: {len(trail)} pts", fill=dim_color, font=font)
-    y_text += 15
-    draw.text((5, y_text), f"heading: {robot_heading:.0f}", fill=dim_color, font=font)
-    y_text += 15
-    view_w = range_x / 100
-    view_h = range_y / 100
-    draw.text((5, y_text), f"view: {view_w:.1f}x{view_h:.1f}m", fill=dim_color, font=font)
-
-    ox, oy = to_px(0, 0)
-    if 0 <= ox < size and 0 <= oy < size:
-        draw.line([(ox - 8, oy), (ox + 8, oy)], fill=(80, 80, 80))
-        draw.line([(ox, oy - 8), (ox, oy + 8)], fill=(80, 80, 80))
-
-    buf = io.BytesIO()
-    img.save(buf, format="PNG")
-    return buf.getvalue()

--- a/custom_components/narwal/config_flow.py
+++ b/custom_components/narwal/config_flow.py
@@ -64,6 +64,7 @@ class NarwalConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Narwal vacuum."""
 
     VERSION = 2
+    MINOR_VERSION = 2
 
     # Host pre-filled when zeroconf or DHCP finds the robot before the user
     # starts the flow. Class-level default: the flow object is also constructed

--- a/custom_components/narwal/const.py
+++ b/custom_components/narwal/const.py
@@ -12,7 +12,6 @@ from .narwal_client import (
 
 DOMAIN = "narwal"
 DEFAULT_PORT = 9002
-
 MANUFACTURER = "Narwal"
 MODEL = "Flow (AX12)"
 
@@ -159,39 +158,20 @@ _FAN_SPEED_CANONICAL: dict[str, FanLevel] = {
 
 FAN_SPEED_LIST: list[str] = list(_FAN_SPEED_CANONICAL)
 
-# Models whose app exposes only four suction tiers: FanLevel.SUPER (5) is unreachable
-# there, and the live clean/set_fan_level enum (SweepFanLevel) has no SUPER at all, so
-# offering "Ultra" would silently apply Strong. AX26 confirmed by app captures in #70 —
-# its top tier ("Super powerful" / "super puissant") sends CleanParam tag 2 = 4 (DEEP).
-NO_ULTRA_FAN_PRODUCT_KEYS: frozenset[str] = frozenset({"qV6BujoYLz"})
+# Models whose app exposes only four suction tiers: FanLevel.SUPER (5) is
+# unreachable there, and the live clean/set_fan_level enum has no SUPER at all.
+# AX26 confirmed by app captures in #70: its top tier sends CleanParam tag 2 =
+# 4 (DEEP), exposed as "Super Powerful" for those models.
+NO_LEVEL_5_FAN_PRODUCT_KEYS: frozenset[str] = frozenset({"qV6BujoYLz"})
 
+_FAN_SPEED_NO_LEVEL_5: dict[str, FanLevel] = {
+    "Quiet": FanLevel.MUTE,
+    "Standard": FanLevel.NORMAL,
+    "Strong": FanLevel.STRONG,
+    "Super Powerful": FanLevel.DEEP,
+}
 
-def fan_speed_list_for(data: dict) -> list[str]:
-    """fan_speed options for this configured model — no "Ultra" where 5 is unreachable."""
-    if data.get(CONF_PRODUCT_KEY) in NO_ULTRA_FAN_PRODUCT_KEYS:
-        return [
-            label
-            for label, level in _FAN_SPEED_CANONICAL.items()
-            if level is not FanLevel.SUPER
-        ]
-    return FAN_SPEED_LIST
-
-
-def normalize_fan_level_for_model(data: dict, fan: FanLevel) -> FanLevel:
-    """Return a persisted fan level supported by the configured model."""
-    if (
-        fan == FanLevel.SUPER
-        and data.get(CONF_PRODUCT_KEY) in NO_ULTRA_FAN_PRODUCT_KEYS
-    ):
-        return FanLevel.DEEP
-    return fan
-
-
-# FAN_SPEED_MAP also accepts the "… powerful" labels shipped through v1.0.3 and the
-# short "Super" label used by this stack, and the original lowercase fan_speed
-# values (quiet/normal/strong/max) so existing automations keep working; these
-# aliases are not offered in FAN_SPEED_LIST.
-FAN_SPEED_MAP: dict[str, FanLevel] = _FAN_SPEED_CANONICAL | {
+_FAN_SPEED_ALIASES: dict[str, FanLevel] = {
     "Super": FanLevel.DEEP,
     "Super powerful": FanLevel.DEEP,
     "Ultra powerful": FanLevel.SUPER,
@@ -219,6 +199,60 @@ UNVERSIONED_FAN_SPEED_MAP: dict[str, FanLevel] = {
     "max": FanLevel.SUPER,
 }
 
+_FAN_SPEED_NO_LEVEL_5_ALIASES: dict[str, FanLevel] = {
+    "Super": FanLevel.DEEP,
+    "Super powerful": FanLevel.DEEP,
+    "quiet": FanLevel.MUTE,
+    "normal": FanLevel.NORMAL,
+    "strong": FanLevel.STRONG,
+    "max": FanLevel.DEEP,
+}
+
+
+def fan_speed_list_for(data: dict) -> list[str]:
+    """Return visible fan_speed options for this configured model."""
+    return list(fan_speed_map_for(data, include_aliases=False))
+
+
+def fan_speed_map_for(
+    data: dict,
+    *,
+    include_aliases: bool = True,
+) -> dict[str, FanLevel]:
+    """Return visible and compatibility fan_speed labels for this model."""
+    if data.get(CONF_PRODUCT_KEY) in NO_LEVEL_5_FAN_PRODUCT_KEYS:
+        return _FAN_SPEED_NO_LEVEL_5 | (
+            _FAN_SPEED_NO_LEVEL_5_ALIASES if include_aliases else {}
+        )
+    return _FAN_SPEED_CANONICAL | (_FAN_SPEED_ALIASES if include_aliases else {})
+
+
+def fan_speed_label_map_for(data: dict) -> dict[FanLevel, str]:
+    """Return FanLevel -> visible fan_speed label for this model."""
+    return {
+        level: label
+        for label, level in fan_speed_map_for(data, include_aliases=False).items()
+    }
+
+
+def normalize_fan_level_for_model(data: dict, fan: FanLevel) -> FanLevel:
+    """Return a persisted fan level supported by the configured model."""
+    if (
+        fan == FanLevel.SUPER
+        and data.get(CONF_PRODUCT_KEY) in NO_LEVEL_5_FAN_PRODUCT_KEYS
+    ):
+        return FanLevel.DEEP
+    return fan
+
+
+# FAN_SPEED_MAP also accepts the short "Super" label shipped through this stack
+# and v1.0.3's "… powerful" labels, plus the original lowercase fan_speed values
+# (quiet/normal/strong/max) so existing automations keep working; these aliases
+# are not offered in FAN_SPEED_LIST.
+FAN_SPEED_MAP: dict[str, FanLevel] = _FAN_SPEED_CANONICAL | _FAN_SPEED_ALIASES
+
+# Backwards-compatible name for existing imports/tests.
+NO_ULTRA_FAN_PRODUCT_KEYS = NO_LEVEL_5_FAN_PRODUCT_KEYS
 # base_status field 15 (terminateReason) value → HA option key. From the decoded
 # TaskResult enum (re/ENUMS.md). Live-confirmed: 1 = NORMAL_END.
 TASK_RESULT_OPTIONS: dict[int, str] = {

--- a/custom_components/narwal/coordinator.py
+++ b/custom_components/narwal/coordinator.py
@@ -16,6 +16,12 @@ from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, NO_BROADCAST_PRODUCT_KEYS
+from .dock_tasks import (
+    ROBOT_START_STOP_REQUIRED_DOCK_TASKS,
+    can_start_robot_clean,
+    can_stop_dock_task,
+    dock_task_blocks_robot_return,
+)
 from .narwal_client import (
     CleaningRoute,
     CommandResponse,
@@ -144,7 +150,6 @@ def is_clean_session_context(state: NarwalState | None) -> bool:
         or _state_attr_is_true(state, "has_recent_active_working_status")
         or _state_attr_is_true(state, "has_paused_clean_task_context")
         or _state_attr_is_true(state, "is_returning")
-        or _state_attr_is_true(state, "is_charging_to_resume")
     )
 
 
@@ -156,15 +161,14 @@ def is_live_clean_setting_available(state: NarwalState | None) -> bool:
         return False
     return (
         (_state_attr_is_true(state, "is_cleaning") or is_active_clean_session(state))
-        and not _state_attr_is_true(state, "is_charging_to_resume")
-        and not _state_attr_is_true(state, "is_station_active")
+        and not dock_task_blocks_robot_return(state)
     )
 
 
 def clean_setting_applies_to_mode(attr: str, work_mode: WorkMode | None) -> bool:
     """Return True when a clean setting is meaningful for the selected mode."""
     if work_mode is None:
-        return True
+        return attr not in {"fan", "water", "mop_strength"}
     if attr in {"water", "mop_strength"}:
         return work_mode in MOP_WORK_MODES
     if attr == "fan":
@@ -208,8 +212,100 @@ def can_start_cleaning(state: NarwalState | None) -> bool:
     return (
         state.is_docked
         and not is_clean_session_context(state)
-        and not state.blocks_robot_start_for_dock_task
+        and can_start_robot_clean(state)
     )
+
+
+def _can_start_cleaning_without_dock_stop(state: NarwalState | None) -> bool:
+    """Return True when refreshed state permits sending a clean command now."""
+    return (
+        can_start_cleaning(state)
+        and not state.has_unmapped_active_dock_task
+        and state.assumed_active_dock_task is None
+    )
+
+
+def can_prepare_clean_start(
+    state: NarwalState | None,
+    *,
+    allow_dock_stop: bool = True,
+) -> bool:
+    """Return True when a clean start can run now or after a safe dock stop."""
+    if state is None:
+        return False
+    active_tasks = state.active_dock_task_keys
+    if _can_start_cleaning_without_dock_stop(state):
+        return True
+    if not allow_dock_stop:
+        return False
+    if (
+        has_blocking_error(state)
+        or not state.is_docked
+        or is_clean_session_context(state)
+        or state.has_unmapped_active_dock_task
+        or state.assumed_active_dock_task is not None
+    ):
+        return False
+
+    return (
+        len(active_tasks) == 1
+        and active_tasks[0] in ROBOT_START_STOP_REQUIRED_DOCK_TASKS
+        and can_stop_dock_task(state, active_tasks[0])
+    )
+
+
+def can_pause_cleaning(state: NarwalState | None) -> bool:
+    """Return True when the active robot clean can be paused."""
+    if has_blocking_error(state):
+        return False
+    return (
+        (
+            _state_attr_is_true(state, "is_cleaning")
+            or state.working_status == WorkingStatus.REMAPPING
+        )
+        and not _state_attr_is_true(state, "is_paused")
+        and not dock_task_blocks_robot_return(state)
+    )
+
+
+def can_resume_cleaning(state: NarwalState | None) -> bool:
+    """Return True when a paused robot clean can be resumed."""
+    if has_blocking_error(state):
+        return False
+    return (
+        (
+            state.working_status in (*ACTIVE_CLEANING_STATUSES, WorkingStatus.REMAPPING)
+            or _state_attr_is_true(state, "has_paused_clean_task_context")
+        )
+        and _state_attr_is_true(state, "is_paused")
+        and not dock_task_blocks_robot_return(state)
+    )
+
+
+def can_stop_cleaning(state: NarwalState | None) -> bool:
+    """Return True when a robot-side clean task can be stopped."""
+    if has_blocking_error(state):
+        return False
+    return is_clean_session_context(state)
+
+
+def can_return_home(state: NarwalState | None) -> bool:
+    """Return True when the robot can be recalled to the dock."""
+    if has_blocking_error(state):
+        return False
+    return (
+        not state.is_docked
+        and state.working_status != WorkingStatus.TASK_COMPLETED
+        and not _state_attr_is_true(state, "is_returning")
+        and not dock_task_blocks_robot_return(state)
+    )
+
+
+def can_locate_robot(state: NarwalState | None) -> bool:
+    """Return True when the locate command can be sent."""
+    if has_blocking_error(state):
+        return False
+    return not dock_task_blocks_robot_return(state)
 
 
 class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
@@ -1083,6 +1179,75 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         if full_update and not _has_dock_status_payload(response):
             self._mark_dock_status_refresh_failed()
             _LOGGER.debug("Dock status refresh returned no dock-status payload")
+            self._sync_active_clean_context(self.client.state)
+            self.async_set_updated_data(self.client.state)
+            return False
+        if full_update:
+            self._mark_dock_status_refresh_succeeded()
+        self._sync_active_clean_context(self.client.state)
+        self.async_set_updated_data(self.client.state)
+        return True
+
+    async def async_prepare_clean_start(self, *, allow_dock_stop: bool = True) -> bool:
+        """Stop safe dock-side blockers before starting a robot clean."""
+        if not await self.async_refresh_dock_status():
+            return False
+        state = self.client.state
+        active_tasks = state.active_dock_task_keys
+        if _can_start_cleaning_without_dock_stop(state):
+            return True
+        if not allow_dock_stop:
+            return False
+        if (
+            has_blocking_error(state)
+            or not state.is_docked
+            or is_clean_session_context(state)
+            or state.has_unmapped_active_dock_task
+            or state.assumed_active_dock_task is not None
+            or len(active_tasks) != 1
+        ):
+            return False
+
+        blocker = active_tasks[0]
+        if blocker not in ROBOT_START_STOP_REQUIRED_DOCK_TASKS or not can_stop_dock_task(
+            state, blocker
+        ):
+            return False
+        response = await self.client.stop_dock_task(blocker)
+        if not response.accepted:
+            return False
+        self._sync_active_clean_context(self.client.state)
+        self.async_set_updated_data(self.client.state)
+
+        if not await self.async_refresh_dock_status():
+            return False
+        return _can_start_cleaning_without_dock_stop(self.client.state)
+
+    async def async_refresh_action_status(self) -> bool:
+        """Refresh state for a robot action without clobbering live task telemetry."""
+        full_update = not self.client.state.has_recent_active_working_status
+        try:
+            response = await self.client.get_status(full_update=full_update)
+        except Exception:
+            _LOGGER.debug("Failed to refresh Narwal action status")
+            if full_update:
+                self._mark_dock_status_refresh_failed()
+            self._sync_active_clean_context(self.client.state)
+            self.async_set_updated_data(self.client.state)
+            return False
+        if not response.accepted:
+            _LOGGER.debug(
+                "Narwal action status refresh was rejected with code %s",
+                response.result_code,
+            )
+            if full_update:
+                self._mark_dock_status_refresh_failed()
+            self._sync_active_clean_context(self.client.state)
+            self.async_set_updated_data(self.client.state)
+            return False
+        if full_update and not _has_dock_status_payload(response):
+            _LOGGER.debug("Narwal action status refresh returned no dock-status payload")
+            self._mark_dock_status_refresh_failed()
             self._sync_active_clean_context(self.client.state)
             self.async_set_updated_data(self.client.state)
             return False

--- a/custom_components/narwal/coordinator.py
+++ b/custom_components/narwal/coordinator.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import logging
 import time
+import zlib
+from bisect import bisect_left
 from collections.abc import Mapping
 from dataclasses import dataclass, fields, replace
 from datetime import timedelta
@@ -26,6 +29,7 @@ from .narwal_client import (
     CleaningRoute,
     CommandResponse,
     FanLevel,
+    MapDisplayData,
     MopHumidity,
     MopStrengthLevel,
     NarwalClient,
@@ -46,7 +50,15 @@ FAST_POLL_MAX = 6  # up to 60s of fast polling before falling back to normal
 
 # Consumable alerts change over weeks — poll every ~30 min (30 * POLL_INTERVAL).
 CONSUMABLE_POLL_EVERY = 30
+MAP_DISPLAY_CACHE_VERSION = 1
 ROOM_SELECTION_STORE_VERSION = 1
+# Retained routes can reach roughly 0.5 MiB at the point cap. Persist session
+# boundaries immediately, but checkpoint point growth at a storage-safe cadence.
+MAP_DISPLAY_CACHE_SAVE_INTERVAL = 300.0
+NATIVE_TRAJECTORY_MAX_POINTS = 50_000
+NATIVE_TRAJECTORY_RECENT_TAIL_POINTS = 200
+NATIVE_TRAJECTORY_RESTORE_MIN_OVERLAP_POINTS = 3
+NATIVE_TRAJECTORY_RESTORE_GRACE = 60.0
 
 # The robot only broadcasts working_status and display_map while an
 # active_robot_publish subscription is live, and that subscription lasts
@@ -69,6 +81,21 @@ MOP_WORK_MODES = frozenset(
 VACUUM_WORK_MODES = frozenset(
     {WorkMode.VACUUM, WorkMode.VACUUM_THEN_MOP, WorkMode.VACUUM_AND_MOP}
 )
+
+
+@dataclass(frozen=True)
+class _MapDisplayCacheSnapshot:
+    """Lightweight display-map trajectory snapshot queued for persistence."""
+
+    map_id: int
+    map_created_at: int
+    active_clean: bool
+    display: MapDisplayData
+
+    @property
+    def trajectory_signature(self) -> tuple[int, int, int] | tuple[()]:
+        """Return the native trajectory signature for this snapshot."""
+        return self.display.trajectory_signature
 
 
 def _status_payload(response: CommandResponse) -> dict[str, object] | None:
@@ -123,6 +150,19 @@ def has_blocking_error(state: NarwalState | None) -> bool:
         state is None
         or state.working_status == WorkingStatus.ERROR
         or _state_attr_is_true(state, "has_error")
+    )
+
+
+def is_confirmed_terminal_clean_state(state: NarwalState) -> bool:
+    """Return True when reconciled telemetry confirms the clean has ended."""
+    if has_blocking_error(state) or state.working_status == WorkingStatus.TASK_COMPLETED:
+        return True
+    if _state_attr_is_true(state, "has_paused_clean_task_context"):
+        return False
+    return (
+        not state.has_assumed_robot_clean
+        and not state.has_explicit_off_dock_signal
+        and (state.is_docked or state.has_recent_terminal_working_status)
     )
 
 
@@ -359,6 +399,7 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         self._listen_task: asyncio.Task[None] | None = None
         self._fast_poll_remaining = 0
         self._prev_working_status = WorkingStatus.UNKNOWN
+        self._clean_session_active = False
         self._map_fetch_pending = False
         self._last_display_map_resub: float = 0.0
         self._last_topic_subscribe: float = 0.0
@@ -366,6 +407,28 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         self._max_failures = 5  # 5 * 60s = 5 minutes before entities go unavailable
         self._dock_status_refresh_failed = True
         self._consumable_poll_countdown = 0
+        self._map_display_cache_store = Store(
+            hass,
+            MAP_DISPLAY_CACHE_VERSION,
+            f"{DOMAIN}_map_display_{entry.entry_id}",
+        )
+        self._map_display_cache_signature: tuple[int, int, int] | tuple[()] = ()
+        self._map_display_cache_active_clean: bool | None = None
+        self._map_display_cache_last_save = 0.0
+        self._pending_map_display_cache_snapshot: _MapDisplayCacheSnapshot | None = None
+        self._pending_map_display_cache_restore: dict[str, object] | None = None
+        self._map_display_cache_save_task: asyncio.Task[None] | None = None
+        self._map_display_cache_clear_event = asyncio.Event()
+        self._map_display_cache_clear_event.set()
+        self._map_display_cache_clear_lock = asyncio.Lock()
+        self._map_display_cache_write_lock = asyncio.Lock()
+        self._map_display_cache_clear_count = 0
+        self._map_display_cache_clear_pending = False
+        self._retained_map_display: MapDisplayData | None = None
+        self._retained_map_identity: tuple[int, int] | None = None
+        self._map_display_cache_restored = False
+        self._map_display_cache_restored_from_active = False
+        self._map_display_cache_restored_at = 0.0
         self.dock_action_lock = asyncio.Lock()
 
     @property
@@ -408,6 +471,7 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
     ) -> None:
         """Record effective room profiles for the accepted robot task."""
         self.active_clean_setting_overrides = {}
+        self._clean_session_active = True
         self.active_clean_work_mode = self.shared_room_clean_work_mode(
             room_settings
         )
@@ -956,6 +1020,1154 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
             self._room_profile_pending_resolution.add(room_id)
         self._schedule_room_selection_save()
 
+    def _map_display_cache_payload(
+        self,
+        state: NarwalState,
+    ) -> dict[str, object] | None:
+        """Return a serializable display-map trajectory cache payload."""
+        snapshot = self._map_display_cache_snapshot(state)
+        return (
+            self._map_display_cache_payload_from_snapshot(snapshot)
+            if snapshot is not None
+            else None
+        )
+
+    def _map_display_cache_snapshot(
+        self,
+        state: NarwalState,
+    ) -> _MapDisplayCacheSnapshot | None:
+        """Return a lightweight display-map trajectory cache snapshot."""
+        if state.working_status == WorkingStatus.REMAPPING:
+            return None
+        display = state.map_display_data
+        if display is None or not display.has_trajectory:
+            return None
+        static_map = state.map_data
+        confirmed_terminal = (
+            is_confirmed_terminal_clean_state(state)
+            and not self._stale_startup_dock_may_await_trajectory(state)
+        )
+        active_clean = not confirmed_terminal and (
+            is_clean_session_context(state)
+            or getattr(self, "_map_display_cache_restored_from_active", False)
+        )
+        return _MapDisplayCacheSnapshot(
+            map_id=getattr(static_map, "map_id", 0) if static_map else 0,
+            map_created_at=getattr(static_map, "created_at", 0) if static_map else 0,
+            active_clean=active_clean,
+            display=display,
+        )
+
+    @staticmethod
+    def _map_display_cache_snapshot_is_scoped(
+        snapshot: _MapDisplayCacheSnapshot,
+    ) -> bool:
+        """Return whether a trajectory snapshot identifies its static map."""
+        return snapshot.map_id != 0 or snapshot.map_created_at != 0
+
+    @staticmethod
+    def _static_map_identity(state: NarwalState) -> tuple[int, int] | None:
+        """Return the identity of the active static map, when known."""
+        static_map = state.map_data
+        if static_map is None:
+            return None
+        return (static_map.map_id, static_map.created_at)
+
+    @staticmethod
+    def _map_display_cache_payload_from_snapshot(
+        snapshot: _MapDisplayCacheSnapshot,
+    ) -> dict[str, object]:
+        """Return a serializable display-map trajectory cache payload."""
+        display = snapshot.display
+        return {
+            "map_id": snapshot.map_id,
+            "map_created_at": snapshot.map_created_at,
+            "active_clean": snapshot.active_clean,
+            "robot_x": display.robot_x,
+            "robot_y": display.robot_y,
+            "robot_heading": display.robot_heading,
+            "timestamp": display.timestamp,
+            "dock_ref_x": display.dock_ref_x,
+            "dock_ref_y": display.dock_ref_y,
+            "trajectory_x_values": base64.b64encode(
+                display.trajectory_x_values
+            ).decode("ascii"),
+            "trajectory_y_values": base64.b64encode(
+                display.trajectory_y_values
+            ).decode("ascii"),
+            "trajectory_signature": list(display.trajectory_signature),
+            "trajectory_breaks": list(display.trajectory_breaks),
+        }
+
+    @staticmethod
+    def _optional_cache_int(value: object) -> int | None:
+        """Return an integer cache value, treating blank/zero as absent."""
+        if value in (None, "", 0, "0"):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _map_display_from_cache(
+        payload: Mapping[str, object] | None,
+    ) -> MapDisplayData | None:
+        """Return cached display-map data, if the stored payload is valid."""
+        if not payload:
+            return None
+        try:
+            trajectory_x_values = base64.b64decode(
+                str(payload["trajectory_x_values"])
+            )
+            trajectory_y_values = base64.b64decode(
+                str(payload["trajectory_y_values"])
+            )
+            signature_raw = payload["trajectory_signature"]
+            if not isinstance(signature_raw, list):
+                return None
+            signature = tuple(int(value) for value in signature_raw)
+            if len(signature) != 3:
+                return None
+            breaks_raw = payload.get("trajectory_breaks", [])
+            if not isinstance(breaks_raw, list):
+                return None
+            trajectory_breaks = tuple(int(value) for value in breaks_raw)
+            display = MapDisplayData(
+                # Cached trajectories are persisted so completed routes survive
+                # restart, but robot pose must come from a live display_map packet.
+                robot_x=0.0,
+                robot_y=0.0,
+                robot_heading=0.0,
+                timestamp=int(payload.get("timestamp", 0)),
+                dock_ref_x=float(payload.get("dock_ref_x", 0.0)),
+                dock_ref_y=float(payload.get("dock_ref_y", 0.0)),
+                trajectory_x_values=trajectory_x_values,
+                trajectory_y_values=trajectory_y_values,
+                trajectory_signature=signature,
+                trajectory_breaks=trajectory_breaks,
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+        return display if display.has_trajectory else None
+
+    async def _async_restore_map_display_cache(self) -> None:
+        """Restore the last display-map trajectory for the active static map."""
+        payload = await self._map_display_cache_store.async_load()
+        if not isinstance(payload, Mapping):
+            return
+        if self.client.state.map_data is None:
+            self._pending_map_display_cache_restore = dict(payload)
+            return
+        self._restore_map_display_cache_with_live_trajectory(payload)
+
+    def _restore_pending_map_display_cache(self) -> None:
+        """Restore a delayed display-map cache once a static map is available."""
+        payload = self._pending_map_display_cache_restore
+        if payload is None:
+            return
+        self._pending_map_display_cache_restore = None
+        self._restore_map_display_cache_with_live_trajectory(payload)
+
+    def _restore_map_display_cache_with_live_trajectory(
+        self,
+        payload: Mapping[str, object],
+    ) -> bool:
+        """Restore an active prefix before merging an early live window."""
+        state = self.client.state
+        current = state.map_display_data
+        if current is None:
+            return self._restore_map_display_cache_payload(payload)
+        if not current.has_trajectory:
+            restored = self._restore_map_display_cache_payload(payload)
+            if not restored or state.map_display_data is None:
+                return restored
+            restored_display = replace(
+                state.map_display_data,
+                robot_x=current.robot_x,
+                robot_y=current.robot_y,
+                robot_heading=current.robot_heading,
+                timestamp=current.timestamp,
+            )
+            state.map_display_data = restored_display
+            self._retained_map_display = restored_display
+            snapshot = self._map_display_cache_snapshot(state)
+            if snapshot is not None:
+                self._pending_map_display_cache_snapshot = snapshot
+            return True
+        if payload.get("active_clean") is not True:
+            return False
+
+        state.map_display_data = None
+        restored = self._restore_map_display_cache_payload(payload)
+        state.map_display_data = current
+        if restored:
+            self._retain_native_trajectory(state)
+            snapshot = self._map_display_cache_snapshot(state)
+            if snapshot is not None:
+                self._pending_map_display_cache_snapshot = snapshot
+        return restored
+
+    def _scope_pending_map_display_cache_snapshot(self) -> None:
+        """Bind a pre-map trajectory snapshot to the map fetched later."""
+        snapshot = self._pending_map_display_cache_snapshot
+        map_identity = self._static_map_identity(self.client.state)
+        if (
+            snapshot is None
+            or map_identity is None
+            or snapshot.map_id != 0
+            or snapshot.map_created_at != 0
+        ):
+            return
+        self._pending_map_display_cache_snapshot = replace(
+            snapshot,
+            map_id=map_identity[0],
+            map_created_at=map_identity[1],
+        )
+
+    def _restore_map_display_cache_payload(
+        self,
+        payload: Mapping[str, object],
+    ) -> bool:
+        """Restore a display-map cache payload if it matches the active map."""
+        display = self._map_display_from_cache(payload)
+        if display is None:
+            return False
+
+        static_map = self.client.state.map_data
+        if static_map is None:
+            self._pending_map_display_cache_restore = dict(payload)
+            return False
+        cached_map_id = self._optional_cache_int(payload.get("map_id"))
+        cached_created_at = self._optional_cache_int(payload.get("map_created_at"))
+        if cached_map_id is None and cached_created_at is None:
+            return False
+        if cached_map_id is not None and cached_map_id != static_map.map_id:
+            return False
+        if (
+            cached_created_at is not None
+            and cached_created_at != static_map.created_at
+        ):
+            return False
+        if self._has_current_map_display_trajectory():
+            return False
+        cached_active_clean = payload.get("active_clean") is True
+        if is_active_clean_session(self.client.state) and not cached_active_clean:
+            return False
+
+        self.client.state.map_display_data = display
+        self._retained_map_display = display
+        self._retained_map_identity = self._static_map_identity(self.client.state)
+        self._map_display_cache_signature = display.trajectory_signature
+        self._map_display_cache_active_clean = cached_active_clean
+        self._map_display_cache_restored = True
+        self._map_display_cache_restored_from_active = cached_active_clean
+        self._map_display_cache_restored_at = (
+            time.monotonic() if cached_active_clean else 0.0
+        )
+        _LOGGER.debug(
+            "Restored Narwal display-map trajectory cache with %d bytes",
+            len(display.trajectory_x_values) + len(display.trajectory_y_values),
+        )
+        return True
+
+    def _reset_map_display_cache_state(self, *, clear_memory: bool) -> None:
+        """Reset in-memory display-map trail cache state."""
+        self._pending_map_display_cache_snapshot = None
+        self._pending_map_display_cache_restore = None
+        self._map_display_cache_signature = ()
+        self._map_display_cache_active_clean = None
+        self._map_display_cache_restored = False
+        self._map_display_cache_restored_from_active = False
+        self._map_display_cache_restored_at = 0.0
+        if clear_memory:
+            self.client.state.map_display_data = None
+            self._retained_map_display = None
+            self._retained_map_identity = None
+        else:
+            self._retained_map_display = self.client.state.map_display_data
+            self._retained_map_identity = self._static_map_identity(self.client.state)
+
+    @staticmethod
+    def _native_trajectory_overlap(
+        previous: MapDisplayData,
+        current: MapDisplayData,
+    ) -> int:
+        """Return the exact point overlap between two Narwal trajectory windows."""
+        previous_count = min(
+            len(previous.trajectory_x_values),
+            len(previous.trajectory_y_values),
+        ) // 4
+        current_count = min(
+            len(current.trajectory_x_values),
+            len(current.trajectory_y_values),
+        ) // 4
+        if previous_count <= 0 or current_count <= 0:
+            return 0
+
+        previous_x = memoryview(previous.trajectory_x_values)[
+            : previous_count * 4
+        ].cast("I")
+        previous_y = memoryview(previous.trajectory_y_values)[
+            : previous_count * 4
+        ].cast("I")
+        current_x = memoryview(current.trajectory_x_values)[
+            : current_count * 4
+        ].cast("I")
+        current_y = memoryview(current.trajectory_y_values)[
+            : current_count * 4
+        ].cast("I")
+
+        # KMP keeps overlap discovery linear at the 50,000-point retention cap.
+        prefix = [0] * current_count
+        matched = 0
+        for index in range(1, current_count):
+            while matched and (
+                current_x[index] != current_x[matched]
+                or current_y[index] != current_y[matched]
+            ):
+                matched = prefix[matched - 1]
+            if (
+                current_x[index] == current_x[matched]
+                and current_y[index] == current_y[matched]
+            ):
+                matched += 1
+            prefix[index] = matched
+
+        matched = 0
+        for index in range(previous_count):
+            while matched and (
+                previous_x[index] != current_x[matched]
+                or previous_y[index] != current_y[matched]
+            ):
+                matched = prefix[matched - 1]
+            if (
+                previous_x[index] == current_x[matched]
+                and previous_y[index] == current_y[matched]
+            ):
+                matched += 1
+            if matched == current_count and index != previous_count - 1:
+                matched = prefix[matched - 1]
+        return matched
+
+    @staticmethod
+    def _native_trajectory_find(
+        haystack_x: bytes,
+        haystack_y: bytes,
+        needle_x: bytes,
+        needle_y: bytes,
+    ) -> int | None:
+        """Return the last exact packed-point sequence offset, if present."""
+        haystack_count = min(len(haystack_x), len(haystack_y)) // 4
+        needle_count = min(len(needle_x), len(needle_y)) // 4
+        if needle_count <= 0 or haystack_count < needle_count:
+            return None
+
+        haystack_x_view = memoryview(haystack_x)[: haystack_count * 4].cast("I")
+        haystack_y_view = memoryview(haystack_y)[: haystack_count * 4].cast("I")
+        needle_x_view = memoryview(needle_x)[: needle_count * 4].cast("I")
+        needle_y_view = memoryview(needle_y)[: needle_count * 4].cast("I")
+
+        prefix = [0] * needle_count
+        matched = 0
+        for index in range(1, needle_count):
+            while matched and (
+                needle_x_view[index] != needle_x_view[matched]
+                or needle_y_view[index] != needle_y_view[matched]
+            ):
+                matched = prefix[matched - 1]
+            if (
+                needle_x_view[index] == needle_x_view[matched]
+                and needle_y_view[index] == needle_y_view[matched]
+            ):
+                matched += 1
+            prefix[index] = matched
+
+        matched = 0
+        last_match: int | None = None
+        for index in range(haystack_count):
+            while matched and (
+                haystack_x_view[index] != needle_x_view[matched]
+                or haystack_y_view[index] != needle_y_view[matched]
+            ):
+                matched = prefix[matched - 1]
+            if (
+                haystack_x_view[index] == needle_x_view[matched]
+                and haystack_y_view[index] == needle_y_view[matched]
+            ):
+                matched += 1
+            if matched == needle_count:
+                last_match = index - needle_count + 1
+                matched = prefix[matched - 1]
+        return last_match
+
+    @classmethod
+    def _native_trajectory_contains(
+        cls,
+        haystack_x: bytes,
+        haystack_y: bytes,
+        needle_x: bytes,
+        needle_y: bytes,
+    ) -> bool:
+        """Return whether packed trajectory points contain an exact sequence."""
+        return cls._native_trajectory_find(
+            haystack_x, haystack_y, needle_x, needle_y
+        ) is not None
+
+    @classmethod
+    def _native_trajectory_compacted_tail_end(
+        cls,
+        previous: MapDisplayData,
+        current: MapDisplayData,
+    ) -> int:
+        """Return the end offset of a retained compacted tail in a rolling window."""
+        previous_count = min(
+            len(previous.trajectory_x_values),
+            len(previous.trajectory_y_values),
+        ) // 4
+        if previous_count != NATIVE_TRAJECTORY_MAX_POINTS:
+            return 0
+        tail_count = min(NATIVE_TRAJECTORY_RECENT_TAIL_POINTS, previous_count)
+        tail_size = tail_count * 4
+        start = cls._native_trajectory_find(
+            current.trajectory_x_values,
+            current.trajectory_y_values,
+            previous.trajectory_x_values[-tail_size:],
+            previous.trajectory_y_values[-tail_size:],
+        )
+        return 0 if start is None else start + tail_count
+
+    @classmethod
+    def _compact_native_trajectory(
+        cls,
+        x_values: bytes,
+        y_values: bytes,
+        breaks: tuple[int, ...],
+        *,
+        max_points: int | None = None,
+        recent_tail_points: int | None = None,
+    ) -> tuple[bytes, bytes, tuple[int, ...]]:
+        """Bound retained route work while preserving its shape and recent tail."""
+        if max_points is None:
+            max_points = NATIVE_TRAJECTORY_MAX_POINTS
+        if recent_tail_points is None:
+            recent_tail_points = NATIVE_TRAJECTORY_RECENT_TAIL_POINTS
+        point_count = min(len(x_values), len(y_values)) // 4
+        if point_count <= max_points:
+            return x_values, y_values, breaks
+
+        tail_size = min(recent_tail_points, max_points)
+        tail_start = point_count - tail_size
+        prefix_slots = max_points - tail_size
+        span = max(tail_start - 1, 0)
+        slots = max(prefix_slots - 1, 1)
+        selected = {
+            round(slot * span / slots) for slot in range(prefix_slots)
+        }
+        selected.update(range(tail_start, point_count))
+        selected_indices = sorted(selected)
+        x_view = memoryview(x_values)
+        y_view = memoryview(y_values)
+        compact_x = b"".join(
+            x_view[index * 4 : index * 4 + 4] for index in selected_indices
+        )
+        compact_y = b"".join(
+            y_view[index * 4 : index * 4 + 4] for index in selected_indices
+        )
+        compact_breaks = {
+            bisect_left(selected_indices, index) for index in breaks
+        }
+        return (
+            compact_x,
+            compact_y,
+            tuple(
+                sorted(
+                    index
+                    for index in compact_breaks
+                    if 0 < index < len(selected_indices)
+                )
+            ),
+        )
+
+    @classmethod
+    def _native_trajectory_replaces_compacted(
+        cls,
+        previous: MapDisplayData,
+        current: MapDisplayData,
+    ) -> bool:
+        """Return whether a full native route contains a compacted route tail."""
+        previous_count = min(
+            len(previous.trajectory_x_values),
+            len(previous.trajectory_y_values),
+        ) // 4
+        current_count = min(
+            len(current.trajectory_x_values),
+            len(current.trajectory_y_values),
+        ) // 4
+        if (
+            previous_count != NATIVE_TRAJECTORY_MAX_POINTS
+            or current_count < previous_count
+        ):
+            return False
+        previous_x = previous.trajectory_x_values[: previous_count * 4]
+        previous_y = previous.trajectory_y_values[: previous_count * 4]
+        current_x = current.trajectory_x_values[: current_count * 4]
+        current_y = current.trajectory_y_values[: current_count * 4]
+        if current_x[:4] != previous_x[:4] or current_y[:4] != previous_y[:4]:
+            return False
+        tail_count = min(NATIVE_TRAJECTORY_RECENT_TAIL_POINTS, previous_count)
+        tail_size = tail_count * 4
+        return cls._native_trajectory_contains(
+            current_x,
+            current_y,
+            previous_x[-tail_size:],
+            previous_y[-tail_size:],
+        )
+
+    @classmethod
+    def _merge_native_trajectory_windows(
+        cls,
+        previous: MapDisplayData,
+        current: MapDisplayData,
+    ) -> MapDisplayData:
+        """Append a Narwal trajectory window to the route retained by HA."""
+        previous_count = min(
+            len(previous.trajectory_x_values),
+            len(previous.trajectory_y_values),
+        ) // 4
+        current_count = min(
+            len(current.trajectory_x_values),
+            len(current.trajectory_y_values),
+        ) // 4
+        if previous_count <= 0:
+            return current
+        if current_count <= 0:
+            return replace(
+                current,
+                trajectory_x_values=previous.trajectory_x_values,
+                trajectory_y_values=previous.trajectory_y_values,
+                trajectory_signature=previous.trajectory_signature,
+                trajectory_breaks=previous.trajectory_breaks,
+            )
+        if (
+            current.timestamp
+            and previous.timestamp
+            and current.timestamp < previous.timestamp
+        ):
+            return previous
+
+        previous_x = previous.trajectory_x_values[: previous_count * 4]
+        previous_y = previous.trajectory_y_values[: previous_count * 4]
+        current_x = current.trajectory_x_values[: current_count * 4]
+        current_y = current.trajectory_y_values[: current_count * 4]
+        current_has_previous_prefix = (
+            current_count >= previous_count
+            and current_x.startswith(previous_x)
+            and current_y.startswith(previous_y)
+        )
+        # Once HA compacts an accumulated route, its full byte prefix no
+        # longer matches. The untouched recent tail still identifies the
+        # next full Narwal window without re-appending the whole route.
+        current_replaces_compacted = (
+            not current_has_previous_prefix
+            and cls._native_trajectory_replaces_compacted(previous, current)
+        )
+        if current_has_previous_prefix or current_replaces_compacted:
+            # Exact prefix growth retains HA's discontinuities. A complete
+            # Narwal window replacing compacted data is authoritative and can
+            # resolve a gap that HA previously had to mark locally.
+            replacement_breaks = current.trajectory_breaks
+            if current_has_previous_prefix:
+                replacement_breaks = tuple(
+                    sorted(
+                        set(previous.trajectory_breaks)
+                        | set(current.trajectory_breaks)
+                    )
+                )
+            bounded_x, bounded_y, bounded_breaks = cls._compact_native_trajectory(
+                current_x,
+                current_y,
+                replacement_breaks,
+            )
+            if (
+                bounded_x == current.trajectory_x_values
+                and bounded_y == current.trajectory_y_values
+                and bounded_breaks == current.trajectory_breaks
+            ):
+                return current
+            break_bytes = b"".join(
+                index.to_bytes(4, "little", signed=False)
+                for index in bounded_breaks
+            )
+            return replace(
+                current,
+                trajectory_x_values=bounded_x,
+                trajectory_y_values=bounded_y,
+                trajectory_signature=(
+                    len(bounded_x) // 4,
+                    zlib.crc32(bounded_x) & 0xFFFFFFFF,
+                    zlib.crc32(break_bytes, zlib.crc32(bounded_y)) & 0xFFFFFFFF,
+                ),
+                trajectory_breaks=bounded_breaks,
+            )
+        overlap = cls._native_trajectory_overlap(previous, current)
+        compacted_tail_end = cls._native_trajectory_compacted_tail_end(
+            previous, current
+        )
+
+        append_point = max(overlap, compacted_tail_end)
+        current_break_start = 0
+        if compacted_tail_end > overlap:
+            current_break_start = compacted_tail_end - min(
+                NATIVE_TRAJECTORY_RECENT_TAIL_POINTS,
+                previous_count,
+            )
+        append_offset = append_point * 4
+        merged_x = previous_x + current_x[append_offset:]
+        merged_y = previous_y + current_y[append_offset:]
+        current_offset = previous_count - append_point
+        merged_count = len(merged_x) // 4
+        merged_breaks = set(previous.trajectory_breaks)
+        merged_breaks.update(
+            current_offset + index
+            for index in current.trajectory_breaks
+            if index >= current_break_start
+        )
+        if append_point == 0:
+            merged_breaks.add(previous_count)
+        valid_breaks = tuple(
+            sorted(index for index in merged_breaks if 0 < index < merged_count)
+        )
+        merged_x, merged_y, valid_breaks = cls._compact_native_trajectory(
+            merged_x,
+            merged_y,
+            valid_breaks,
+        )
+        break_bytes = b"".join(
+            index.to_bytes(4, "little", signed=False) for index in valid_breaks
+        )
+        return replace(
+            current,
+            trajectory_x_values=merged_x,
+            trajectory_y_values=merged_y,
+            trajectory_signature=(
+                len(merged_x) // 4,
+                zlib.crc32(merged_x) & 0xFFFFFFFF,
+                zlib.crc32(break_bytes, zlib.crc32(merged_y)) & 0xFFFFFFFF,
+            ),
+            trajectory_breaks=valid_breaks,
+        )
+
+    def _retain_native_trajectory(self, state: NarwalState) -> None:
+        """Accumulate Narwal's overlapping trajectory windows for this clean."""
+        map_identity = self._static_map_identity(state)
+        retained_map_identity = getattr(self, "_retained_map_identity", None)
+        if retained_map_identity is None and map_identity is not None:
+            self._retained_map_identity = map_identity
+            retained_map_identity = map_identity
+        if (
+            retained_map_identity is not None
+            and map_identity is not None
+            and map_identity != retained_map_identity
+        ):
+            # A display-map packet cannot be attributed safely while the active
+            # static map is changing. Drop it with the old route; the next
+            # packet on the new map starts a fresh retained trajectory.
+            self._reset_map_display_cache_state(clear_memory=True)
+            self._retained_map_identity = map_identity
+            self._schedule_map_display_cache_clear(None)
+            return
+        if state.working_status == WorkingStatus.REMAPPING:
+            # display_map field 2 is also populated while Narwal rebuilds its
+            # map. Keep that geometry out of the retained cleaning route while
+            # still publishing the live pose carried by the current packet.
+            current = state.map_display_data
+            previous = getattr(self, "_retained_map_display", None)
+            if current is not None and previous is not None:
+                retained = replace(
+                    previous,
+                    robot_x=current.robot_x,
+                    robot_y=current.robot_y,
+                    robot_heading=current.robot_heading,
+                    timestamp=current.timestamp,
+                    dock_ref_x=current.dock_ref_x,
+                    dock_ref_y=current.dock_ref_y,
+                )
+                state.map_display_data = retained
+                self._retained_map_display = retained
+            elif current is not None:
+                state.map_display_data = replace(
+                    current,
+                    trajectory_x_values=b"",
+                    trajectory_y_values=b"",
+                    trajectory_signature=(),
+                    trajectory_breaks=(),
+                )
+            else:
+                state.map_display_data = previous
+            return
+        current = state.map_display_data
+        if current is None:
+            return
+        previous = getattr(self, "_retained_map_display", None)
+        if previous is current:
+            return
+        if previous is None:
+            self._retained_map_display = current
+            self._retained_map_identity = map_identity
+            return
+        restored_active = getattr(
+            self,
+            "_map_display_cache_restored_from_active",
+            False,
+        )
+        if restored_active and current.has_trajectory:
+            if (
+                current.timestamp
+                and previous.timestamp
+                and current.timestamp < previous.timestamp
+            ):
+                state.map_display_data = previous
+                return
+            previous_count = min(
+                len(previous.trajectory_x_values),
+                len(previous.trajectory_y_values),
+            ) // 4
+            current_count = min(
+                len(current.trajectory_x_values),
+                len(current.trajectory_y_values),
+            ) // 4
+            required_overlap = min(
+                NATIVE_TRAJECTORY_RESTORE_MIN_OVERLAP_POINTS,
+                previous_count,
+            )
+            if current_count < required_overlap:
+                pending = replace(
+                    current,
+                    trajectory_x_values=previous.trajectory_x_values,
+                    trajectory_y_values=previous.trajectory_y_values,
+                    trajectory_signature=previous.trajectory_signature,
+                    trajectory_breaks=previous.trajectory_breaks,
+                )
+                state.map_display_data = pending
+                # A later non-map callback can revisit the published state.
+                # Keep object identity aligned so the restored route cannot
+                # validate itself before another native window arrives.
+                self._retained_map_display = pending
+                return
+            if (
+                max(
+                    self._native_trajectory_overlap(previous, current),
+                    self._native_trajectory_compacted_tail_end(previous, current),
+                )
+                < required_overlap
+                and not self._native_trajectory_replaces_compacted(previous, current)
+            ):
+                # Narwal exposes no cleaning-session id. Refuse to join a cached
+                # route unless a short tail sequence appears in the first live
+                # rolling window; one point can coincide across different cleans.
+                self._retained_map_display = current
+                self._map_display_cache_signature = ()
+                self._map_display_cache_active_clean = None
+                self._map_display_cache_restored = False
+                self._map_display_cache_restored_from_active = False
+                self._map_display_cache_restored_at = 0.0
+                return
+        merged = self._merge_native_trajectory_windows(previous, current)
+        state.map_display_data = merged
+        self._retained_map_display = merged
+        if (
+            restored_active
+            and current.has_trajectory
+            and is_active_clean_session(state)
+        ):
+            self._map_display_cache_restored = False
+            self._map_display_cache_restored_from_active = False
+            self._map_display_cache_restored_at = 0.0
+
+    def _has_current_map_display_trajectory(self) -> bool:
+        """Return true when current state already has native trajectory data."""
+        display = self.client.state.map_display_data
+        return display is not None and display.has_trajectory
+
+    @staticmethod
+    def _map_display_signature_from_payload(
+        payload: Mapping[str, object],
+    ) -> tuple[int, int, int] | tuple[()]:
+        """Return the trajectory signature stored in a cache payload."""
+        signature_raw = payload.get("trajectory_signature")
+        return (
+            tuple(int(value) for value in signature_raw)
+            if isinstance(signature_raw, list)
+            else ()
+        )
+
+    def _schedule_map_display_cache_save(
+        self, state: NarwalState, *, immediate: bool = False
+    ) -> None:
+        """Schedule a throttled save of the latest display-map trajectory."""
+        snapshot = self._map_display_cache_snapshot(state)
+        if snapshot is None:
+            return
+        if (
+            snapshot.trajectory_signature == self._map_display_cache_signature
+            and snapshot.active_clean
+            == getattr(self, "_map_display_cache_active_clean", None)
+        ):
+            return
+        active_clean_changed = snapshot.active_clean != getattr(
+            self, "_map_display_cache_active_clean", None
+        )
+        if active_clean_changed:
+            immediate = True
+        self._pending_map_display_cache_snapshot = snapshot
+        if not self._map_display_cache_snapshot_is_scoped(snapshot):
+            return
+        if (
+            self._map_display_cache_save_task is not None
+            and not self._map_display_cache_save_task.done()
+        ):
+            if not immediate:
+                return
+            self._map_display_cache_save_task.cancel()
+            self._map_display_cache_save_task = None
+        delay = (
+            0.0
+            if immediate
+            else max(
+                0.0,
+                MAP_DISPLAY_CACHE_SAVE_INTERVAL
+                - (time.monotonic() - self._map_display_cache_last_save),
+            )
+        )
+        self._map_display_cache_save_task = self.config_entry.async_create_background_task(
+            self.hass,
+            self._async_save_pending_map_display_cache(delay),
+            f"{DOMAIN}_map_display_cache_save",
+        )
+
+    def _cancel_map_display_cache_save_task(self) -> asyncio.Task[None] | None:
+        """Cancel any queued trajectory-cache write and return the task."""
+        task = self._map_display_cache_save_task
+        if task is None or task.done():
+            return None
+        task.cancel()
+        return task
+
+    async def _async_cancel_map_display_cache_save(self) -> None:
+        """Cancel and await any queued trajectory-cache write."""
+        task = self._cancel_map_display_cache_save_task()
+        if task is not None:
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        if self._map_display_cache_save_task is task:
+            self._map_display_cache_save_task = None
+
+    async def _async_save_pending_map_display_cache(self, delay: float) -> None:
+        """Persist the newest queued display-map trajectory cache payload."""
+        clear_event = getattr(self, "_map_display_cache_clear_event", None)
+        if clear_event is not None:
+            await clear_event.wait()
+        if delay > 0:
+            await asyncio.sleep(delay)
+        while self._pending_map_display_cache_snapshot is not None:
+            snapshot = self._pending_map_display_cache_snapshot
+            self._pending_map_display_cache_snapshot = None
+            if not self._map_display_cache_snapshot_is_scoped(snapshot):
+                self._pending_map_display_cache_snapshot = snapshot
+                return
+            payload = self._map_display_cache_payload_from_snapshot(snapshot)
+            try:
+                await self._async_write_map_display_cache(payload)
+            except Exception:
+                _LOGGER.debug("Could not save display-map trajectory cache")
+                return
+            self._map_display_cache_signature = snapshot.trajectory_signature
+            self._map_display_cache_active_clean = snapshot.active_clean
+            self._map_display_cache_last_save = time.monotonic()
+            self._map_display_cache_clear_pending = False
+            if self._pending_map_display_cache_snapshot is not None:
+                await asyncio.sleep(MAP_DISPLAY_CACHE_SAVE_INTERVAL)
+
+    async def _async_flush_map_display_cache(self) -> None:
+        """Persist the current display-map trajectory before shutdown."""
+        clear_event = getattr(self, "_map_display_cache_clear_event", None)
+        if clear_event is not None:
+            await clear_event.wait()
+        await self._async_cancel_map_display_cache_save()
+        self._scope_pending_map_display_cache_snapshot()
+
+        snapshot = (
+            self._pending_map_display_cache_snapshot
+            or self._map_display_cache_snapshot(self.client.state)
+        )
+        if snapshot is not None and not self._map_display_cache_snapshot_is_scoped(
+            snapshot
+        ):
+            if not getattr(self, "_map_display_cache_clear_pending", False):
+                return
+            try:
+                await self._async_write_map_display_cache({})
+            except Exception:
+                _LOGGER.debug("Could not flush display-map trajectory cache clear")
+                return
+            self._map_display_cache_signature = ()
+            self._map_display_cache_active_clean = False
+            self._map_display_cache_last_save = time.monotonic()
+            self._map_display_cache_clear_pending = False
+            return
+        self._pending_map_display_cache_snapshot = None
+        payload = (
+            self._map_display_cache_payload_from_snapshot(snapshot)
+            if snapshot is not None
+            else (
+                {}
+                if getattr(self, "_map_display_cache_clear_pending", False)
+                else None
+            )
+        )
+        if payload is None:
+            return
+
+        try:
+            await self._async_write_map_display_cache(payload)
+        except Exception:
+            _LOGGER.debug("Could not flush display-map trajectory cache")
+            return
+        self._map_display_cache_signature = self._map_display_signature_from_payload(
+            payload
+        )
+        self._map_display_cache_active_clean = payload.get("active_clean") is True
+        self._map_display_cache_last_save = time.monotonic()
+        self._map_display_cache_clear_pending = False
+
+    def _map_display_cache_clear_gate(self) -> asyncio.Event:
+        """Return the gate that serializes new route writes after cache clears."""
+        event = getattr(self, "_map_display_cache_clear_event", None)
+        if event is None:
+            event = asyncio.Event()
+            event.set()
+            self._map_display_cache_clear_event = event
+        return event
+
+    def _map_display_cache_clear_mutex(self) -> asyncio.Lock:
+        """Return the lock that orders overlapping trajectory-cache clears."""
+        lock = getattr(self, "_map_display_cache_clear_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._map_display_cache_clear_lock = lock
+        return lock
+
+    def _map_display_cache_write_mutex(self) -> asyncio.Lock:
+        """Return the lock that serializes every trajectory-cache write."""
+        lock = getattr(self, "_map_display_cache_write_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._map_display_cache_write_lock = lock
+        return lock
+
+    async def _async_write_map_display_cache(self, payload: object) -> None:
+        """Finish an in-flight storage write before honoring cancellation."""
+        async with self._map_display_cache_write_mutex():
+            write_task = asyncio.create_task(
+                self._map_display_cache_store.async_save(payload)
+            )
+            try:
+                await asyncio.shield(write_task)
+            except asyncio.CancelledError:
+                while not write_task.done():
+                    try:
+                        await asyncio.shield(write_task)
+                    except asyncio.CancelledError:
+                        continue
+                with contextlib.suppress(Exception):
+                    write_task.result()
+                raise
+
+    def _begin_map_display_cache_clear(self) -> None:
+        """Keep route writes gated until every scheduled clear has finished."""
+        self._map_display_cache_clear_count = (
+            getattr(self, "_map_display_cache_clear_count", 0) + 1
+        )
+        self._map_display_cache_clear_gate().clear()
+
+    def _finish_map_display_cache_clear(self) -> None:
+        """Release route writes after the last overlapping clear."""
+        remaining = max(
+            0, getattr(self, "_map_display_cache_clear_count", 1) - 1
+        )
+        self._map_display_cache_clear_count = remaining
+        if remaining:
+            return
+        self._map_display_cache_clear_gate().set()
+        if self._pending_map_display_cache_snapshot is not None:
+            self._schedule_map_display_cache_save(self.client.state, immediate=True)
+
+    async def async_clear_map_display_cache(self) -> None:
+        """Clear cached display-map trajectory after accepting a new clean."""
+        self._begin_map_display_cache_clear()
+        self._map_display_cache_clear_pending = True
+        cancelled_save = self._cancel_map_display_cache_save_task()
+        self._reset_map_display_cache_state(clear_memory=True)
+        try:
+            async with self._map_display_cache_clear_mutex():
+                if cancelled_save is not None:
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await cancelled_save
+                    if self._map_display_cache_save_task is cancelled_save:
+                        self._map_display_cache_save_task = None
+                try:
+                    await self._async_write_map_display_cache({})
+                except Exception:
+                    _LOGGER.debug("Could not clear display-map trajectory cache")
+                else:
+                    self._map_display_cache_clear_pending = False
+        finally:
+            self._finish_map_display_cache_clear()
+
+    def _schedule_map_display_cache_clear(
+        self,
+        snapshot: _MapDisplayCacheSnapshot | None,
+    ) -> None:
+        """Clear or replace persisted trail cache from a synchronous callback."""
+        self._begin_map_display_cache_clear()
+        self._map_display_cache_clear_pending = True
+        cancelled_save = self._cancel_map_display_cache_save_task()
+        self._pending_map_display_cache_snapshot = None
+        self.config_entry.async_create_background_task(
+            self.hass,
+            self._async_clear_or_replace_map_display_cache(snapshot, cancelled_save),
+            f"{DOMAIN}_map_display_cache_clear",
+        )
+
+    async def _async_clear_or_replace_map_display_cache(
+        self,
+        snapshot: _MapDisplayCacheSnapshot | None,
+        cancelled_save: asyncio.Task[None] | None,
+    ) -> None:
+        """Persist the new-clean cache decision after cancelling stale writes."""
+        try:
+            async with self._map_display_cache_clear_mutex():
+                if cancelled_save is not None:
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await cancelled_save
+                    if self._map_display_cache_save_task is cancelled_save:
+                        self._map_display_cache_save_task = None
+                if snapshot is None:
+                    try:
+                        await self._async_write_map_display_cache({})
+                    except Exception:
+                        _LOGGER.debug("Could not clear display-map trajectory cache")
+                    else:
+                        self._map_display_cache_clear_pending = False
+                else:
+                    payload = self._map_display_cache_payload_from_snapshot(snapshot)
+                    try:
+                        await self._async_write_map_display_cache(payload)
+                    except Exception:
+                        _LOGGER.debug("Could not replace display-map trajectory cache")
+                    else:
+                        self._map_display_cache_signature = snapshot.trajectory_signature
+                        self._map_display_cache_active_clean = snapshot.active_clean
+                        self._map_display_cache_last_save = time.monotonic()
+                        self._map_display_cache_clear_pending = False
+        finally:
+            self._finish_map_display_cache_clear()
+
+    @staticmethod
+    def _has_clean_session_signal(state: NarwalState) -> bool:
+        """Return true when current telemetry describes an active clean session."""
+        if (
+            state.working_status == WorkingStatus.REMAPPING
+            or is_confirmed_terminal_clean_state(state)
+        ):
+            return False
+        return (
+            state.working_status in ACTIVE_CLEANING_STATUSES
+            or state.has_assumed_robot_clean
+            or state.has_paused_clean_task_context
+            or (
+                state.has_recent_active_working_status
+                and not _state_attr_is_true(state, "is_returning")
+            )
+        )
+
+    def _reconcile_map_display_after_status_refresh(self) -> None:
+        """Apply refreshed task state to trajectory retention and persistence."""
+        state = self.client.state
+        self._handle_working_status_transition(state)
+        self._retain_native_trajectory(state)
+        self._schedule_map_display_cache_save(state)
+
+    def _is_new_clean_transition(self, state: NarwalState) -> bool:
+        """Return true when state has entered a new robot cleaning session."""
+        if not self._has_clean_session_signal(state):
+            return False
+        if getattr(self, "_clean_session_active", False):
+            return False
+        pending_restore = getattr(self, "_pending_map_display_cache_restore", None)
+        if isinstance(pending_restore, Mapping) and pending_restore.get(
+            "active_clean"
+        ) is True:
+            return False
+        return not (
+            self._map_display_cache_restored
+            and self._map_display_cache_restored_from_active
+        )
+
+    def _active_map_display_cache_awaits_validation(self) -> bool:
+        """Return true while a restored active route awaits its first live window."""
+        restored_at = getattr(self, "_map_display_cache_restored_at", 0.0)
+        return bool(
+            getattr(self, "_map_display_cache_restored_from_active", False)
+            and restored_at > 0
+            and time.monotonic() - restored_at <= NATIVE_TRAJECTORY_RESTORE_GRACE
+        )
+
+    def _stale_startup_dock_may_await_trajectory(self, state: NarwalState) -> bool:
+        """Return true only for ambiguous idle-dock state during restore grace."""
+        return (
+            self._active_map_display_cache_awaits_validation()
+            and state.working_status
+            in {
+                WorkingStatus.STANDBY,
+                WorkingStatus.DOCKED,
+                WorkingStatus.CHARGED,
+                WorkingStatus.DOCKED_V2,
+            }
+            and state.is_docked
+            and not has_blocking_error(state)
+        )
+
+    def _clear_map_display_cache_for_new_clean(self) -> None:
+        """Clear stale trail data when a clean starts outside HA."""
+        self._reset_map_display_cache_state(clear_memory=True)
+        self._schedule_map_display_cache_clear(None)
+        _LOGGER.debug("Cleared Narwal display-map trajectory cache for new clean")
+
+    def _handle_working_status_transition(self, state: NarwalState) -> None:
+        """Apply transition side effects and record the latest working status."""
+        if (
+            is_confirmed_terminal_clean_state(state)
+            and not self._stale_startup_dock_may_await_trajectory(state)
+        ):
+            self._map_display_cache_restored_from_active = False
+            self._map_display_cache_restored_at = 0.0
+            pending_restore = getattr(
+                self, "_pending_map_display_cache_restore", None
+            )
+            if isinstance(pending_restore, Mapping) and pending_restore.get(
+                "active_clean"
+            ) is True:
+                self._pending_map_display_cache_restore = {
+                    **pending_restore,
+                    "active_clean": False,
+                }
+        if self._is_new_clean_transition(state):
+            self._clear_map_display_cache_for_new_clean()
+        self._clean_session_active = self._has_clean_session_signal(state)
+        self._prev_working_status = state.working_status
+
     async def async_setup(self) -> None:
         """Connect to the vacuum and start the WebSocket listener.
 
@@ -996,6 +2208,21 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
             _LOGGER.debug("Could not fetch initial map")
 
         try:
+            await self._async_restore_map_display_cache()
+        except Exception:
+            _LOGGER.debug("Could not restore display-map trajectory cache")
+        if (
+            self._has_clean_session_signal(self.client.state)
+            and not getattr(self, "_map_display_cache_restored", False)
+            and getattr(self, "_pending_map_display_cache_restore", None) is None
+        ):
+            # Initial map fetches can already have delivered this clean's first
+            # native window. Treat it as the current session, not stale history.
+            self._clean_session_active = True
+        self._handle_working_status_transition(self.client.state)
+        self._retain_native_trajectory(self.client.state)
+
+        try:
             await self.client.get_consumable_info()
         except Exception:
             _LOGGER.debug("Could not fetch initial consumable info")
@@ -1009,7 +2236,11 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
             except Exception:
                 _LOGGER.debug("Could not send topic subscription at startup")
 
+        self._retain_native_trajectory(self.client.state)
+        self._schedule_map_display_cache_save(self.client.state)
         self.async_set_updated_data(self.client.state)
+        self._prev_working_status = self.client.state.working_status
+        self._clean_session_active = self._has_clean_session_signal(self.client.state)
 
         # Set up push callback and start persistent listener
         self.client.on_state_update = self._on_state_update
@@ -1048,6 +2279,8 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
                 self._fetch_missing_map(),
                 f"{DOMAIN}_map_fetch",
             )
+        elif state.map_data is not None:
+            self._restore_pending_map_display_cache()
 
         # Detect return-to-dock transition: CLEANING/CLEANING_ALT → docked state.
         # Broadcast dock fields are stale after docking — immediate poll
@@ -1063,7 +2296,9 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         ):
             _LOGGER.info("Return-to-dock detected, refreshing dock status")
             self.hass.async_create_task(self._refresh_dock_status())
-        self._prev_working_status = state.working_status
+        self._handle_working_status_transition(state)
+        self._retain_native_trajectory(state)
+        self._schedule_map_display_cache_save(state)
 
         # display_map dropout recovery: if cleaning but no display_map for
         # 30s, re-send topic subscription. Only subscription — no wake burst
@@ -1115,6 +2350,8 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
             _LOGGER.debug("Map fetch failed — will retry on next broadcast")
             self._map_fetch_pending = False
             return
+        self._scope_pending_map_display_cache_snapshot()
+        self._restore_pending_map_display_cache()
         if self.client.supports_broadcasts:
             try:
                 await self.client.subscribe_to_topics()
@@ -1148,6 +2385,7 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
                     "Status refresh returned no dock-status payload"
                 )
             self._mark_dock_status_refresh_succeeded()
+            self._reconcile_map_display_after_status_refresh()
             self._sync_active_clean_context(self.client.state)
             self.async_set_updated_data(self.client.state)
         except Exception:
@@ -1184,6 +2422,7 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
             return False
         if full_update:
             self._mark_dock_status_refresh_succeeded()
+        self._reconcile_map_display_after_status_refresh()
         self._sync_active_clean_context(self.client.state)
         self.async_set_updated_data(self.client.state)
         return True
@@ -1253,6 +2492,7 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
             return False
         if full_update:
             self._mark_dock_status_refresh_succeeded()
+        self._reconcile_map_display_after_status_refresh()
         self._sync_active_clean_context(self.client.state)
         self.async_set_updated_data(self.client.state)
         return True
@@ -1313,6 +2553,11 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         if self.client.state.map_data is None:
             with contextlib.suppress(Exception):
                 await self.client.get_map()
+        if self.client.state.map_data is not None:
+            self._scope_pending_map_display_cache_snapshot()
+            self._restore_pending_map_display_cache()
+
+        self._reconcile_map_display_after_status_refresh()
 
         # Renew the broadcast subscription before it lapses. This is deliberately
         # NOT conditional on believing we are cleaning: working_status is what tells
@@ -1358,5 +2603,8 @@ class NarwalCoordinator(DataUpdateCoordinator[NarwalState]):
         await self.client.disconnect()
         if self._listen_task and not self._listen_task.done():
             self._listen_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._listen_task
+        await self._async_flush_map_display_cache()
         await self._async_save_room_selections()
         await super().async_shutdown()

--- a/custom_components/narwal/dock_tasks.py
+++ b/custom_components/narwal/dock_tasks.py
@@ -67,6 +67,11 @@ GENERIC_STOP_DOCK_TASKS = frozenset(
 )
 SCOPED_STOP_DOCK_TASKS = frozenset({DOCK_TASK_DRY_DOCK_BAG, DOCK_TASK_DRY_DUST_BIN})
 STOPPABLE_DOCK_TASKS = GENERIC_STOP_DOCK_TASKS | SCOPED_STOP_DOCK_TASKS
+ROBOT_RETURN_COMPATIBLE_DOCK_TASKS = frozenset({DOCK_TASK_DRY_DOCK_BAG})
+ROBOT_START_COMPATIBLE_DOCK_TASKS = frozenset(
+    {DOCK_TASK_DRY_MOP, DOCK_TASK_DRY_DUST_BIN, DOCK_TASK_DRY_DOCK_BAG}
+)
+ROBOT_START_STOP_REQUIRED_DOCK_TASKS = frozenset({DOCK_TASK_EMPTY_DUSTBIN, DOCK_TASK_WASH_MOP})
 
 
 def has_blocking_error(state: NarwalState | None) -> bool:
@@ -84,6 +89,7 @@ def is_clean_session_context(state: NarwalState | None) -> bool:
         or state.working_status in ACTIVE_CLEANING_STATUSES
         or state.working_status == WorkingStatus.TASK_COMPLETED
         or state.has_recent_active_working_status
+        or state.has_paused_clean_task_context
         or state.is_returning
     )
 
@@ -97,6 +103,7 @@ def is_robot_work_context(state: NarwalState | None) -> bool:
         or state.has_assumed_robot_clean
         or state.working_status in ACTIVE_CLEANING_STATUSES
         or state.has_recent_active_working_status
+        or state.has_paused_clean_task_context
         or state.is_returning
     )
 
@@ -140,9 +147,32 @@ def can_start_robot_clean(state: NarwalState | None) -> bool:
         return False
     if state.working_status == WorkingStatus.UNKNOWN:
         return False
-    if state.has_assumed_robot_clean:
+    if not state.is_docked or is_clean_session_context(state):
         return False
+    if state.has_unmapped_active_dock_task or state.assumed_active_dock_task is not None:
+        return False
+    active_tasks = set(state.active_dock_task_keys)
+    if active_tasks:
+        return active_tasks <= ROBOT_START_COMPATIBLE_DOCK_TASKS and active_tasks <= set(
+            state.telemetry_dock_task_keys
+        )
     return not state.blocks_robot_start_for_dock_task
+
+
+def dock_task_blocks_robot_return(state: NarwalState | None) -> bool:
+    """Return True when dock work should block recalling an off-dock robot."""
+    if state is None:
+        return False
+    if state.has_unmapped_active_dock_task:
+        return True
+    if state.assumed_active_dock_task is not None:
+        return state.assumed_active_dock_task not in ROBOT_RETURN_COMPATIBLE_DOCK_TASKS
+    if not state.is_station_active:
+        return False
+    active_tasks = set(state.active_dock_task_keys)
+    if not active_tasks:
+        return True
+    return not active_tasks <= ROBOT_RETURN_COMPATIBLE_DOCK_TASKS
 
 
 def can_stop_dock_task(state: NarwalState | None, task_key: str | None = None) -> bool:

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -122,6 +122,7 @@ def _clean_session_context(state: NarwalState) -> bool:
         or state.working_status in ACTIVE_CLEANING_STATUSES
         or state.working_status == WorkingStatus.TASK_COMPLETED
         or state.has_recent_active_working_status
+        or state.has_paused_clean_task_context
         or state.is_returning
     )
 
@@ -133,13 +134,20 @@ def _robot_work_blocks_generic_dock_stop(state: NarwalState) -> bool:
         or state.has_assumed_robot_clean
         or state.working_status in ACTIVE_CLEANING_STATUSES
         or state.has_recent_active_working_status
+        or state.has_paused_clean_task_context
         or state.is_returning
     )
 
 
 def _robot_start_blocked(state: NarwalState) -> bool:
-    """Return true when a private guard or dock task blocks a start."""
-    return state.has_assumed_robot_clean or state.blocks_robot_start_for_dock_task
+    """Return true unless fresh state permits dispatching a robot start."""
+    return (
+        state.has_error
+        or state.working_status in (WorkingStatus.UNKNOWN, WorkingStatus.ERROR)
+        or not state.is_docked
+        or _clean_session_context(state)
+        or state.blocks_robot_start_for_dock_task
+    )
 
 
 def _can_force_end_scoped_dock_task(state: NarwalState, task: str | None) -> bool:
@@ -177,33 +185,6 @@ def _base_status_working_status(decoded: dict[str, Any] | object) -> WorkingStat
         return WorkingStatus(int(field3["1"]))
     except (TypeError, ValueError):
         return None
-
-
-def _base_status_confirms_docked(
-    decoded: dict[str, Any] | object, status: WorkingStatus | None
-) -> bool:
-    """Return true when a terminal status also carries live dock indicators."""
-    if not isinstance(decoded, dict) or status not in _STALE_DOCK_BASE_STATUSES:
-        return False
-
-    field3 = decoded.get("3")
-    if isinstance(field3, list):
-        field3 = field3[0] if field3 else None
-    field3 = field3 if isinstance(field3, dict) else {}
-
-    def int_field(container: dict[str, Any], field: str) -> int:
-        try:
-            return int(container.get(field, 0))
-        except (TypeError, ValueError):
-            return 0
-
-    return (
-        int_field(decoded, "11") >= 2
-        or int_field(decoded, "47") in (1, 3)
-        or int_field(field3, "3") in (1, 6)
-        or int_field(field3, "10") == 1
-        or int_field(field3, "12") > 0
-    )
 
 
 def _base_status_payload(response: CommandResponse) -> dict[str, Any] | None:
@@ -360,7 +341,6 @@ class NarwalClient:
         if (
             self.state.has_recent_active_working_status
             and status in _STALE_DOCK_BASE_STATUSES
-            and not _base_status_confirms_docked(decoded, status)
         ):
             self.state.update_battery_from_base_status(decoded)
             _LOGGER.debug(
@@ -1226,14 +1206,14 @@ class NarwalClient:
         Newer firmware answers SUCCESS there and does nothing, so this path
         fails clearly when no room list is available instead (#69).
         """
+        if not self.connected:
+            raise NarwalConnectionError("Not connected to vacuum")
         if _robot_start_blocked(self.state):
             _LOGGER.warning(
                 "start: robot or dock task active (%s); not starting whole-house clean",
                 self.state.active_dock_task_keys or "unmapped",
             )
             return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
-        if not self.connected:
-            raise NarwalConnectionError("Not connected to vacuum")
         room_ids = await self._all_room_ids()
         if not room_ids:
             _LOGGER.warning("start(): no map rooms available")
@@ -1518,7 +1498,11 @@ class NarwalClient:
 
             map_data = self.state.map_data
             if not map_data or not map_data.map_id:
-                map_data = await self.get_map()
+                try:
+                    map_data = await self.get_map()
+                except NarwalCommandError as err:
+                    _LOGGER.warning("start_rooms: map fetch failed: %s", err)
+                    map_data = self.state.map_data
             map_id = map_data.map_id if map_data else 0
             if not map_id:
                 _LOGGER.warning(
@@ -1541,6 +1525,11 @@ class NarwalClient:
             except ValueError as err:
                 _LOGGER.warning("start_rooms: %s", err)
                 return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            if _robot_start_blocked(self.state):
+                _LOGGER.warning(
+                    "start_rooms: state changed before dispatch; not starting room clean"
+                )
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
             resp = await self.send_command(
                 TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
             )
@@ -1556,6 +1545,11 @@ class NarwalClient:
                     break
                 _LOGGER.info("start_rooms: robot docking/settling, retrying clean/start_clean")
                 await asyncio.sleep(3.0)
+                if _robot_start_blocked(self.state):
+                    _LOGGER.warning(
+                        "start_rooms: state changed before retry; not starting room clean"
+                    )
+                    return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
                 resp = await self.send_command(
                     TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
                 )

--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -351,6 +351,17 @@ class NarwalClient:
 
         self.state.update_from_base_status(decoded)
 
+    def _update_from_display_map_broadcast(self, decoded: dict[str, Any]) -> None:
+        """Apply a display-map broadcast and mark the trajectory as fresh."""
+        self.state.map_display_data = MapDisplayData.from_broadcast(decoded)
+        self._last_display_map_time = time.monotonic()
+        _LOGGER.debug(
+            "display_map received: robot=(%.2f, %.2f) ts=%d",
+            self.state.map_display_data.robot_x,
+            self.state.map_display_data.robot_y,
+            self.state.map_display_data.timestamp,
+        )
+
     async def connect(self) -> None:
         """Establish WebSocket connection to the vacuum.
 
@@ -646,14 +657,7 @@ class NarwalClient:
         elif short_topic == "status/download_status":
             self.state.update_from_download_status(decoded)
         elif short_topic == "map/display_map":
-            self.state.map_display_data = MapDisplayData.from_broadcast(decoded)
-            self._last_display_map_time = time.monotonic()
-            _LOGGER.debug(
-                "display_map received: robot=(%.2f, %.2f) ts=%d",
-                self.state.map_display_data.robot_x,
-                self.state.map_display_data.robot_y,
-                self.state.map_display_data.timestamp,
-            )
+            self._update_from_display_map_broadcast(decoded)
         if self.on_state_update:
             self.on_state_update(self.state)
 
@@ -706,7 +710,7 @@ class NarwalClient:
         """Encode a protobuf string field."""
         return cls._encode_bytes_field(field_num, text.encode("utf-8"))
 
-    # All broadcast topics the robot can send — used for active_robot_publish
+    # Broadcast topics needed for state, maps and diagnostics.
     _ALL_BROADCAST_TOPICS = [
         "status/robot_base_status",
         "status/working_status",
@@ -714,8 +718,6 @@ class NarwalClient:
         "status/download_status",
         "map/display_map",
         "status/time_line_status",
-        "status/point_navi_plan_traj",
-        "developer/planning_debug_info",
     ]
 
     def _build_topic_subscription(self, duration: int = 600) -> bytes:
@@ -1142,7 +1144,7 @@ class NarwalClient:
             elif short_topic == "status/download_status":
                 self.state.update_from_download_status(decoded)
             elif short_topic == "map/display_map":
-                self.state.map_display_data = MapDisplayData.from_broadcast(decoded)
+                self._update_from_display_map_broadcast(decoded)
 
         raise NarwalCommandError(
             f"No field5 response within {timeout}s"

--- a/custom_components/narwal/narwal_client/const.py
+++ b/custom_components/narwal/narwal_client/const.py
@@ -68,7 +68,6 @@ TOPIC_UPGRADE_STATUS = "upgrade/upgrade_status"
 TOPIC_DOWNLOAD_STATUS = "status/download_status"
 TOPIC_DISPLAY_MAP = "map/display_map"
 TOPIC_TIMELINE_STATUS = "status/time_line_status"
-TOPIC_PLANNING_DEBUG = "developer/planning_debug_info"
 
 # --- Command topics (client → robot, confirmed working) ---
 # Common

--- a/custom_components/narwal/narwal_client/map_renderer.py
+++ b/custom_components/narwal/narwal_client/map_renderer.py
@@ -18,6 +18,10 @@ import io
 import logging
 import math
 import zlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from PIL import Image, ImageDraw
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -123,7 +127,7 @@ def _load_font(image_font: object, size: int):
     for path in FONT_PATHS:
         try:
             return image_font.truetype(path, size)
-        except (IOError, OSError):
+        except OSError:
             continue
     return image_font.load_default()
 
@@ -135,7 +139,7 @@ def _scaled_coord(value: float, scale: float, size: int) -> int:
 
 
 def _draw_label(
-    draw: "ImageDraw.ImageDraw",
+    draw: ImageDraw.ImageDraw,
     xy: tuple[int, int],
     text: str,
     font: object,
@@ -388,7 +392,7 @@ def _darken(color: tuple[int, int, int], amount: int = 80) -> tuple[int, int, in
 
 
 def _draw_dock(
-    draw: "ImageDraw.ImageDraw",
+    draw: ImageDraw.ImageDraw,
     dock_x: int,
     dock_y: int,
     size: int = 6,
@@ -428,7 +432,7 @@ def _draw_dock(
 
 
 def _draw_robot(
-    draw: "ImageDraw.ImageDraw",
+    draw: ImageDraw.ImageDraw,
     rx: int,
     ry: int,
     heading: float | None,
@@ -482,7 +486,6 @@ def _draw_robot(
     )
 
     # Flow-style front sensor bar, rotated with heading.
-    front_centre = point(radius * 0.58, 0)
     bar_half_width = radius * 0.38
     bar_half_height = max(2, radius * 0.13)
     bar = [
@@ -594,10 +597,11 @@ def render_map_png(
             room_id = val >> 8
             ptype = val & 0xFF
 
-            if 1 <= room_id <= len(ROOM_COLORS):
-                base = ROOM_COLORS[room_id - 1]
-            else:
-                base = COLOR_FALLBACK
+            base = (
+                ROOM_COLORS[room_id - 1]
+                if 1 <= room_id <= len(ROOM_COLORS)
+                else COLOR_FALLBACK
+            )
 
             if ptype & 0x10:  # wall/border edge
                 px[x, y] = _opaque(_darken(base))
@@ -691,13 +695,13 @@ def render_base_map(
     dock_x: float | None = None,
     dock_y: float | None = None,
     room_names: dict[int, str] | None = None,
-    obstacles: "list | None" = None,
+    obstacles: list | None = None,
     origin_x: int = 0,
     origin_y: int = 0,
     show_obstacle_labels: bool = True,
     show_room_labels: bool = True,
     show_dock: bool = True,
-) -> "Image.Image | None":
+) -> Image.Image | None:
     """Render the static floor plan as a PIL Image (no robot overlay).
 
     Returns a PIL Image that can be cached and reused across frames.
@@ -750,10 +754,11 @@ def render_base_map(
             room_id = val >> 8
             ptype = val & 0xFF
 
-            if 1 <= room_id <= len(ROOM_COLORS):
-                base = ROOM_COLORS[room_id - 1]
-            else:
-                base = COLOR_FALLBACK
+            base = (
+                ROOM_COLORS[room_id - 1]
+                if 1 <= room_id <= len(ROOM_COLORS)
+                else COLOR_FALLBACK
+            )
 
             if ptype & 0x10:
                 px[x, y] = _opaque(_darken(base))
@@ -847,7 +852,7 @@ def render_base_map(
 
 
 def render_overlay(
-    base_img: "Image.Image",
+    base_img: Image.Image,
     height: int,
     robot_x: float | None = None,
     robot_y: float | None = None,
@@ -867,7 +872,7 @@ def render_overlay(
         robot_x: Robot X in grid coordinates.
         robot_y: Robot Y in grid coordinates.
         robot_heading: Heading in degrees.
-        trail: List of (grid_x, grid_y) positions to draw as cleaning path.
+        trail: Narwal-native display_map trajectory points in grid coordinates.
         rotation_degrees: Clockwise map rotation in degrees.
         zoom: Centre zoom factor.
         room_labels: Room label centre points in grid coordinates.
@@ -910,10 +915,9 @@ def render_overlay(
         tx, ty = transformed
         return int(round(tx)), int(round(ty))
 
-    # Draw trail, splitting at invalid samples or impossible jumps.
+    # Draw the Narwal-native trajectory, skipping invalid or discontinuous points.
     if trail and len(trail) >= 2:
-        recent_start = max(len(trail) - 200, 0)
-        trail_width = max(3, int(round(2 * scale)))
+        trail_width = max(1, int(round(scale)))
         previous_grid: tuple[float, float] | None = None
         previous_point: tuple[int, int] | None = None
         for i in range(len(trail) - 1):
@@ -935,12 +939,11 @@ def render_overlay(
                     grid_y - previous_grid[1],
                 )
                 if distance <= max_grid_segment:
-                    color = (
-                        (255, 255, 255, 220)
-                        if i >= recent_start
-                        else (215, 220, 225, 130)
+                    draw.line(
+                        [previous_point, point],
+                        fill=(255, 255, 255, 220),
+                        width=trail_width,
                     )
-                    draw.line([previous_point, point], fill=color, width=trail_width)
 
             previous_grid = (grid_x, grid_y)
             previous_point = point
@@ -1000,10 +1003,10 @@ def render_overlay(
 
 
 def _apply_view_transform(
-    img: "Image.Image",
+    img: Image.Image,
     rotation_degrees: int = 0,
     zoom: float = 1.0,
-) -> "Image.Image":
+) -> Image.Image:
     """Apply final map rotation and centre zoom."""
     rotation = _normalize_rotation(rotation_degrees)
     if rotation:

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import math
 import struct
 import time
+import zlib
 from dataclasses import dataclass, field
 from typing import Any, ClassVar
 
@@ -251,12 +253,132 @@ def _to_float32(val: Any) -> float | None:
     return None
 
 
+def overlay_to_grid(value: float, origin: int) -> float | None:
+    """Convert a Narwal map/display_map coordinate to a grid coordinate."""
+    if not math.isfinite(value):
+        return None
+    return value - origin
+
+
 def _optional_int(value: Any) -> int | None:
     """Coerce a protobuf scalar to int when possible."""
     try:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+def _packed_float32_values(value: Any) -> list[float]:
+    """Decode a protobuf packed fixed32/float stream."""
+    if isinstance(value, (bytes, bytearray)):
+        raw = bytes(value)
+        return [
+            struct.unpack_from("<f", raw, offset)[0]
+            for offset in range(0, len(raw) - len(raw) % 4, 4)
+        ]
+    if isinstance(value, str):
+        raw = value.encode("latin-1", "ignore")
+        return [
+            struct.unpack_from("<f", raw, offset)[0]
+            for offset in range(0, len(raw) - len(raw) % 4, 4)
+        ]
+    if isinstance(value, list):
+        values: list[float] = []
+        for item in value:
+            parsed = _to_float32(item)
+            if parsed is not None:
+                values.append(parsed)
+        return values
+    return []
+
+
+def _packed_float32_bytes(value: Any) -> bytes:
+    """Return raw packed float32 bytes from a protobuf field."""
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value)
+    if isinstance(value, str):
+        return value.encode("latin-1", "ignore")
+    if isinstance(value, list):
+        raw = bytearray()
+        for item in value:
+            parsed = _to_float32(item)
+            raw.extend(struct.pack("<f", parsed if parsed is not None else float("nan")))
+        return bytes(raw)
+    return b""
+
+
+def _decode_trajectory(
+    x_values: bytes,
+    y_values: bytes,
+) -> list[tuple[float, float]]:
+    """Decode map/display_map field 2 into Narwal-native trajectory points."""
+    import math
+
+    xs = _packed_float32_values(x_values)
+    ys = _packed_float32_values(y_values)
+    # X/Y are parallel streams. Filter after zipping so one invalid value
+    # drops that coordinate pair instead of shifting the axes.
+    return [
+        (x, y)
+        for x, y in zip(xs, ys, strict=False)
+        if math.isfinite(x) and math.isfinite(y)
+    ]
+
+
+def _trajectory_window_streams(
+    decoded: dict[str, Any],
+) -> tuple[
+    bytes,
+    bytes,
+    tuple[int, int, int] | tuple[()],
+    tuple[int, ...],
+]:
+    """Return one native trajectory window and its deterministic signature."""
+    raw = decoded.get("2")
+    if not isinstance(raw, dict):
+        return b"", b"", (), ()
+    x_values = _packed_float32_bytes(raw.get("1"))
+    y_values = _packed_float32_bytes(raw.get("2"))
+    pair_bytes = min(len(x_values), len(y_values))
+    pair_bytes -= pair_bytes % 4
+    if pair_bytes <= 0:
+        return b"", b"", (), ()
+    finite_x = bytearray()
+    finite_y = bytearray()
+    breaks: list[int] = []
+    pending_break = False
+    for offset in range(0, pair_bytes, 4):
+        x_chunk = x_values[offset : offset + 4]
+        y_chunk = y_values[offset : offset + 4]
+        x = struct.unpack("<f", x_chunk)[0]
+        y = struct.unpack("<f", y_chunk)[0]
+        if not (math.isfinite(x) and math.isfinite(y)):
+            pending_break = bool(finite_x)
+            continue
+        if pending_break:
+            breaks.append(len(finite_x) // 4)
+            pending_break = False
+        finite_x.extend(x_chunk)
+        finite_y.extend(y_chunk)
+    if not finite_x:
+        return b"", b"", (), ()
+    x_values = bytes(finite_x)
+    y_values = bytes(finite_y)
+    trajectory_breaks = tuple(breaks)
+    break_bytes = b"".join(
+        index.to_bytes(4, "little", signed=False) for index in trajectory_breaks
+    )
+    return (
+        x_values,
+        y_values,
+        (
+            len(x_values) // 4,
+            zlib.crc32(x_values) & 0xFFFFFFFF,
+            zlib.crc32(break_bytes, zlib.crc32(y_values)) & 0xFFFFFFFF,
+        ),
+        trajectory_breaks,
+    )
+
 
 
 def _dock_drying_timers(decoded: dict[str, Any]) -> dict[str, DockTaskTimer]:
@@ -447,7 +569,8 @@ class MapData:
 
         # Extract origin offsets from field 6 (coordinate transform).
         # Field 6: {1: origin_y, 2: ?, 3: origin_x, 4: resolution}
-        # Positions are in grid-offset units: pixel = raw - origin
+        # field 6 provides grid origin offsets used by live map overlays:
+        # pixel = value - origin
         origin_x = 0
         origin_y = 0
         field6 = payload.get("6")
@@ -458,10 +581,10 @@ class MapData:
                 origin_y = int(field6.get("1", 0))
 
         # Parse dock position from field 8 (dock/charging station location).
-        # Field 8 structure: {1: {1: x_dm, 2: y_dm}, 2: heading_rad}
-        # Coordinates are in decimeters (same as display_map field 5).
+        # Field 8 structure: {1: {1: x, 2: y}, 2: heading_rad}
+        # Coordinates use the same live map units as display_map field 5.
         # Matches display_map field 5 (confirmed via live capture cross-reference).
-        # Pixel transform: px = (x_dm * 10) / cm_per_pixel - origin
+        # Pixel transform: px = value - origin
         dock_x = None
         dock_y = None
         field8 = payload.get("8")
@@ -469,11 +592,11 @@ class MapData:
             pos = field8.get("1")
             if isinstance(pos, dict) and "1" in pos and "2" in pos:
                 try:
-                    x_dm = _to_float32(pos["1"])
-                    y_dm = _to_float32(pos["2"])
-                    if x_dm is not None and y_dm is not None:
-                        dock_x = x_dm - origin_x
-                        dock_y = y_dm - origin_y
+                    x_pos = _to_float32(pos["1"])
+                    y_pos = _to_float32(pos["2"])
+                    if x_pos is not None and y_pos is not None:
+                        dock_x = overlay_to_grid(x_pos, origin_x)
+                        dock_y = overlay_to_grid(y_pos, origin_y)
                 except (struct.error, OverflowError, ValueError, TypeError):
                     pass
 
@@ -505,35 +628,60 @@ class MapData:
 class MapDisplayData:
     """Real-time robot position from map/display_map broadcasts.
 
-    Sent every ~1.5s during active cleaning. Contains robot position in cm,
+    Sent every ~1.5s during active cleaning. Contains robot position,
     heading in radians, and a small cleaned-area grid overlay (NOT the full
     house map — that comes from get_map).
 
     Validated field layout (live capture 2026-02-28, 13 broadcasts):
-      field 1.1: {1: x_cm, 2: y_cm} — robot position as float32 centimeters
+      field 1.1: {1: x, 2: y} — robot position as float32 map coordinates
       field 1.2: heading as float32 radians
+      field 2: rolling trajectory window {1: x_bytes, 2: y_bytes}
       field 5: dock/reference position (constant, same format)
       field 7: cleaned-area grid {1: width, 2: height, 3: compressed_bytes}
       field 10: timestamp in milliseconds since epoch
       field 12: active room list
     """
 
-    robot_x: float = 0.0  # decimeters, world coordinates
-    robot_y: float = 0.0  # decimeters, world coordinates
+    robot_x: float = 0.0  # live map X coordinate
+    robot_y: float = 0.0  # live map Y coordinate
     robot_heading: float = 0.0  # degrees (converted from radians for renderer)
     timestamp: int = 0  # milliseconds since epoch (field 10)
     # Dock/reference position from field 5 (same coordinate system as robot)
     dock_ref_x: float = 0.0
     dock_ref_y: float = 0.0
+    trajectory_x_values: bytes = b""
+    trajectory_y_values: bytes = b""
+    trajectory_signature: tuple[int, int, int] | tuple[()] = ()
+    trajectory_breaks: tuple[int, ...] = ()
+
+    @property
+    def has_trajectory(self) -> bool:
+        """Return true when display_map carried a native trajectory."""
+        return bool(self.trajectory_signature)
+
+    def trajectory_points(self) -> list[tuple[float, float]]:
+        """Decode Narwal-native trajectory points from display_map field 2."""
+        return _decode_trajectory(
+            self.trajectory_x_values,
+            self.trajectory_y_values,
+        )
+
+    def trajectory_render_points(self) -> list[tuple[float, float]]:
+        """Return trajectory points with invalid sentinels at segment breaks."""
+        points = self.trajectory_points()
+        for index in reversed(self.trajectory_breaks):
+            if 0 < index < len(points):
+                points.insert(index, (float("nan"), float("nan")))
+        return points
 
     def to_grid_coords(
         self, resolution: int, origin_x: int, origin_y: int,
     ) -> tuple[float, float] | None:
-        """Convert world-coordinate position (dm) to grid pixel coordinates.
+        """Convert live map position to grid pixel coordinates.
 
-        display_map positions are in decimeters (validated via live capture).
+        display_map positions already use the static map coordinate scale.
         Same coordinate system as get_map field 8 (dock position).
-          pixel = (x_dm * 10) / cm_per_pixel - origin_offset
+          pixel = value - origin_offset
 
         Args:
             resolution: Map resolution in mm/pixel (e.g. 60).
@@ -547,9 +695,10 @@ class MapDisplayData:
             return None
         if resolution <= 0:
             return None
-        # Positions are in grid-offset units: pixel = raw - origin
-        px = self.robot_x - origin_x
-        py = self.robot_y - origin_y
+        px = overlay_to_grid(self.robot_x, origin_x)
+        py = overlay_to_grid(self.robot_y, origin_y)
+        if px is None or py is None:
+            return None
         return (px, py)
 
     @classmethod
@@ -576,6 +725,16 @@ class MapDisplayData:
                 h_f = _to_float32(heading_raw)
                 if h_f is not None and math.isfinite(h_f):
                     result.robot_heading = math.degrees(h_f)
+
+        # Rolling cleaning trajectory window from Narwal itself. Keep raw
+        # streams here so HA can join exact overlapping windows without
+        # sampling robot positions or decoding the route on the event loop.
+        (
+            result.trajectory_x_values,
+            result.trajectory_y_values,
+            result.trajectory_signature,
+            result.trajectory_breaks,
+        ) = _trajectory_window_streams(decoded)
 
         # Dock/reference position — field 5 (same format as field 1)
         field5 = decoded.get("5", {})
@@ -1047,6 +1206,7 @@ class NarwalState:
     def assume_robot_clean(self) -> None:
         """Temporarily reserve robot-clean command context after an accepted start."""
         self.assumed_robot_clean_until = time.monotonic() + _ROBOT_START_ASSUME_TTL
+        self.map_display_data = None
 
     def clear_assumed_robot_clean(self) -> None:
         """Clear the local robot-clean command reservation."""

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -1207,6 +1207,11 @@ class NarwalState:
                     self.working_status = WorkingStatus.UNKNOWN
                 if self.working_status not in ACTIVE_CLEANING_STATUSES:
                     self.last_active_working_status_time = 0.0
+                if self.working_status in {
+                    WorkingStatus.TASK_COMPLETED,
+                    WorkingStatus.ERROR,
+                }:
+                    self.clear_assumed_robot_clean()
             # Sub-field 2: paused overlay (0 or absent = not paused, 1 = paused)
             self.is_paused = bool(field3.get("2"))
             # Sub-field 7: returning to dock on old FW (value 1 = returning).

--- a/custom_components/narwal/narwal_client/models.py
+++ b/custom_components/narwal/narwal_client/models.py
@@ -23,9 +23,15 @@ _LOGGER = logging.getLogger(__name__)
 _WARNED_WORKING_STATUS: set[Any] = set()
 
 _ACTIVE_WORKING_STATUS_TTL = 15.0
+_TERMINAL_WORKING_STATUS_TTL = 15.0
 _DOCK_DRYING_STATUS_TTL = 180.0
 _DOCK_TASK_ASSUME_TTL = 30.0
-_ROBOT_START_ASSUME_TTL = 30.0
+# clean/start_clean can be accepted long before working_status metrics arrive.
+_ROBOT_START_ASSUME_TTL = 180.0
+# Live hardware has taken about 50 seconds to leave a stale docked status after
+# accepting a room clean. After this handoff window, repeated idle dock
+# telemetry is stronger evidence than the accepted-command reservation.
+_ROBOT_START_DOCKED_HANDOFF_GRACE = 60.0
 _KNOWN_DOCK_ACTIVITY_VALUES = {0, 2, 3, 4, 6}
 
 DOCK_TASK_EMPTY_DUSTBIN = "empty_dustbin"
@@ -649,6 +655,15 @@ class NarwalState:
     cleaning_area: float = 0.0  # m² (coveredArea)
     cleaning_time: int = 0  # seconds
     last_active_working_status_time: float = 0.0
+    last_terminal_working_status_time: float = 0.0
+    pending_active_working_status: dict[str, Any] | None = field(
+        default=None, repr=False
+    )
+    pending_active_working_status_time: float = 0.0
+    task_progress_percent: int | None = None
+    task_elapsed_time: int = 0
+    task_remaining_time: int = 0
+    current_room_aux_name: str = ""
 
     # Consumables / station / fault (base_status; present on dock and during cleaning)
     dust_bag_health: float = 0.0  # field 35 stationBagHealthScore (%)
@@ -743,8 +758,6 @@ class NarwalState:
     @property
     def has_recent_active_working_status(self) -> bool:
         """True while live working_status task metrics are still fresh."""
-        if self.working_status not in ACTIVE_CLEANING_STATUSES:
-            return False
         if self.last_active_working_status_time <= 0:
             return False
         return (
@@ -753,13 +766,24 @@ class NarwalState:
         )
 
     @property
+    def has_recent_terminal_working_status(self) -> bool:
+        """True just after authoritative terminal base-status telemetry."""
+        if self.last_terminal_working_status_time <= 0:
+            return False
+        return (
+            time.monotonic() - self.last_terminal_working_status_time
+            <= _TERMINAL_WORKING_STATUS_TTL
+        )
+
+    @property
     def has_paused_clean_task_context(self) -> bool:
         """True when a paused overlay still has retained robot clean details."""
-        if not self.is_paused or self.is_docked:
+        if not self.is_paused:
             return False
         return (
             getattr(self, "task_progress_percent", None) is not None
-            or getattr(self, "task_elapsed_time", self.cleaning_time) > 0
+            or getattr(self, "task_elapsed_time", 0) > 0
+            or self.cleaning_time > 0
             or getattr(self, "task_remaining_time", 0) > 0
             or self.current_room_id is not None
             or bool(getattr(self, "current_room_aux_name", ""))
@@ -775,7 +799,7 @@ class NarwalState:
         return (
             self.working_status in ACTIVE_CLEANING_STATUSES
             and not self.is_paused
-            and not self.is_returning_to_dock
+            and not self.is_returning
         )
 
     @property
@@ -810,14 +834,14 @@ class NarwalState:
         cleaning is not active, since the robot can report unmapped states
         (e.g. self-test) while physically docked.
         """
+        if self.has_recent_active_working_status:
+            return False
         if self.has_explicit_off_dock_signal:
             return False
         if self.working_status in (
             WorkingStatus.DOCKED, WorkingStatus.CHARGED, WorkingStatus.DOCKED_V2,
         ):
             return True
-        if self.has_recent_active_working_status:
-            return False
         if self.working_status in ACTIVE_CLEANING_STATUSES:
             return False
         # For STANDBY, UNKNOWN, or any other status: check dock field signals.
@@ -871,6 +895,12 @@ class NarwalState:
     @property
     def is_station_active(self) -> bool:
         """True when the dock/base station is running a dock-side task."""
+        if self.has_recent_active_working_status:
+            return (
+                self.station_activity in (1, 2, 3)
+                or self.is_washing_mop
+                or bool(self.active_dock_drying_tasks)
+            )
         return (
             self.is_washing_mop
             or self.is_drying_mop
@@ -895,9 +925,9 @@ class NarwalState:
         if not telemetry_tasks:
             return False
         return not (
-            telemetry_tasks == {DOCK_TASK_DRY_DOCK_BAG}
+            telemetry_tasks.issubset(_DOCK_DRYING_TASK_ORDER)
             and self.has_recent_dock_drying_status
-            and self.dock_task_timer(DOCK_TASK_DRY_DOCK_BAG) is not None
+            and all(self.dock_task_timer(task) is not None for task in telemetry_tasks)
         )
 
     @property
@@ -926,12 +956,17 @@ class NarwalState:
     def telemetry_dock_task_keys(self) -> tuple[str, ...]:
         """Return active dock task keys from robot telemetry only."""
         tasks: list[str] = []
-        if self.station_activity == 1:
-            tasks.append(DOCK_TASK_EMPTY_DUSTBIN)
-        if self.is_washing_mop:
-            tasks.append(DOCK_TASK_WASH_MOP)
+        if not self.has_recent_active_working_status:
+            if self.station_activity == 1:
+                tasks.append(DOCK_TASK_EMPTY_DUSTBIN)
+            if self.is_washing_mop:
+                tasks.append(DOCK_TASK_WASH_MOP)
         tasks.extend(self.telemetry_dock_drying_tasks)
-        if self.is_drying_mop and DOCK_TASK_DRY_MOP not in tasks:
+        if (
+            not self.has_recent_active_working_status
+            and self.is_drying_mop
+            and DOCK_TASK_DRY_MOP not in tasks
+        ):
             tasks.append(DOCK_TASK_DRY_MOP)
         active = set(tasks)
         return tuple(task for task in DOCK_TASK_KEYS if task in active)
@@ -1017,6 +1052,39 @@ class NarwalState:
         """Clear the local robot-clean command reservation."""
         self.assumed_robot_clean_until = 0.0
 
+    def _clear_assumed_robot_clean_on_terminal_base_status(
+        self,
+        *,
+        is_paused: bool,
+    ) -> None:
+        """Clear accepted-start context once base status proves it is terminal."""
+        if not self.has_assumed_robot_clean:
+            return
+        if self.has_error or self.working_status == WorkingStatus.ERROR:
+            self.clear_assumed_robot_clean()
+            return
+        if self.working_status == WorkingStatus.TASK_COMPLETED:
+            self.clear_assumed_robot_clean()
+            return
+        handoff_ends = (
+            self.assumed_robot_clean_until
+            - _ROBOT_START_ASSUME_TTL
+            + _ROBOT_START_DOCKED_HANDOFF_GRACE
+        )
+        if (
+            not is_paused
+            and time.monotonic() >= handoff_ends
+            and self.working_status
+            in (
+                WorkingStatus.STANDBY,
+                WorkingStatus.DOCKED,
+                WorkingStatus.CHARGED,
+                WorkingStatus.DOCKED_V2,
+            )
+            and self.is_docked
+        ):
+            self.clear_assumed_robot_clean()
+
     def dock_task_timer(self, task: str) -> DockTaskTimer | None:
         """Return timer details for one active dock task."""
         timer = self.dock_drying_tasks.get(task)
@@ -1074,11 +1142,68 @@ class NarwalState:
         if self.current_room_id is None:
             return None
         if self.map_data is None:
-            return None
+            return self.current_room_aux_name or None
         for room in self.map_data.rooms:
             if room.room_id == self.current_room_id:
                 return room.display_name
+        return self.current_room_aux_name or None
+
+    def clear_task_details(self) -> None:
+        """Clear active robot-task detail fields."""
+        self.is_paused = False
+        self.cleaning_area = 0.0
+        self.cleaning_time = 0
+        self.task_progress_percent = None
+        self.task_elapsed_time = 0
+        self.task_remaining_time = 0
+        self.current_room_id = None
+        self.current_room_aux_name = ""
+
+    @staticmethod
+    def _task_progress_percent(value: Any) -> int | None:
+        """Return a percent for task progress encoded as percent or 0..1 float."""
+        if isinstance(value, float):
+            if 0.0 <= value <= 1.0:
+                return round(value * 100)
+            if 0.0 <= value <= 100.0:
+                return round(value)
+        progress = _optional_int(value)
+        if progress is not None and 0 <= progress <= 100:
+            return progress
+        progress_float = _to_float32(value)
+        if progress_float is None:
+            return None
+        if 0.0 <= progress_float <= 1.0:
+            return round(progress_float * 100)
+        if 0.0 <= progress_float <= 100.0:
+            return round(progress_float)
         return None
+
+    def _update_current_room(self, payload: dict[str, Any]) -> None:
+        """Parse scalar and nested current-room working-status fields."""
+        room = payload.get("6")
+        if not isinstance(room, dict):
+            room = payload.get("8")
+        if isinstance(room, dict):
+            room_id = _optional_int(room.get("1"))
+            if room_id is not None:
+                self.current_room_id = room_id or None
+            name = room.get("3")
+            if isinstance(name, (bytes, bytearray)):
+                self.current_room_aux_name = bytes(name).decode(
+                    "utf-8", errors="replace"
+                )
+            else:
+                self.current_room_aux_name = str(name) if name else ""
+                if (
+                    self.current_room_aux_name.startswith("b'")
+                    and self.current_room_aux_name.endswith("'")
+                ):
+                    self.current_room_aux_name = self.current_room_aux_name[2:-1]
+        else:
+            room_id = _optional_int(payload.get("6"))
+            if room_id is not None:
+                self.current_room_id = room_id or None
 
     def update_from_working_status(self, decoded: dict[str, Any]) -> None:
         """Update state from a decoded working_status message.
@@ -1092,8 +1217,29 @@ class NarwalState:
         not area — reading it as area is why the sensor was stuck at 1.8 m².
         """
         self.raw_working_status = decoded
+        reported_task_details: dict[str, Any] = {}
+        previous_task_details = (
+            self.task_progress_percent,
+            self.cleaning_area,
+            self.cleaning_time,
+            self.task_remaining_time,
+            self.current_room_id,
+            self.current_room_aux_name,
+        )
+        progress = self._task_progress_percent(decoded.get("1"))
+        if progress is not None:
+            self.task_progress_percent = max(0, min(100, progress))
+            reported_task_details["progress"] = self.task_progress_percent
+        remaining = _optional_int(decoded.get("4"))
+        if remaining is not None:
+            self.task_remaining_time = max(0, remaining)
+            reported_task_details["remaining"] = self.task_remaining_time
+        has_robot_side_drying = False
         if _has_dock_drying_timer_fields(decoded):
             timers = _dock_drying_timers(decoded)
+            has_robot_side_drying = bool(
+                timers.keys() & {DOCK_TASK_DRY_MOP, DOCK_TASK_DRY_DUST_BIN}
+            )
             self.dock_drying_tasks = timers
             self.has_dock_drying_timer_snapshot = True
             self.has_unmapped_dock_drying_timer = _has_unmapped_dock_drying_timer(
@@ -1109,6 +1255,8 @@ class NarwalState:
         if "3" in decoded:
             try:
                 self.cleaning_time = int(decoded["3"])
+                self.task_elapsed_time = self.cleaning_time
+                reported_task_details["elapsed"] = self.cleaning_time
                 active_payload = active_payload or self.cleaning_time > 0
             except (ValueError, TypeError):
                 pass
@@ -1116,29 +1264,97 @@ class NarwalState:
             area = _to_float32(decoded["2"])
             if area is not None and area >= 0:
                 self.cleaning_area = area
+                reported_task_details["area"] = self.cleaning_area
                 active_payload = active_payload or area > 0
-        if "6" in decoded:
-            # Field 6 = current target room_id (confirmed 2026-04-24 from live capture:
-            # value changed 4→1 as robot moved from Corridor to Living Room).
-            try:
-                room_id = int(decoded["6"])
-                self.current_room_id = room_id if room_id != 0 else None
-            except (ValueError, TypeError):
-                pass
-        if active_payload:
-            if self.working_status != WorkingStatus.CUSTOM_CLEANING:
-                self.working_status = WorkingStatus.CLEANING
-            self.last_active_working_status_time = time.monotonic()
-            self.clear_assumed_robot_clean()
-            self.is_paused = False
-            self.is_returning_to_dock = False
-            self.dock_sub_state = 0
+        if "6" in decoded or isinstance(decoded.get("8"), dict):
+            # Field 6 is a scalar room id on Flow 2 and a nested room detail
+            # message on other firmware; field 8 is the alternate nested shape.
+            self._update_current_room(decoded)
+            reported_task_details["room"] = (
+                self.current_room_id,
+                self.current_room_aux_name,
+            )
+        current_task_details = (
+            self.task_progress_percent,
+            self.cleaning_area,
+            self.cleaning_time,
+            self.task_remaining_time,
+            self.current_room_id,
+            self.current_room_aux_name,
+        )
+        task_details_changed = previous_task_details != current_task_details
+        # Clean counters can arrive late from the previous session. Fresh
+        # empty/wash telemetry is authoritative because raw clean commands
+        # cannot start robot work during either task.
+        has_blocking_station_task = (
+            self.station_activity in (1, 2, 3)
+            or self.dock_activity == 3
+            or has_robot_side_drying
+            or self.assumed_active_dock_task
+            in (DOCK_TASK_EMPTY_DUSTBIN, DOCK_TASK_WASH_MOP)
+        )
+        explicit_terminal_status = self.working_status in {
+            WorkingStatus.TASK_COMPLETED,
+            WorkingStatus.ERROR,
+        }
+        now = time.monotonic()
+        pending_candidate = self.pending_active_working_status
+        pending_candidate_fresh = (
+            pending_candidate is not None
+            and now - self.pending_active_working_status_time
+            <= _TERMINAL_WORKING_STATUS_TTL
+        )
+        confirmed_external_clean = (
+            active_payload
+            and not explicit_terminal_status
+            and self.has_recent_terminal_working_status
+            and pending_candidate_fresh
+            and pending_candidate is not None
+            and any(
+                key in pending_candidate and pending_candidate[key] != value
+                for key, value in reported_task_details.items()
+            )
+        )
+        has_terminal_robot_status = not self.has_assumed_robot_clean and (
+            explicit_terminal_status
+            or (
+                self.has_recent_terminal_working_status
+                and not confirmed_external_clean
+            )
+        )
+        if (
+            active_payload
+            and not has_blocking_station_task
+            and not has_terminal_robot_status
+        ):
+            if task_details_changed:
+                self.last_active_working_status_time = now
+                self.is_paused = False
+            self.last_terminal_working_status_time = 0.0
+            self.pending_active_working_status = None
+            self.pending_active_working_status_time = 0.0
             self.dock_activity = 0
             self.station_activity = 0
             self.clear_assumed_dock_task()
-            self.dock_presence = 2
-            self.dock_field11 = 1
-            self.dock_field47 = 2
+        elif has_terminal_robot_status:
+            if active_payload and not explicit_terminal_status:
+                if not pending_candidate_fresh:
+                    self.pending_active_working_status = dict(reported_task_details)
+                    self.pending_active_working_status_time = now
+                else:
+                    assert pending_candidate is not None
+                    pending_candidate.update(reported_task_details)
+            else:
+                self.pending_active_working_status = None
+                self.pending_active_working_status_time = 0.0
+            self.clear_task_details()
+
+    def _update_battery_level(self, raw_value: Any) -> None:
+        """Update battery level from base-status telemetry."""
+        bat = _to_float32(raw_value)
+        if bat is None:
+            return
+        self.battery_level = round(bat)
 
     def update_from_base_status(self, decoded: dict[str, Any]) -> None:
         """Update state from a decoded robot_base_status message.
@@ -1162,6 +1378,8 @@ class NarwalState:
         Note: field 32 mirrors field 3 exactly (redundant).
         """
         self.raw_base_status = decoded
+        if "2" in decoded:
+            self._update_battery_level(decoded["2"])
         # Field 11 = dock indicator (2=docked, 1=undocked)
         if "11" in decoded:
             try:
@@ -1190,10 +1408,40 @@ class NarwalState:
         field3 = decoded.get("3")
         if isinstance(field3, list):
             field3 = field3[0] if field3 else None
+        current_reports_docked = False
         if isinstance(field3, dict):
+            is_paused = bool(field3.get("2"))
+            current_presence = _optional_int(field3.get("3"))
+            current_sub_state = _optional_int(field3.get("10"))
+            current_field11 = _optional_int(decoded.get("11"))
+            current_field47 = _optional_int(decoded.get("47"))
+            if current_presence is not None:
+                self.dock_presence = current_presence
+            if current_sub_state is not None:
+                self.dock_sub_state = current_sub_state
+            current_reports_docked = (
+                current_presence in (1, 6)
+                or current_sub_state == 1
+                or (current_field11 is not None and current_field11 >= 2)
+                or current_field47 in (1, 3)
+            )
+            current_reports_off_dock = (
+                current_presence == 2
+                or current_sub_state == 2
+                or (current_field11 == 1 and current_field47 == 2)
+            )
+            if current_reports_docked or current_reports_off_dock:
+                if current_presence is None:
+                    self.dock_presence = 0
+                if current_sub_state is None:
+                    self.dock_sub_state = 0
+                if current_field11 is None:
+                    self.dock_field11 = 0
+                if current_field47 is None:
+                    self.dock_field47 = 0
             if "1" in field3:
                 try:
-                    self.working_status = WorkingStatus(int(field3["1"]))
+                    next_working_status = WorkingStatus(int(field3["1"]))
                 except (ValueError, TypeError):
                     raw_val = field3["1"]
                     if raw_val not in _WARNED_WORKING_STATUS:
@@ -1203,24 +1451,46 @@ class NarwalState:
                             "Please report this value at the GitHub repo. "
                             "(further occurrences of this value are suppressed)",
                             raw_val,
-                        )
-                    self.working_status = WorkingStatus.UNKNOWN
-                if self.working_status not in ACTIVE_CLEANING_STATUSES:
+                    )
+                    next_working_status = WorkingStatus.UNKNOWN
+                self.working_status = next_working_status
+                terminal_robot = self.working_status in {
+                    WorkingStatus.TASK_COMPLETED,
+                    WorkingStatus.ERROR,
+                }
+                terminal_dock = self.working_status in {
+                    WorkingStatus.DOCKED,
+                    WorkingStatus.CHARGED,
+                    WorkingStatus.DOCKED_V2,
+                }
+                if terminal_robot or (
+                    terminal_dock and not self.has_explicit_off_dock_signal
+                ):
+                    self.last_terminal_working_status_time = time.monotonic()
+                elif (
+                    terminal_dock
+                    or current_reports_off_dock
+                    or self.working_status in ACTIVE_CLEANING_STATUSES
+                ):
+                    self.last_terminal_working_status_time = 0.0
+                if (
+                    self.working_status not in ACTIVE_CLEANING_STATUSES
+                    and not is_paused
+                    and not self.has_assumed_robot_clean
+                ):
                     self.last_active_working_status_time = 0.0
+                    self.clear_task_details()
                 if self.working_status in {
                     WorkingStatus.TASK_COMPLETED,
                     WorkingStatus.ERROR,
                 }:
                     self.clear_assumed_robot_clean()
             # Sub-field 2: paused overlay (0 or absent = not paused, 1 = paused)
-            self.is_paused = bool(field3.get("2"))
+            self.is_paused = is_paused
             # Sub-field 7: returning to dock on old FW (value 1 = returning).
             # On newer FW, field 7 is repurposed (e.g. value 7 during cleaning).
             # Only treat value 1 as returning — other values are not the flag.
             self.is_returning_to_dock = field3.get("7") == 1
-            if "10" in field3:
-                with contextlib.suppress(ValueError, TypeError):
-                    self.dock_sub_state = int(field3["10"])
             if "12" in field3:
                 with contextlib.suppress(ValueError, TypeError):
                     self.dock_activity = int(field3["12"])
@@ -1230,9 +1500,6 @@ class NarwalState:
             if "18" in field3:
                 with contextlib.suppress(ValueError, TypeError):
                     self.station_activity = int(field3["18"])
-            if "3" in field3:
-                with contextlib.suppress(ValueError, TypeError):
-                    self.dock_presence = int(field3["3"])
             if self.working_status in ACTIVE_CLEANING_STATUSES:
                 self.clear_assumed_robot_clean()
                 if "10" not in field3:
@@ -1299,12 +1566,41 @@ class NarwalState:
                 "Please report this at the GitHub repo.",
                 type(field3).__name__, field3,
             )
-        if "2" in decoded:
-            # Field 2 = real-time battery SOC as float32 (batteryPercentage)
-            # (e.g. 1118175232 → 83.0%; bbp may return int or float)
-            bat = _to_float32(decoded["2"])
-            if bat is not None:
-                self.battery_level = round(bat)
+        if isinstance(field3, dict) and "1" in field3:
+            self._clear_assumed_robot_clean_on_terminal_base_status(
+                is_paused=bool(field3.get("2"))
+            )
+        standby_docked = (
+            isinstance(field3, dict)
+            and self.working_status == WorkingStatus.STANDBY
+            and not self.is_paused
+            and not self.has_assumed_robot_clean
+            and current_reports_docked
+        )
+        has_current_working_status = isinstance(field3, dict) and "1" in field3
+        terminal_docked = standby_docked or (
+            has_current_working_status
+            and self.working_status
+            in (
+                WorkingStatus.DOCKED,
+                WorkingStatus.CHARGED,
+                WorkingStatus.DOCKED_V2,
+            )
+        )
+        terminal_robot = has_current_working_status and self.working_status in (
+            WorkingStatus.TASK_COMPLETED,
+            WorkingStatus.ERROR,
+        )
+        if standby_docked:
+            self.last_terminal_working_status_time = time.monotonic()
+        if (
+            (terminal_robot or (terminal_docked and not self.has_explicit_off_dock_signal))
+            and not self.has_assumed_robot_clean
+        ):
+            # The paused overlay can remain set after docking. A terminal
+            # base-status packet is authoritative over retained task context.
+            self.last_active_working_status_time = 0.0
+            self.clear_task_details()
         self._update_consumables(decoded)
         if "13" in decoded:
             raw = decoded["13"]
@@ -1381,9 +1677,7 @@ class NarwalState:
         """
         self.raw_base_status = decoded
         if "2" in decoded:
-            bat = _to_float32(decoded["2"])
-            if bat is not None:
-                self.battery_level = round(bat)
+            self._update_battery_level(decoded["2"])
         self._update_consumables(decoded)
 
     def update_from_upgrade_status(self, decoded: dict[str, Any]) -> None:

--- a/custom_components/narwal/select.py
+++ b/custom_components/narwal/select.py
@@ -18,13 +18,13 @@ from homeassistant.util import slugify
 
 from . import NarwalConfigEntry
 from .const import (
-    FAN_SPEED_LIST,
-    FAN_SPEED_MAP,
     MOP_STRENGTH_MAP,
     UNVERSIONED_FAN_SPEED_MAP,
     WATER_MAP,
     WORK_MODE_MAP,
+    fan_speed_label_map_for,
     fan_speed_list_for,
+    fan_speed_map_for,
     normalize_fan_level_for_model,
 )
 from .coordinator import (
@@ -122,7 +122,7 @@ SELECT_DESCRIPTIONS: tuple[NarwalSelectEntityDescription, ...] = (
 )
 
 LEGACY_MODE_OPTIONS = ("Vacuum", "Mop", "Vacuum then mop", "Vacuum and mop")
-LEGACY_SUCTION_OPTIONS = ("AI", *FAN_SPEED_LIST)
+LEGACY_SUCTION_OPTIONS = ("AI", *fan_speed_list_for({}))
 LEGACY_WATER_OPTIONS = ("Dry", "Normal", "Wet")
 LEGACY_SCRUB_OPTIONS = ("Normal", "High")
 LEGACY_ROUTE_OPTIONS = ("Standard", "Meticulous")
@@ -137,17 +137,14 @@ LEGACY_MODE_MAP: dict[str, WorkMode] = {
 LEGACY_MODE_LABELS: dict[WorkMode, str] = {
     value: label for label, value in LEGACY_MODE_MAP.items()
 }
-LEGACY_SUCTION_MAP: dict[str, FanLevel] = {
-    "AI": FanLevel.UNSPECIFIED,
-    "Super": FanLevel.DEEP,
-    "Super powerful": FanLevel.DEEP,
-    "Ultra powerful": FanLevel.SUPER,
-    **{option: FAN_SPEED_MAP[option] for option in FAN_SPEED_LIST},
-}
-LEGACY_SUCTION_LABELS: dict[FanLevel, str] = {
-    FanLevel.UNSPECIFIED: "AI",
-    **{FAN_SPEED_MAP[option]: option for option in FAN_SPEED_LIST},
-}
+def _legacy_suction_map_for(data: dict) -> dict[str, FanLevel]:
+    """Return legacy suction options for this model, including hidden aliases."""
+    return {"AI": FanLevel.UNSPECIFIED, **fan_speed_map_for(data)}
+
+
+def _legacy_suction_labels_for(data: dict) -> dict[FanLevel, str]:
+    """Return FanLevel labels for this model's visible legacy suction options."""
+    return {FanLevel.UNSPECIFIED: "AI", **fan_speed_label_map_for(data)}
 LEGACY_WATER_MAP: dict[str, MopHumidity] = {
     "Dry": MopHumidity.DRY,
     "Normal": MopHumidity.NORMAL,
@@ -417,12 +414,9 @@ class NarwalSelect(NarwalEntity, RestoreEntity, SelectEntity):
             return setup_available and setup_applies
         live_available = super().available and is_live_clean_setting_available(state)
         live_mode = self.coordinator.clean_setting_applicability_mode(live=True)
-        live_applies = (
-            live_mode is not None
-            and clean_setting_applies_to_mode(
-                self.entity_description.attr,
-                live_mode,
-            )
+        live_applies = clean_setting_applies_to_mode(
+            self.entity_description.attr,
+            live_mode,
         )
         return (
             (setup_available and setup_applies)
@@ -456,12 +450,9 @@ class NarwalSelect(NarwalEntity, RestoreEntity, SelectEntity):
             self.coordinator.clean_settings.work_mode,
         )
         live_mode = self.coordinator.clean_setting_applicability_mode(live=True)
-        live_applies = (
-            live_mode is not None
-            and clean_setting_applies_to_mode(
-                self.entity_description.attr,
-                live_mode,
-            )
+        live_applies = clean_setting_applies_to_mode(
+            self.entity_description.attr,
+            live_mode,
         )
         if not (
             (setup_available and setup_applies)
@@ -684,7 +675,7 @@ class RoomNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
         if key == "mode":
             return LEGACY_MODE_LABELS.get(value)
         if key == "suction":
-            return LEGACY_SUCTION_LABELS.get(value)
+            return self._suction_labels.get(value)
         if key == "water":
             labels = {value: label for label, value in LEGACY_WATER_MAP.items()}
             return labels.get(value)
@@ -704,7 +695,7 @@ class RoomNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
             return option
         if self.entity_description.setting_key != "suction":
             return None
-        label = LEGACY_SUCTION_LABELS.get(LEGACY_SUCTION_MAP.get(option))
+        label = self._suction_labels.get(self._suction_map.get(option))
         return label if label in self.options else None
 
     @staticmethod
@@ -731,7 +722,7 @@ class RoomNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
             mapping = (
                 UNVERSIONED_FAN_SPEED_MAP
                 if unversioned
-                else LEGACY_SUCTION_MAP
+                else self._suction_map
             )
             return mapping.get(option)
         elif key == "water":
@@ -794,6 +785,16 @@ class RoomNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
             value,
             map_id=self._map_id,
         )
+
+    @property
+    def _suction_map(self) -> dict[str, FanLevel]:
+        """Return the model-specific room suction map."""
+        return _legacy_suction_map_for(self.coordinator.config_entry.data)
+
+    @property
+    def _suction_labels(self) -> dict[FanLevel, str]:
+        """Return the model-specific room suction labels."""
+        return _legacy_suction_labels_for(self.coordinator.config_entry.data)
 
     async def async_select_option(self, option: str) -> None:
         """Apply a room profile option."""
@@ -910,7 +911,7 @@ class LegacyNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
         """Return whether the legacy setting applies to the selected mode."""
         mode = self._mode_for_applicability(live=live)
         if mode is None:
-            return not live
+            return key not in {"suction", "water", "scrub"}
         if key == "water" and mode not in LEGACY_MOP_MODES:
             return False
         if key == "scrub" and mode not in LEGACY_MOP_MODES:
@@ -949,7 +950,7 @@ class LegacyNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
             settings.work_mode = LEGACY_MODE_MAP[option]
             self.coordinator._legacy_mode_option = option
         elif key == "suction":
-            settings.fan = LEGACY_SUCTION_MAP[option]
+            settings.fan = self._suction_map[option]
         elif key == "water":
             settings.water = LEGACY_WATER_MAP[option]
         elif key == "scrub":
@@ -1028,7 +1029,7 @@ class LegacyNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
             option = LEGACY_MODE_LABELS.get(settings.work_mode)
         elif key == "suction":
             value = self.coordinator.active_clean_setting("fan")
-            option = LEGACY_SUCTION_LABELS.get(
+            option = self._suction_labels.get(
                 value if value is not None else settings.fan
             )
         elif key == "water":
@@ -1056,7 +1057,7 @@ class LegacyNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
             return option
         if self.entity_description.setting_key != "suction":
             return None
-        label = LEGACY_SUCTION_LABELS.get(LEGACY_SUCTION_MAP.get(option))
+        label = self._suction_labels.get(self._suction_map.get(option))
         return label if label in self.options else None
 
     async def async_select_option(self, option: str) -> None:
@@ -1102,7 +1103,7 @@ class LegacyNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
         if live_available and live_applies and not setup_available:
             if key == "suction":
                 response = await self.coordinator.client.set_fan_speed(
-                    LEGACY_SUCTION_MAP[option]
+                    self._suction_map[option]
                 )
             elif key == "water":
                 response = await self.coordinator.client.set_mop_humidity(
@@ -1121,7 +1122,7 @@ class LegacyNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
         if response is not None:
             attr = "fan" if key == "suction" else "water"
             value = (
-                LEGACY_SUCTION_MAP[option]
+                self._suction_map[option]
                 if key == "suction"
                 else LEGACY_WATER_MAP[option]
             )
@@ -1131,3 +1132,13 @@ class LegacyNarwalSettingSelect(NarwalEntity, RestoreEntity, SelectEntity):
             self._apply_option(option)
         self.async_write_ha_state()
         self.coordinator.async_update_listeners()
+
+    @property
+    def _suction_map(self) -> dict[str, FanLevel]:
+        """Return the model-specific legacy suction map."""
+        return _legacy_suction_map_for(self.coordinator.config_entry.data)
+
+    @property
+    def _suction_labels(self) -> dict[FanLevel, str]:
+        """Return the model-specific legacy suction labels."""
+        return _legacy_suction_labels_for(self.coordinator.config_entry.data)

--- a/custom_components/narwal/sensor.py
+++ b/custom_components/narwal/sensor.py
@@ -26,8 +26,18 @@ from .narwal_client import NarwalState
 class NarwalSensorEntityDescription(SensorEntityDescription):
     """Describes a Narwal sensor entity."""
 
-    value_fn: Callable[[NarwalState], float | str | None]
+    value_fn: Callable[[NarwalState], float | int | str | None]
+    available_fn: Callable[[NarwalState], bool] | None = None
     dock_device: bool = False
+
+
+def _has_active_cleaning_metrics(state: NarwalState) -> bool:
+    """Return true while live clean-progress metrics describe the current task."""
+    return (
+        state.is_cleaning
+        or state.has_recent_active_working_status
+        or state.has_paused_clean_task_context
+    )
 
 
 SENSOR_DESCRIPTIONS: tuple[NarwalSensorEntityDescription, ...] = (
@@ -48,6 +58,7 @@ SENSOR_DESCRIPTIONS: tuple[NarwalSensorEntityDescription, ...] = (
         value_fn=lambda state: round(state.cleaning_area, 2)
         if state.cleaning_area > 0
         else None,
+        available_fn=_has_active_cleaning_metrics,
     ),
     NarwalSensorEntityDescription(
         key="cleaning_time",
@@ -60,6 +71,19 @@ SENSOR_DESCRIPTIONS: tuple[NarwalSensorEntityDescription, ...] = (
         value_fn=lambda state: state.cleaning_time
         if state.cleaning_time > 0
         else None,
+        available_fn=_has_active_cleaning_metrics,
+    ),
+    NarwalSensorEntityDescription(
+        key="remaining_time",
+        translation_key="remaining_time",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        state_class=SensorStateClass.MEASUREMENT,
+        # base_status task ETA, populated while the robot keeps an active clean task.
+        value_fn=lambda state: state.task_remaining_time
+        if state.task_remaining_time > 0
+        else None,
+        available_fn=_has_active_cleaning_metrics,
     ),
     NarwalSensorEntityDescription(
         key="dust_bag_health",
@@ -100,14 +124,6 @@ SENSOR_DESCRIPTIONS: tuple[NarwalSensorEntityDescription, ...] = (
         # base_status field 15 terminateReason (TaskResult) — why the last task ended.
         value_fn=lambda state: TASK_RESULT_OPTIONS.get(state.terminate_reason),
     ),
-    NarwalSensorEntityDescription(
-        key="current_room",
-        translation_key="current_room",
-        icon="mdi:map-marker",
-        # working_status field 6: room_id of the room currently being cleaned.
-        # Resolved to a display name via the cached room map from get_map.
-        value_fn=lambda state: state.current_room_name,
-    ),
 )
 
 
@@ -147,12 +163,22 @@ class NarwalSensor(NarwalEntity, SensorEntity):
         self._attr_unique_id = f"{device_id}_{description.key}"
 
     @property
-    def native_value(self) -> float | str | None:
+    def native_value(self) -> float | int | str | None:
         """Return the sensor value."""
         state = self.coordinator.data
         if state is None:
             return None
         return self.entity_description.value_fn(state)
+
+    @property
+    def available(self) -> bool:
+        """Return True when this sensor has meaningful current data."""
+        if not super().available:
+            return False
+        if self.entity_description.available_fn is None:
+            return True
+        state = self.coordinator.data
+        return state is not None and self.entity_description.available_fn(state)
 
 
 class NarwalDockSensor(NarwalDockEntity, SensorEntity):
@@ -172,12 +198,22 @@ class NarwalDockSensor(NarwalDockEntity, SensorEntity):
         self._attr_unique_id = f"{device_id}_{description.key}"
 
     @property
-    def native_value(self) -> float | str | None:
+    def native_value(self) -> float | int | str | None:
         """Return the sensor value."""
         state = self.coordinator.data
         if state is None:
             return None
         return self.entity_description.value_fn(state)
+
+    @property
+    def available(self) -> bool:
+        """Return True when this sensor has meaningful current data."""
+        if not super().available:
+            return False
+        if self.entity_description.available_fn is None:
+            return True
+        state = self.coordinator.data
+        return state is not None and self.entity_description.available_fn(state)
 
 
 class NarwalChargingStateSensor(NarwalEntity, SensorEntity):

--- a/custom_components/narwal/strings.json
+++ b/custom_components/narwal/strings.json
@@ -42,6 +42,9 @@
       "cleaning_time": {
         "name": "Cleaning time"
       },
+      "remaining_time": {
+        "name": "Remaining time"
+      },
       "firmware_version": {
         "name": "Firmware version"
       },
@@ -81,9 +84,6 @@
           "fully_charged": "Fully Charged",
           "not_charging": "Not Charging"
         }
-      },
-      "current_room": {
-        "name": "Current room"
       }
     },
     "binary_sensor": {

--- a/custom_components/narwal/switch.py
+++ b/custom_components/narwal/switch.py
@@ -225,6 +225,8 @@ class NarwalDockTaskSwitch(NarwalDockEntity, SwitchEntity):
                 await client.wake(timeout=10.0, force=force_wake)
             if not await self.coordinator.async_refresh_dock_status():
                 raise HomeAssistantError("Narwal dock status could not be refreshed")
+            if self.is_on:
+                return
             if not can_start_dock_task(client.state, self.entity_description.key):
                 raise HomeAssistantError("Narwal dock task cannot be started right now")
 
@@ -247,6 +249,8 @@ class NarwalDockTaskSwitch(NarwalDockEntity, SwitchEntity):
                 await client.wake(timeout=10.0, force=force_wake)
             if not await self.coordinator.async_refresh_dock_status():
                 raise HomeAssistantError("Narwal dock status could not be refreshed")
+            if self.entity_description.key not in client.state.active_dock_task_keys:
+                return
             if not can_stop_dock_task(client.state, self.entity_description.key):
                 raise HomeAssistantError("Narwal dock task cannot be stopped right now")
 

--- a/custom_components/narwal/translations/en.json
+++ b/custom_components/narwal/translations/en.json
@@ -42,6 +42,9 @@
       "cleaning_time": {
         "name": "Cleaning time"
       },
+      "remaining_time": {
+        "name": "Remaining time"
+      },
       "firmware_version": {
         "name": "Firmware version"
       },
@@ -81,9 +84,6 @@
           "fully_charged": "Fully Charged",
           "not_charging": "Not Charging"
         }
-      },
-      "current_room": {
-        "name": "Current room"
       }
     },
     "binary_sensor": {

--- a/custom_components/narwal/vacuum.py
+++ b/custom_components/narwal/vacuum.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.components.vacuum import (
@@ -18,19 +19,30 @@ except ImportError:
     Segment = None  # HA < 2026.3 — room cleaning unavailable
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 
 from . import NarwalConfigEntry
-from .const import FAN_SPEED_LIST, FAN_SPEED_MAP, fan_speed_list_for
-from .coordinator import NarwalCoordinator
+from .const import (
+    FAN_SPEED_LIST,
+    FAN_SPEED_MAP,
+    fan_speed_list_for,
+    normalize_fan_level_for_model,
+)
+from .coordinator import (
+    NarwalCoordinator,
+    can_edit_pending_clean_settings,
+    clean_setting_applies_to_mode,
+    has_blocking_error,
+    is_clean_session_context,
+    is_live_clean_setting_available,
+)
 from .dock_tasks import (
     can_start_robot_clean,
     can_stop_dock_task,
     has_active_dock_work,
-    is_clean_session_context,
 )
 from .entity import NarwalEntity
-from .narwal_client import CommandResult, WorkingStatus
+from .narwal_client import CommandResult, FanLevel, WorkingStatus
 from .narwal_client.const import ACTIVE_CLEANING_STATUSES
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,6 +50,18 @@ _LOGGER = logging.getLogger(__name__)
 # working_status values already reported as unmapped. Activity is recomputed on
 # every state broadcast, so warn once per distinct value instead of flooding.
 _WARNED_UNMAPPED_ACTIVITY: set[int] = set()
+
+
+@dataclass(frozen=True)
+class FanSettingRestoreData(ExtraStoredData):
+    """Persist pending suction by its stable robot value."""
+
+    value: int
+    version: int = 1
+
+    def as_dict(self) -> dict[str, int]:
+        """Return a JSON-serializable representation."""
+        return {"version": self.version, "value": self.value}
 
 WORKING_STATUS_TO_ACTIVITY: dict[WorkingStatus, VacuumActivity] = {
     WorkingStatus.DOCKED: VacuumActivity.DOCKED,
@@ -47,6 +71,7 @@ WORKING_STATUS_TO_ACTIVITY: dict[WorkingStatus, VacuumActivity] = {
     WorkingStatus.CLEANING_V2: VacuumActivity.CLEANING,
     WorkingStatus.CLEANING: VacuumActivity.CLEANING,
     WorkingStatus.CLEANING_ALT: VacuumActivity.CLEANING,
+    WorkingStatus.CUSTOM_CLEANING: VacuumActivity.CLEANING,
     # Mapping/exploration is active robot work.
     WorkingStatus.REMAPPING: VacuumActivity.CLEANING,
     WorkingStatus.TASK_COMPLETED: VacuumActivity.RETURNING,
@@ -66,6 +91,15 @@ def _result_name(result_code: int | CommandResult) -> str:
 
 # FanLevel value -> fan_speed label. FAN_SPEED_MAP also holds back-compat aliases.
 _FAN_LABELS: dict[int, str] = {int(FAN_SPEED_MAP[label]): label for label in FAN_SPEED_LIST}
+
+
+def _raise_if_command_failed(response: Any, action: str) -> None:
+    """Raise a Home Assistant service error for rejected robot commands."""
+    if response.accepted:
+        return
+    raise HomeAssistantError(
+        f"Narwal {action} failed: {_result_name(response.result_code)}"
+    )
 
 
 async def async_setup_entry(
@@ -97,6 +131,25 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         """Hide robot actions while dock work makes them unsafe or ambiguous."""
         features = self._BASE_SUPPORTED_FEATURES
         state = self.coordinator.data
+        setup_fan = (
+            can_edit_pending_clean_settings(state)
+            and not self.coordinator.has_selected_clean_rooms()
+            and clean_setting_applies_to_mode(
+                "fan", self.coordinator.clean_settings.work_mode
+            )
+        )
+        live_fan = False
+        if is_live_clean_setting_available(state):
+            live_mode = self.coordinator.clean_setting_applicability_mode(live=True)
+            live_fan = live_mode is not None and clean_setting_applies_to_mode(
+                "fan", live_mode
+            )
+        if not setup_fan and not live_fan:
+            features &= ~VacuumEntityFeature.FAN_SPEED
+        if not getattr(self.coordinator, "_room_profile_store_loaded", True):
+            features &= ~VacuumEntityFeature.CLEAN_AREA
+            if not (state and state.is_paused and is_clean_session_context(state)):
+                features &= ~VacuumEntityFeature.START
         if not has_active_dock_work(state):
             return features
         features &= ~(
@@ -121,8 +174,37 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         """Restore the pending fan speed into clean_settings (persists across restarts)."""
         await super().async_added_to_hass()
         last = await self.async_get_last_state()
-        if last is not None and (fan := last.attributes.get("fan_speed")) in FAN_SPEED_MAP:
-            self.coordinator.clean_settings.fan = FAN_SPEED_MAP[fan]
+        extra = await self.async_get_last_extra_data()
+        if extra is not None:
+            data = extra.as_dict()
+            raw_value = data.get("value")
+            values = {int(value): value for value in FanLevel}
+            if (
+                data.get("version") == 1
+                and isinstance(raw_value, int)
+                and not isinstance(raw_value, bool)
+                and raw_value in values
+            ):
+                self.coordinator.clean_settings.fan = normalize_fan_level_for_model(
+                    self.coordinator.config_entry.data,
+                    values[raw_value],
+                )
+                return
+        if last is None or "fan_speed" not in last.attributes:
+            return
+        fan = last.attributes.get("fan_speed")
+        if fan is None:
+            self.coordinator.clean_settings.fan = FanLevel.UNSPECIFIED
+        elif fan in FAN_SPEED_MAP:
+            self.coordinator.clean_settings.fan = normalize_fan_level_for_model(
+                self.coordinator.config_entry.data,
+                FAN_SPEED_MAP[fan],
+            )
+
+    @property
+    def extra_restore_state_data(self) -> ExtraStoredData:
+        """Return pending suction independently of its displayed active value."""
+        return FanSettingRestoreData(value=int(self.coordinator.clean_settings.fan))
 
     @property
     def activity(self) -> VacuumActivity:
@@ -173,7 +255,10 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         pending value held in coordinator.clean_settings (applied at the next clean
         and, while cleaning, written live via set_fan_speed).
         """
-        return _FAN_LABELS.get(int(self.coordinator.clean_settings.fan))
+        fan = self.coordinator.active_clean_setting("fan")
+        if fan is None:
+            fan = self.coordinator.clean_settings.fan
+        return _FAN_LABELS.get(int(fan))
 
     # Timeout for action commands (start/stop/return) — robot may need
     # time to load map, plan route, etc., especially after waking.
@@ -202,38 +287,62 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         """Start or resume cleaning."""
         await self._ensure_awake()
         state = self.coordinator.data
-        # is_paused stays stale after docking — only trust it during cleaning
-        is_cleaning = state and state.working_status in ACTIVE_CLEANING_STATUSES
-        if is_cleaning and state.is_paused:
-            await self.coordinator.client.resume(timeout=self._ACTION_TIMEOUT)
+        if (
+            state
+            and not has_blocking_error(state)
+            and state.working_status != WorkingStatus.TASK_COMPLETED
+            and state.is_paused
+            and is_clean_session_context(state)
+        ):
+            response = await self.coordinator.client.resume(
+                timeout=self._ACTION_TIMEOUT
+            )
+            _raise_if_command_failed(response, "resume")
             return
+        if getattr(self.coordinator, "_room_profile_store_loaded", True) is False:
+            raise HomeAssistantError("Narwal room profiles are not restored yet")
         room_ids: list[int] = []
         async with self.coordinator.dock_action_lock:
             await self._validate_clean_start()
 
-            # Whole-house clean enumerates every room via clean/start_clean, matching the
-            # app's allRoomIds() path. clean/plan/start (StartWithPlan) would instead re-run
-            # the saved current plan — i.e. the last room selection — not the whole house.
-            room_ids = await self._all_room_ids()
-            if room_ids:
-                settings = self.coordinator.clean_settings
-                resp = await self.coordinator.client.start_rooms(
-                    room_ids,
-                    work_mode=settings.work_mode,
-                    fan=settings.fan,
-                    water=settings.water,
-                    mop_strength=settings.mop_strength,
-                    passes=settings.passes,
-                )
-            else:
-                # No map rooms known — best-effort fall back to the saved-plan start.
-                resp = await self.coordinator.client.start()
+            # The HA vacuum start command uses integration-owned room selections:
+            # selected rooms when any are on, otherwise all rooms.
+            all_room_ids = await self._all_room_ids()
+            if not all_room_ids:
+                raise HomeAssistantError("Narwal room map is not available")
+            map_id = self.coordinator.room_settings_map_id(
+                self.coordinator.client.state.map_data
+            )
+            if map_id is None and self.coordinator.selected_clean_rooms:
+                raise HomeAssistantError("Narwal room selection is not available")
+            room_ids = self.coordinator.selected_clean_room_ids_for(
+                all_room_ids,
+                map_id=map_id,
+            )
+            if not room_ids:
+                raise HomeAssistantError("Narwal room selection is not available")
+            settings = self.coordinator.clean_settings
+            room_settings = self.coordinator.room_clean_settings_for_rooms(
+                room_ids,
+                map_id=map_id,
+            )
+            resp = await self.coordinator.client.start_rooms(
+                room_ids,
+                work_mode=settings.work_mode,
+                fan=settings.fan,
+                water=settings.water,
+                mop_strength=settings.mop_strength,
+                passes=settings.passes,
+                route=settings.route,
+                room_settings=room_settings,
+            )
             if resp.accepted:
+                self.coordinator.record_accepted_clean_start(room_settings)
                 self.coordinator.client.state.assume_robot_clean()
                 self.coordinator.async_set_updated_data(self.coordinator.client.state)
         _LOGGER.info(
-            "Whole-house start: code=%s, success=%s, rooms=%s",
-            resp.result_code, resp.success, room_ids or "(saved plan)",
+            "Room-aware start: code=%s, success=%s, rooms=%s",
+            resp.result_code, resp.success, room_ids,
         )
         if not resp.accepted:
             _LOGGER.warning(
@@ -244,27 +353,18 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
             raise HomeAssistantError(
                 f"Narwal start command failed: {_result_name(resp.result_code)}"
             )
+        self.async_write_ha_state()
 
     async def _all_room_ids(self) -> list[int]:
-        """Every cleanable room id for a whole-house clean; fetches the map if not cached."""
-        state = self.coordinator.data
-        if state is None or state.map_data is None:
-            try:
-                await self.coordinator.client.get_map()
-            except Exception:  # noqa: BLE001 — best-effort prefetch; fall through to fallback
-                _LOGGER.debug("get_map for whole-house clean failed")
-            state = self.coordinator.data
+        """Return room ids from an authoritative static map."""
+        try:
+            await self.coordinator.client.get_map()
+        except Exception as err:
+            raise HomeAssistantError("Narwal map could not be refreshed") from err
+        state = self.coordinator.client.state
         if state and state.map_data:
             return [r.room_id for r in state.map_data.rooms if r.room_id > 0]
-        # Map still unavailable — reuse the HA segment cache (Segment.id == str(room_id)).
-        cached = getattr(self, "last_seen_segments", None) or []
-        ids: list[int] = []
-        for seg in cached:
-            try:
-                ids.append(int(seg.id))
-            except (ValueError, AttributeError, TypeError):
-                continue
-        return ids
+        return []
 
     async def async_stop(self, **kwargs) -> None:
         """Stop cleaning."""
@@ -338,17 +438,49 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
     async def async_set_fan_speed(self, fan_speed: str, **kwargs) -> None:
         """Set the fan speed.
 
-        Stores it as the pending suction for the next clean; if the robot is
-        currently cleaning, also writes it live via set_fan_speed.
+        Stores it as whole-floor pending suction when no rooms are selected;
+        while cleaning, it also writes the active task live.
         """
         level = FAN_SPEED_MAP.get(fan_speed)
         if level is None:
             return
-        self.coordinator.clean_settings.fan = level
-        self.async_write_ha_state()
         state = self.coordinator.data
-        if state is not None and state.is_cleaning:
-            await self.coordinator.client.set_fan_speed(level)
+        has_selected_rooms = self.coordinator.has_selected_clean_rooms()
+        setup_available = (
+            can_edit_pending_clean_settings(state)
+            and not has_selected_rooms
+        )
+        live_available = super().available and is_live_clean_setting_available(state)
+        setup_applies = clean_setting_applies_to_mode(
+            "fan",
+            self.coordinator.clean_settings.work_mode,
+        )
+        live_mode = self.coordinator.clean_setting_applicability_mode(live=True)
+        live_applies = (
+            live_mode is not None
+            and clean_setting_applies_to_mode("fan", live_mode)
+        )
+        if not (
+            (setup_available and setup_applies)
+            or (live_available and live_applies)
+        ):
+            if not setup_applies and not live_applies:
+                raise HomeAssistantError(
+                    "Narwal fan speed is not available in mop-only mode"
+                )
+            raise HomeAssistantError("Narwal fan speed cannot be changed right now")
+        if live_available and not live_applies:
+            raise HomeAssistantError(
+                "Narwal fan speed is not available in mop-only mode"
+            )
+        if live_available:
+            resp = await self.coordinator.client.set_fan_speed(level)
+            _raise_if_command_failed(resp, "set fan speed")
+            self.coordinator.set_active_clean_setting("fan", level)
+        if not has_selected_rooms:
+            self.coordinator.clean_settings.fan = level
+        self.async_write_ha_state()
+        self.coordinator.async_update_listeners()
 
     # --- Segment API (HA 2026.3 room-specific cleaning) ---
 
@@ -387,38 +519,48 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         Converts string segment IDs back to integer room IDs and sends
         a room-specific clean command to the robot.
         """
+        if getattr(self.coordinator, "_room_profile_store_loaded", True) is False:
+            raise HomeAssistantError("Narwal room profiles are not restored yet")
         await self._ensure_awake()
         try:
-            room_ids = [int(sid) for sid in segment_ids]
+            room_ids = list(dict.fromkeys(int(sid) for sid in segment_ids))
         except (TypeError, ValueError) as err:
             raise HomeAssistantError("Narwal segment IDs must be numeric") from err
+        if not room_ids:
+            raise HomeAssistantError("Narwal segment IDs must not be empty")
+        if any(room_id <= 0 for room_id in room_ids):
+            raise HomeAssistantError("Narwal segment IDs must be positive")
 
         async with self.coordinator.dock_action_lock:
             await self._validate_clean_start()
             try:
                 await self.coordinator.client.get_map()
-            except Exception:
-                _LOGGER.debug("Could not refresh Narwal map before segment clean")
+            except Exception as err:
+                raise HomeAssistantError(
+                    "Narwal map could not be refreshed"
+                ) from err
             state = self.coordinator.client.state
-            known_room_ids = {
+            known_ids = {
                 room.room_id
                 for room in getattr(getattr(state, "map_data", None), "rooms", ())
                 if room.room_id > 0
             }
-            if known_room_ids:
-                unknown_room_ids = [
-                    room_id for room_id in room_ids if room_id not in known_room_ids
-                ]
-                if unknown_room_ids:
-                    raise HomeAssistantError(
-                        f"Unknown Narwal room ID: {', '.join(map(str, unknown_room_ids))}"
-                    )
+            if not known_ids:
+                raise HomeAssistantError("Narwal map is not available")
+            unknown_ids = [room_id for room_id in room_ids if room_id not in known_ids]
+            if unknown_ids:
+                raise HomeAssistantError(
+                    "Unknown Narwal room ID: "
+                    f"{', '.join(str(room_id) for room_id in unknown_ids)}"
+                )
             settings = self.coordinator.clean_settings
+            room_settings = self.coordinator.room_clean_settings_for_rooms(room_ids)
             _LOGGER.info(
                 "Starting room-specific clean: rooms=%s mode=%s fan=%s water=%s "
-                "mop_strength=%s passes=%s",
+                "mop_strength=%s passes=%s route=%s",
                 room_ids, settings.work_mode.name, settings.fan.name,
                 settings.water.name, settings.mop_strength.name, settings.passes,
+                settings.route.name,
             )
             resp = await self.coordinator.client.start_rooms(
                 room_ids,
@@ -427,8 +569,11 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
                 water=settings.water,
                 mop_strength=settings.mop_strength,
                 passes=settings.passes,
+                route=settings.route,
+                room_settings=room_settings,
             )
             if resp.accepted:
+                self.coordinator.record_accepted_clean_start(room_settings)
                 self.coordinator.client.state.assume_robot_clean()
                 self.coordinator.async_set_updated_data(self.coordinator.client.state)
         result_name = _result_name(resp.result_code)
@@ -447,6 +592,7 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
             raise HomeAssistantError(
                 f"Narwal room clean failed: {result_name}"
             )
+        self.async_write_ha_state()
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/narwal/vacuum.py
+++ b/custom_components/narwal/vacuum.py
@@ -478,6 +478,7 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
             if resp.accepted:
                 self.coordinator.record_accepted_clean_start(room_settings)
                 self.coordinator.client.state.assume_robot_clean()
+                await self.coordinator.async_clear_map_display_cache()
                 self.coordinator.async_set_updated_data(self.coordinator.client.state)
         _LOGGER.info(
             "Room-aware start: code=%s, success=%s, rooms=%s",
@@ -707,6 +708,7 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
             if resp.accepted:
                 self.coordinator.record_accepted_clean_start(room_settings)
                 self.coordinator.client.state.assume_robot_clean()
+                await self.coordinator.async_clear_map_display_cache()
                 self.coordinator.async_set_updated_data(self.coordinator.client.state)
         result_name = _result_name(resp.result_code)
         _LOGGER.info(

--- a/custom_components/narwal/vacuum.py
+++ b/custom_components/narwal/vacuum.py
@@ -23,33 +23,30 @@ from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 
 from . import NarwalConfigEntry
 from .const import (
-    FAN_SPEED_LIST,
-    FAN_SPEED_MAP,
+    UNVERSIONED_FAN_SPEED_MAP,
+    fan_speed_label_map_for,
     fan_speed_list_for,
+    fan_speed_map_for,
     normalize_fan_level_for_model,
 )
 from .coordinator import (
     NarwalCoordinator,
     can_edit_pending_clean_settings,
+    can_locate_robot,
+    can_pause_cleaning,
+    can_prepare_clean_start,
+    can_resume_cleaning,
+    can_return_home,
+    can_start_cleaning,
+    can_stop_cleaning,
     clean_setting_applies_to_mode,
-    has_blocking_error,
-    is_clean_session_context,
     is_live_clean_setting_available,
-)
-from .dock_tasks import (
-    can_start_robot_clean,
-    can_stop_dock_task,
-    has_active_dock_work,
 )
 from .entity import NarwalEntity
 from .narwal_client import CommandResult, FanLevel, WorkingStatus
 from .narwal_client.const import ACTIVE_CLEANING_STATUSES
 
 _LOGGER = logging.getLogger(__name__)
-
-# working_status values already reported as unmapped. Activity is recomputed on
-# every state broadcast, so warn once per distinct value instead of flooding.
-_WARNED_UNMAPPED_ACTIVITY: set[int] = set()
 
 
 @dataclass(frozen=True)
@@ -62,6 +59,7 @@ class FanSettingRestoreData(ExtraStoredData):
     def as_dict(self) -> dict[str, int]:
         """Return a JSON-serializable representation."""
         return {"version": self.version, "value": self.value}
+
 
 WORKING_STATUS_TO_ACTIVITY: dict[WorkingStatus, VacuumActivity] = {
     WorkingStatus.DOCKED: VacuumActivity.DOCKED,
@@ -77,8 +75,6 @@ WORKING_STATUS_TO_ACTIVITY: dict[WorkingStatus, VacuumActivity] = {
     WorkingStatus.TASK_COMPLETED: VacuumActivity.RETURNING,
     WorkingStatus.ERROR: VacuumActivity.ERROR,
 }
-
-
 def _result_name(result_code: int | CommandResult) -> str:
     """Return a readable Narwal command result name."""
     if result_code == 0:
@@ -89,10 +85,6 @@ def _result_name(result_code: int | CommandResult) -> str:
         return f"UNKNOWN({result_code})"
 
 
-# FanLevel value -> fan_speed label. FAN_SPEED_MAP also holds back-compat aliases.
-_FAN_LABELS: dict[int, str] = {int(FAN_SPEED_MAP[label]): label for label in FAN_SPEED_LIST}
-
-
 def _raise_if_command_failed(response: Any, action: str) -> None:
     """Raise a Home Assistant service error for rejected robot commands."""
     if response.accepted:
@@ -100,6 +92,102 @@ def _raise_if_command_failed(response: Any, action: str) -> None:
     raise HomeAssistantError(
         f"Narwal {action} failed: {_result_name(response.result_code)}"
     )
+
+
+def _task_status(state: Any) -> str:
+    """Return a compact active-task status for dashboards and automations."""
+    is_cleaning_state = (
+        state.working_status in ACTIVE_CLEANING_STATUSES
+        or state.has_assumed_robot_clean
+        or state.has_recent_active_working_status
+        or state.has_paused_clean_task_context
+    )
+    if state.working_status == WorkingStatus.ERROR or getattr(state, "has_error", False):
+        return "error"
+    if state.is_paused and is_cleaning_state:
+        return "paused"
+    if state.working_status == WorkingStatus.REMAPPING:
+        return "remapping"
+    if state.is_returning or state.working_status == WorkingStatus.TASK_COMPLETED:
+        return "returning"
+    if state.is_cleaning or state.has_assumed_robot_clean:
+        return "cleaning"
+    if state.is_station_active:
+        return "station_active"
+    if state.is_docked:
+        return "docked"
+    if state.working_status == WorkingStatus.STANDBY:
+        return "idle"
+    return "unknown"
+
+
+def _is_dock_side(state: Any) -> bool:
+    """Return true when robot telemetry says it is physically dock-side."""
+    return state.is_docked
+
+
+def _has_active_cleaning_metrics(state: Any) -> bool:
+    """Return true while live clean-progress details are current."""
+    return (
+        state.is_cleaning
+        or state.has_assumed_robot_clean
+        or state.has_recent_active_working_status
+        or state.has_paused_clean_task_context
+    )
+
+
+def _has_dock_stop_context(state: Any) -> bool:
+    """Return true when dock-side work must be considered before generic stop."""
+    return (
+        state.is_station_active
+        or state.has_unmapped_active_dock_task
+        or bool(state.active_dock_task_keys)
+    )
+
+
+def _can_stop_vacuum(state: Any) -> bool:
+    """Return true when the aggregate vacuum stop command is safe to expose."""
+    if _has_dock_stop_context(state) and not _has_live_robot_stop_context(state):
+        return False
+    return can_stop_cleaning(state)
+
+
+def _can_accept_return_home(state: Any) -> bool:
+    """Return true when return-home can act or is an idle dock no-op."""
+    return can_return_home(state) or (
+        state.is_docked
+        and not _has_dock_stop_context(state)
+        and not _has_live_robot_stop_context(state)
+    )
+
+
+def _has_live_robot_stop_context(state: Any) -> bool:
+    """Return true when robot telemetry identifies live stoppable work."""
+    return (
+        state.working_status in ACTIVE_CLEANING_STATUSES
+        or state.working_status == WorkingStatus.REMAPPING
+        or state.has_assumed_robot_clean
+        or state.has_paused_clean_task_context
+        or state.is_returning
+    )
+
+
+def _status_summary(state: Any) -> str:
+    """Return one concise status line for HA tile state content."""
+    status = _task_status(state)
+    if status in {"error", "paused", "remapping", "returning"}:
+        return status.replace("_", " ").title()
+    active_cleaning_metrics = _has_active_cleaning_metrics(state)
+    parts: list[str] = []
+
+    if active_cleaning_metrics and state.current_room_name:
+        parts.append(state.current_room_name)
+    if active_cleaning_metrics and state.task_progress_percent is not None:
+        parts.append(f"{state.task_progress_percent}%")
+    if parts:
+        return " - ".join(parts)
+
+    return status.replace("_", " ").title()
 
 
 async def async_setup_entry(
@@ -116,52 +204,6 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
     """Representation of a Narwal robot vacuum."""
 
     _attr_translation_key = "vacuum"
-    _BASE_SUPPORTED_FEATURES = (
-        VacuumEntityFeature.STATE
-        | VacuumEntityFeature.START
-        | VacuumEntityFeature.STOP
-        | VacuumEntityFeature.PAUSE
-        | VacuumEntityFeature.RETURN_HOME
-        | VacuumEntityFeature.FAN_SPEED
-        | VacuumEntityFeature.LOCATE
-    ) | (VacuumEntityFeature.CLEAN_AREA if Segment is not None else VacuumEntityFeature(0))
-
-    @property
-    def supported_features(self) -> VacuumEntityFeature:
-        """Hide robot actions while dock work makes them unsafe or ambiguous."""
-        features = self._BASE_SUPPORTED_FEATURES
-        state = self.coordinator.data
-        setup_fan = (
-            can_edit_pending_clean_settings(state)
-            and not self.coordinator.has_selected_clean_rooms()
-            and clean_setting_applies_to_mode(
-                "fan", self.coordinator.clean_settings.work_mode
-            )
-        )
-        live_fan = False
-        if is_live_clean_setting_available(state):
-            live_mode = self.coordinator.clean_setting_applicability_mode(live=True)
-            live_fan = live_mode is not None and clean_setting_applies_to_mode(
-                "fan", live_mode
-            )
-        if not setup_fan and not live_fan:
-            features &= ~VacuumEntityFeature.FAN_SPEED
-        if not getattr(self.coordinator, "_room_profile_store_loaded", True):
-            features &= ~VacuumEntityFeature.CLEAN_AREA
-            if not (state and state.is_paused and is_clean_session_context(state)):
-                features &= ~VacuumEntityFeature.START
-        if not has_active_dock_work(state):
-            return features
-        features &= ~(
-            VacuumEntityFeature.START
-            | VacuumEntityFeature.PAUSE
-            | VacuumEntityFeature.RETURN_HOME
-            | VacuumEntityFeature.LOCATE
-            | VacuumEntityFeature.CLEAN_AREA
-        )
-        if not is_clean_session_context(state):
-            features &= ~VacuumEntityFeature.STOP
-        return features
 
     def __init__(self, coordinator: NarwalCoordinator) -> None:
         """Initialize the vacuum entity."""
@@ -169,6 +211,7 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         self._attr_unique_id = coordinator.config_entry.data["device_id"]
         # Offered tiers are per-model: models whose app tops out at DEEP don't get "Ultra".
         self._attr_fan_speed_list = fan_speed_list_for(coordinator.config_entry.data)
+        self._last_reported_segment_signature = None
 
     async def async_added_to_hass(self) -> None:
         """Restore the pending fan speed into clean_settings (persists across restarts)."""
@@ -195,11 +238,81 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         fan = last.attributes.get("fan_speed")
         if fan is None:
             self.coordinator.clean_settings.fan = FanLevel.UNSPECIFIED
-        elif fan in FAN_SPEED_MAP:
+            return
+        if fan in UNVERSIONED_FAN_SPEED_MAP:
             self.coordinator.clean_settings.fan = normalize_fan_level_for_model(
                 self.coordinator.config_entry.data,
-                FAN_SPEED_MAP[fan],
+                UNVERSIONED_FAN_SPEED_MAP[fan],
             )
+
+    @property
+    def supported_features(self) -> VacuumEntityFeature:
+        """Return currently usable native Home Assistant vacuum features."""
+        features = VacuumEntityFeature.STATE
+        state = self.coordinator.data
+        if state is None or not self.available:
+            return features
+
+        if can_resume_cleaning(state) or self._can_start_selected_rooms(state):
+            features |= VacuumEntityFeature.START
+        if _can_stop_vacuum(state):
+            features |= VacuumEntityFeature.STOP
+        if can_pause_cleaning(state):
+            features |= VacuumEntityFeature.PAUSE
+        if _can_accept_return_home(state):
+            features |= VacuumEntityFeature.RETURN_HOME
+        if can_locate_robot(state):
+            features |= VacuumEntityFeature.LOCATE
+        if self._fan_speed_available(state):
+            features |= VacuumEntityFeature.FAN_SPEED
+        if (
+            Segment is not None
+            and can_prepare_clean_start(state)
+            and getattr(self.coordinator, "_room_profile_store_loaded", True)
+        ):
+            features |= VacuumEntityFeature.CLEAN_AREA
+        return features
+
+    def _can_start_selected_rooms(self, state: Any) -> bool:
+        """Return True when native START can use the current room selection."""
+        if not can_prepare_clean_start(state):
+            return False
+        if not getattr(self.coordinator, "_room_selection_store_loaded", True):
+            return False
+        if not getattr(self.coordinator, "_room_profile_store_loaded", True):
+            return False
+        room_ids = self._known_room_ids(state)
+        if room_ids is None:
+            # async_start can still fetch the map before dispatch.
+            return True
+        if not room_ids:
+            return False
+        selected_room_ids = self.coordinator.selected_clean_room_ids_for(room_ids)
+        return bool(selected_room_ids)
+
+    @staticmethod
+    def _known_room_ids(state: Any) -> list[int] | None:
+        """Return currently cached cleanable room IDs."""
+        map_data = getattr(state, "map_data", None)
+        if map_data is None:
+            return None
+        return [room.room_id for room in map_data.rooms if room.room_id > 0]
+
+    def _fan_speed_available(self, state: Any) -> bool:
+        """Return True when HA should expose the native fan speed control."""
+        setup_available = can_edit_pending_clean_settings(state)
+        live_available = super().available and is_live_clean_setting_available(state)
+        setup_applies = clean_setting_applies_to_mode(
+            "fan",
+            self.coordinator.clean_settings.work_mode,
+        )
+        live_applies = clean_setting_applies_to_mode(
+            "fan",
+            self.coordinator.clean_setting_applicability_mode(live=True),
+        )
+        return (setup_available and setup_applies) or (
+            live_available and live_applies
+        )
 
     @property
     def extra_restore_state_data(self) -> ExtraStoredData:
@@ -214,8 +327,12 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
             return VacuumActivity.IDLE
         is_cleaning_state = (
             state.working_status in ACTIVE_CLEANING_STATUSES
+            or state.has_assumed_robot_clean
             or state.has_recent_active_working_status
+            or state.has_paused_clean_task_context
         )
+        if state.working_status == WorkingStatus.ERROR or getattr(state, "has_error", False):
+            return VacuumActivity.ERROR
         # is_paused (field 3.2) stays stale after docking — only trust
         # during cleaning states. Paused takes priority over returning
         # since the robot physically stops when paused mid-return.
@@ -225,25 +342,21 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         # while navigating back to dock (field 3.7=1 indicates returning)
         if state.is_returning:
             return VacuumActivity.RETURNING
-        if state.is_cleaning:
+        if state.is_cleaning or state.has_assumed_robot_clean:
             return VacuumActivity.CLEANING
-        if state.is_docked:
+        if _is_dock_side(state):
             return VacuumActivity.DOCKED
         activity = WORKING_STATUS_TO_ACTIVITY.get(state.working_status)
+        if activity == VacuumActivity.DOCKED:
+            return VacuumActivity.IDLE
         if activity is not None:
             return activity
-        # Unknown working_status value: infer from dock signals so we don't
-        # report IDLE while the robot is clearly active off-dock. New firmware
-        # versions may introduce values we haven't mapped yet.
-        if not state.is_docked:
-            if state.working_status.value not in _WARNED_UNMAPPED_ACTIVITY:
-                _WARNED_UNMAPPED_ACTIVITY.add(state.working_status.value)
-                _LOGGER.warning(
-                    "Unmapped working_status %s (%d) while off-dock; reporting "
-                    "CLEANING (further occurrences are suppressed)",
-                    state.working_status.name,
-                    state.working_status.value,
-                )
+        if (
+            state.working_status == WorkingStatus.UNKNOWN
+            and state.has_explicit_off_dock_signal
+        ):
+            # New firmware may report an unknown status while the physical
+            # telemetry still proves the robot is away from its dock.
             return VacuumActivity.CLEANING
         return VacuumActivity.IDLE
 
@@ -258,7 +371,25 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         fan = self.coordinator.active_clean_setting("fan")
         if fan is None:
             fan = self.coordinator.clean_settings.fan
-        return _FAN_LABELS.get(int(fan))
+        return fan_speed_label_map_for(self.coordinator.config_entry.data).get(fan)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return task context for dashboard cards and automations."""
+        state = self.coordinator.data
+        if state is None:
+            return None
+
+        attributes: dict[str, Any] = {
+            "task_status": _task_status(state),
+            "status_summary": _status_summary(state),
+        }
+        active_cleaning_metrics = _has_active_cleaning_metrics(state)
+        if active_cleaning_metrics and state.task_progress_percent is not None:
+            attributes["progress"] = state.task_progress_percent
+        if active_cleaning_metrics and state.current_room_name:
+            attributes["current_room"] = state.current_room_name
+        return attributes
 
     # Timeout for action commands (start/stop/return) — robot may need
     # time to load map, plan route, etc., especially after waking.
@@ -277,33 +408,24 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
             await client.wake(timeout=10.0)
 
     async def _validate_clean_start(self) -> None:
-        """Refresh dock state and reject starts that conflict with dock work."""
-        if not await self.coordinator.async_refresh_dock_status():
-            raise HomeAssistantError("Narwal status could not be refreshed")
-        if not can_start_robot_clean(self.coordinator.client.state):
-            raise HomeAssistantError("Narwal dock task is active")
+        """Refresh dock state and clear safe dock blockers before clean start."""
+        if not await self.coordinator.async_prepare_clean_start():
+            raise HomeAssistantError("Narwal clean cannot be started right now")
 
     async def async_start(self) -> None:
         """Start or resume cleaning."""
-        await self._ensure_awake()
-        state = self.coordinator.data
-        if (
-            state
-            and not has_blocking_error(state)
-            and state.working_status != WorkingStatus.TASK_COMPLETED
-            and state.is_paused
-            and is_clean_session_context(state)
-        ):
-            response = await self.coordinator.client.resume(
-                timeout=self._ACTION_TIMEOUT
-            )
-            _raise_if_command_failed(response, "resume")
-            return
-        if getattr(self.coordinator, "_room_profile_store_loaded", True) is False:
-            raise HomeAssistantError("Narwal room profiles are not restored yet")
         room_ids: list[int] = []
         async with self.coordinator.dock_action_lock:
-            await self._validate_clean_start()
+            await self._ensure_awake()
+            if not await self.coordinator.async_refresh_action_status():
+                raise HomeAssistantError("Narwal status could not be refreshed")
+            state = self.coordinator.client.state
+            if can_resume_cleaning(state):
+                resp = await self.coordinator.client.resume(timeout=self._ACTION_TIMEOUT)
+                _raise_if_command_failed(resp, "resume")
+                return
+            if getattr(self.coordinator, "_room_profile_store_loaded", True) is False:
+                raise HomeAssistantError("Narwal room profiles are not restored yet")
 
             # The HA vacuum start command uses integration-owned room selections:
             # selected rooms when any are on, otherwise all rooms.
@@ -326,6 +448,9 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
                 room_ids,
                 map_id=map_id,
             )
+            await self._validate_clean_start()
+            if not can_start_cleaning(self.coordinator.client.state):
+                raise HomeAssistantError("Narwal clean cannot be started right now")
             resp = await self.coordinator.client.start_rooms(
                 room_ids,
                 work_mode=settings.work_mode,
@@ -356,7 +481,7 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         self.async_write_ha_state()
 
     async def _all_room_ids(self) -> list[int]:
-        """Return room ids from an authoritative static map."""
+        """Return every room from an authoritative map refresh."""
         try:
             await self.coordinator.client.get_map()
         except Exception as err:
@@ -367,52 +492,43 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         return []
 
     async def async_stop(self, **kwargs) -> None:
-        """Stop cleaning."""
-        await self._ensure_awake()
+        """Stop robot-side cleaning without affecting dock-only work."""
         async with self.coordinator.dock_action_lock:
-            refreshed = await self.coordinator.async_refresh_dock_status()
+            await self._ensure_awake()
+            refreshed = await self.coordinator.async_refresh_action_status()
+            if not refreshed:
+                raise HomeAssistantError("Narwal status could not be refreshed")
             state = self.coordinator.client.state
-            clean_context = is_clean_session_context(state)
-            if state.has_unmapped_active_dock_task and not clean_context:
-                raise HomeAssistantError(
-                    "Narwal dock task cannot be stopped safely right now"
-                )
-            if state.is_station_active and not clean_context:
-                if not can_stop_dock_task(state):
-                    raise HomeAssistantError(
-                        "Narwal dock task cannot be stopped safely right now"
-                    )
-                resp = await self.coordinator.client.stop_dock_task()
-            elif not clean_context:
-                if not refreshed:
-                    raise HomeAssistantError("Narwal status could not be refreshed")
-                raise HomeAssistantError("Narwal has no active task to stop")
-            else:
-                resp = await self.coordinator.client.stop()
+            if not _can_stop_vacuum(state):
+                raise HomeAssistantError("Narwal has no active robot task to stop")
+            resp = await self.coordinator.client.stop()
         _LOGGER.info("Stop response: code=%s, success=%s", resp.result_code, resp.success)
-        if not resp.accepted:
-            raise HomeAssistantError(
-                f"Narwal stop command failed: {_result_name(resp.result_code)}"
-            )
+        _raise_if_command_failed(resp, "stop")
 
     async def async_pause(self) -> None:
         """Pause cleaning."""
         async with self.coordinator.dock_action_lock:
-            if not await self.coordinator.async_refresh_dock_status():
+            await self._ensure_awake()
+            if not await self.coordinator.async_refresh_action_status():
                 raise HomeAssistantError("Narwal status could not be refreshed")
-            if has_active_dock_work(self.coordinator.client.state):
-                raise HomeAssistantError("Narwal dock task is active")
+            state = self.coordinator.client.state
+            if not can_pause_cleaning(state):
+                raise HomeAssistantError("Narwal clean cannot be paused right now")
             resp = await self.coordinator.client.pause()
         _LOGGER.info("Pause response: code=%s, success=%s", resp.result_code, resp.success)
+        _raise_if_command_failed(resp, "pause")
 
     async def async_return_to_base(self, **kwargs) -> None:
         """Return to the dock."""
-        await self._ensure_awake()
         async with self.coordinator.dock_action_lock:
-            if not await self.coordinator.async_refresh_dock_status():
+            await self._ensure_awake()
+            if not await self.coordinator.async_refresh_action_status():
                 raise HomeAssistantError("Narwal status could not be refreshed")
-            if has_active_dock_work(self.coordinator.client.state):
-                raise HomeAssistantError("Narwal dock task is active")
+            state = self.coordinator.client.state
+            if state.is_docked and _can_accept_return_home(state):
+                return
+            if not can_return_home(state):
+                raise HomeAssistantError("Narwal cannot return to the dock right now")
             resp = await self.coordinator.client.return_to_base(timeout=self._ACTION_TIMEOUT)
         _LOGGER.info(
             "Return-to-base response: code=%s, success=%s",
@@ -424,16 +540,20 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
                 _result_name(resp.result_code),
                 resp.result_code,
             )
+        _raise_if_command_failed(resp, "return to dock")
+        self.async_write_ha_state()
 
     async def async_locate(self, **kwargs) -> None:
         """Locate the vacuum — robot says 'Robot is here'."""
-        await self._ensure_awake()
         async with self.coordinator.dock_action_lock:
-            if not await self.coordinator.async_refresh_dock_status():
+            await self._ensure_awake()
+            if not await self.coordinator.async_refresh_action_status():
                 raise HomeAssistantError("Narwal status could not be refreshed")
-            if has_active_dock_work(self.coordinator.client.state):
-                raise HomeAssistantError("Narwal dock task is active")
-            await self.coordinator.client.locate()
+            state = self.coordinator.client.state
+            if not can_locate_robot(state):
+                raise HomeAssistantError("Narwal locate cannot be used right now")
+            resp = await self.coordinator.client.locate()
+        _raise_if_command_failed(resp, "locate")
 
     async def async_set_fan_speed(self, fan_speed: str, **kwargs) -> None:
         """Set the fan speed.
@@ -441,9 +561,10 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
         Stores it as whole-floor pending suction when no rooms are selected;
         while cleaning, it also writes the active task live.
         """
-        level = FAN_SPEED_MAP.get(fan_speed)
+        fan_speed_map = fan_speed_map_for(self.coordinator.config_entry.data)
+        level = fan_speed_map.get(fan_speed)
         if level is None:
-            return
+            raise HomeAssistantError(f"Unsupported Narwal fan speed: {fan_speed}")
         state = self.coordinator.data
         has_selected_rooms = self.coordinator.has_selected_clean_rooms()
         setup_available = (
@@ -455,10 +576,9 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
             "fan",
             self.coordinator.clean_settings.work_mode,
         )
-        live_mode = self.coordinator.clean_setting_applicability_mode(live=True)
-        live_applies = (
-            live_mode is not None
-            and clean_setting_applies_to_mode("fan", live_mode)
+        live_applies = clean_setting_applies_to_mode(
+            "fan",
+            self.coordinator.clean_setting_applicability_mode(live=True),
         )
         if not (
             (setup_available and setup_applies)
@@ -532,13 +652,10 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
             raise HomeAssistantError("Narwal segment IDs must be positive")
 
         async with self.coordinator.dock_action_lock:
-            await self._validate_clean_start()
             try:
                 await self.coordinator.client.get_map()
             except Exception as err:
-                raise HomeAssistantError(
-                    "Narwal map could not be refreshed"
-                ) from err
+                raise HomeAssistantError("Narwal map could not be refreshed") from err
             state = self.coordinator.client.state
             known_ids = {
                 room.room_id
@@ -555,6 +672,7 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
                 )
             settings = self.coordinator.clean_settings
             room_settings = self.coordinator.room_clean_settings_for_rooms(room_ids)
+            await self._validate_clean_start()
             _LOGGER.info(
                 "Starting room-specific clean: rooms=%s mode=%s fan=%s water=%s "
                 "mop_strength=%s passes=%s route=%s",
@@ -619,9 +737,15 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
             if r.room_id > 0
         }
         last_set = {(s.id, s.name) for s in last}
-        if current_set != last_set:
-            _LOGGER.info(
-                "Segment change detected: %d -> %d rooms",
-                len(last_set), len(current_set),
-            )
-            self.async_create_segments_issue()
+        if current_set == last_set:
+            self._last_reported_segment_signature = None
+            return
+        signature = (frozenset(last_set), frozenset(current_set))
+        if signature == self._last_reported_segment_signature:
+            return
+        self._last_reported_segment_signature = signature
+        _LOGGER.info(
+            "Segment change detected: %d -> %d rooms",
+            len(last_set), len(current_set),
+        )
+        self.async_create_segments_issue()

--- a/custom_components/narwal/vacuum.py
+++ b/custom_components/narwal/vacuum.py
@@ -42,6 +42,7 @@ from .coordinator import (
     clean_setting_applies_to_mode,
     is_live_clean_setting_available,
 )
+from .dock_tasks import ROBOT_RETURN_COMPATIBLE_DOCK_TASKS
 from .entity import NarwalEntity
 from .narwal_client import CommandResult, FanLevel, WorkingStatus
 from .narwal_client.const import ACTIVE_CLEANING_STATUSES
@@ -147,7 +148,17 @@ def _has_dock_stop_context(state: Any) -> bool:
 
 def _can_stop_vacuum(state: Any) -> bool:
     """Return true when the aggregate vacuum stop command is safe to expose."""
-    if _has_dock_stop_context(state) and not _has_live_robot_stop_context(state):
+    compatible_metric_clean = (
+        state.has_recent_active_working_status
+        and not state.has_unmapped_active_dock_task
+        and set(state.active_dock_task_keys)
+        <= ROBOT_RETURN_COMPATIBLE_DOCK_TASKS
+    )
+    if (
+        _has_dock_stop_context(state)
+        and not _has_live_robot_stop_context(state)
+        and not compatible_metric_clean
+    ):
         return False
     return can_stop_cleaning(state)
 
@@ -300,7 +311,10 @@ class NarwalVacuum(NarwalEntity, RestoreEntity, StateVacuumEntity):
 
     def _fan_speed_available(self, state: Any) -> bool:
         """Return True when HA should expose the native fan speed control."""
-        setup_available = can_edit_pending_clean_settings(state)
+        setup_available = (
+            can_edit_pending_clean_settings(state)
+            and not self.coordinator.has_selected_clean_rooms()
+        )
         live_available = super().available and is_live_clean_setting_available(state)
         setup_applies = clean_setting_applies_to_mode(
             "fan",

--- a/docs/DOCK_TASKS.md
+++ b/docs/DOCK_TASKS.md
@@ -89,10 +89,19 @@ Current verified policy should be conservative:
 
 - Do not allow dock-to-dock parallel starts unless hardware testing proves the
   exact combination.
-- Allow robot start during `dry_dock_bag` only when there is typed live evidence
-  that the active task is dock-bag drying.
-- Block robot starts for emptying, washing, mop drying, dust-bin drying, and
-  unmapped station activity.
+- Treat robot Start/Clean Area as an intent. Send it directly during typed mop,
+  dust-bin, or dock-bag drying: live Flow 2 tests show that the robot ends the
+  first two itself and allows dock-bag drying to continue after departure.
+- Stop a single typed emptying or washing task, refresh, then send the robot
+  command. A wash stop may transition into mop drying, which is safe to hand off
+  to the clean command.
+- Keep mixed emptying/washing plus drying states fail-closed because generic
+  force-end cannot identify one task safely in that state.
+- For multi-target room-clean service calls, reject dock-stop preparation
+  instead of partially cancelling maintenance on one target before another
+  target fails.
+- Block robot starts for ambiguous mixed station activity, unmapped station
+  activity, active robot work, faults, and stale status.
 - Keep robot `stop` available during a dock-side phase that belongs to an
   active clean.
 - Do not infer charge-to-resume from dock maintenance.

--- a/docs/DOCK_TASK_TEST_PLAN.md
+++ b/docs/DOCK_TASK_TEST_PLAN.md
@@ -79,8 +79,8 @@ Direct client calls:
 | Charging to resume | all five dock tasks | active task if present | Separate recharge from dock maintenance |
 | Dock-side phase during clean | none | robot stop, matching dock stop | Keep robot cancellation available |
 | Unmapped active station task | all five dock tasks | active task if known | Block unsafe starts |
-| `dry_dock_bag` active | room clean, all other dock tasks | `dry_dock_bag` | Validate robot-compatible dock task |
-| Robot leaves while `dry_dock_bag` active | no dock starts | `dry_dock_bag` | Preserve dock-owned task after departure |
+| `dry_dock_bag` active | room clean, all other dock tasks | `dry_dock_bag` | Validate clean starts while dock-bag drying continues |
+| Robot leaves while `dry_dock_bag` active | no dock starts | `dry_dock_bag` | Preserve already-running dock-owned task after departure |
 
 ## Conflict Matrix
 
@@ -106,7 +106,9 @@ For each active dock task, also try:
 Expected conservative default before verification:
 
 - Other dock task starts are unavailable.
-- Robot start is unavailable except during verified `dry_dock_bag`.
+- Robot start is exposed directly during typed drying tasks. During a single
+  emptying or washing task, it is exposed when preflight can stop that task,
+  refresh, then send the clean command.
 - Robot stop remains available only when the dock task is part of an active
   robot clean session.
 - Locate and return-to-base should not run while station work would make the
@@ -185,6 +187,71 @@ confirmed the same dust-bin drying task was active. Treat that as real device
 telemetry, not a restored HA switch assumption. Dock task switches should only
 come from robot telemetry or a short accepted-command guard.
 
+### 2026-08-29, Flow 2 upstairs, firmware `v01.09.08.00`
+
+Tested through Home Assistant service calls against the upstairs robot.
+
+| Scenario | Result | Notes |
+|---|---|---|
+| HA restart/load while robot docked idle | needs refresh | Vacuum loaded as `docked`, but all dock task switches were `unavailable` until `homeassistant.update_entity` refreshed the Narwal entities. |
+| `empty_dustbin` start/stop | verified | Start set only the empty switch on; other dock starts were unavailable; stop cleared it back to idle. |
+| `wash_mop` start/stop | verified | Stop was accepted and then the dock automatically entered `dry_mop`, matching app-style wash behavior. |
+| clean start during `dry_mop` | blocked | Current code returned a service error instead of stopping the safe blocker first. |
+| `dry_mop` stop | verified | Generic single-task stop cleared the task after the auto-dry phase. |
+| `dry_dust_bin` start | verified | Timer/progress appeared as `45m` and percent progress. |
+| clean start during `dry_dust_bin` | blocked | Current code rejected before attempting a safe blocker stop. |
+| `dry_dust_bin` stop after stale state | fixed in code | First stop attempt was rejected before refresh; an explicit entity refresh then allowed the scoped `0805` stop to clear it. Switch stop now refreshes before stop validation. |
+| `dry_dock_bag` start/stop | verified with caveat | Scoped `0801` stop cleared a correctly typed dock-bag drying task after status settled. A generic-force-end probe did not clear it and briefly exposed overlapping dry task telemetry; do not replace the scoped payload. |
+| clean start during `dry_dock_bag` | accepted, needs repeat | `narwal.clean_rooms` returned success while dock-bag drying was active; HA did not show robot progress for ~25s, then after a HA restart the robot reported Bathroom cleaning at 91%. Treat this as evidence that the robot may accept it, not as the integration rule for a new Start intent. |
+| robot pause during near-complete clean | inconclusive | `vacuum.pause` returned success but HA stayed cleaning at 91%; this may have been a near-completion race. |
+| robot stop/return after accepted clean | verified | `vacuum.stop` accepted, then `vacuum.return_to_base` accepted. After a refresh the vacuum was `docked` and all dock switches were idle. |
+| repeat clean start after `dry_mop` | blocked by hardware fault | After deploying the stricter start planner, a room clean request stopped `dry_mop` and was accepted. Follow-up refresh showed Bathroom progress, but the robot then entered fault `34603041` (`0x02100021`): trapped while navigating back to the base, with no automatic recall. Further live testing needs the upstairs robot physically cleared/reset first. |
+
+Code follow-up from this run:
+
+- Dock switch start/stop service methods refresh before rejecting so stale local
+  state does not block a task that fresh telemetry can stop.
+- Clean start paths should treat Start as an intent: hand typed drying tasks to
+  the robot command, or stop one known emptying/washing task and refresh first.
+  They still fail closed for unmapped activity, ambiguous mixed blockers,
+  active robot work, faults, and stale status.
+- Multi-target room-clean service calls preflight every target before any start.
+  If any target would require stopping a dock task, the call fails before
+  mutation because dock-stop preparation cannot be rolled back atomically.
+- Vacuum supported features should expose Start/Clean Area when the clean-start
+  planner can first clear a safe dock blocker.
+
+### 2026-08-29, Flow 2 downstairs, firmware `v01.09.08.00`
+
+Tested through Home Assistant first, then with Core stopped and a direct local
+client for commands that intentionally bypass the integration's safety gate.
+
+| Active dock task | HA Start with preflight | Raw clean command | Start rule |
+|---|---|---|---|
+| none | accepted; cleaning began | not repeated | send directly |
+| `empty_dustbin` | stopped task, then cleaning began | `CONFLICT` in the direct-client matrix | stop, refresh, start |
+| `wash_mop` | stopped task, then cleaning began | previously returned success without starting and left contradictory fields | stop, refresh, start |
+| `dry_mop` | stopped by the old preflight, then cleaning began | accepted; timer cleared and robot departed | send directly |
+| `dry_dust_bin` | stopped by the old preflight, then cleaning began | accepted; timer cleared and robot departed | send directly |
+| `dry_dock_bag` | stopped by the old preflight, then cleaning began | accepted; timer remained active after robot departure | send directly |
+
+While the robot was cleaning, Home Assistant removed the native Start feature.
+The public service therefore rejected a second start before it reached the
+integration action method.
+
+A raw `dry_station_bag` command sent while `dry_mop` was active returned success,
+but repeated full status refreshes never reported dock-bag drying. This is a
+no-op, not proof that user-started dock tasks can run in parallel. Parallel dock
+task starts remain unavailable. If authoritative telemetry reports multiple
+drying timers, the clean command may be sent directly because each reported
+drying task has independently been verified as start-compatible. Mixed
+emptying/washing plus drying remains fail-closed.
+
+Direct raw starts also showed why command acceptance alone is insufficient:
+after a clean command, coarse `DOCKED_V2` persisted briefly while fields 11 and
+47 correctly changed to off-dock. Follow-up telemetry, not the response code or
+coarse status, was used to classify every result.
+
 ## Per-Task Evidence
 
 ### Empty dustbin
@@ -235,7 +302,8 @@ Verify:
 - Start command accepted from docked idle.
 - Active state maps to `dry_dock_bag`.
 - Timer fields `12/13`, if present, produce `progress` and `time_left`.
-- Robot can start a clean while dock-bag drying continues.
+- A new robot Start intent leaves dock-bag drying active and sends the clean
+  command directly.
 - The switch stays on after the robot leaves the dock if the dock task is still
   running.
 - Typed stop stops dock-bag drying without cancelling a robot clean.
@@ -255,8 +323,8 @@ Unit/entity tests should cover:
 - Wake paths refresh status and revalidate the selected task before command
   dispatch.
 - Polling-only command assumptions clear on authoritative idle state or TTL.
-- `dry_dock_bag` is preserved during robot departure only when backed by typed
-  evidence or a bounded accepted-command fallback.
+- `dry_dock_bag` remains active when a new robot Start is sent; authoritative
+  dock-bag telemetry remains visible after the robot departs.
 - Dock maintenance does not create charge-to-resume.
 - Robot stop remains available during active-clean dock phases.
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -366,13 +366,16 @@ is a mistake this project has made in both directions:
 
 ### `map/display_map` — live position
 
-Sent every ~1.5 s while cleaning; grows as area accumulates (~264 B → ~945 B over 15 s).
+Sent every ~1.5 s while cleaning. Field 2 is a moving window rather than the
+complete route: a live Freo X Ultra capture repeatedly carried 30 points, with
+the next observed window sharing four points with the previous one. Consumers
+must join exact overlapping coordinates if they want to retain the whole route.
 
 | Field | Meaning |
 |---|---|
 | 1.1.1 / 1.1.2 | Robot X / Y — float32, **decimetres** |
 | 1.2 | Heading — float32 radians, [-π, π] |
-| 2 | Accumulated trajectory `{1: x_bytes, 2: y_bytes}` |
+| 2 | Rolling trajectory window `{1: x_bytes, 2: y_bytes}` |
 | 5 | Dock reference position (constant) |
 | 7 | Cleaned-area overlay: `{1: width, 2: height, 3: zlib grid}` — *not* the house map |
 | 10 | Timestamp, **milliseconds** since epoch |
@@ -388,7 +391,6 @@ it is the signature of a job about to abort, not a robot at the origin.
 | `upgrade/upgrade_status` | 2 status, 3 progress, 4 stage, 7 current firmware, 8 target firmware |
 | `status/download_status` | OTA download state |
 | `status/time_line_status` | Session timeline |
-| `status/point_navi_plan_traj` | Navigation trajectory points |
 | `report/clean_report` | End-of-session summary: 3 elapsed, 6 start, 7 end, 12 detail, 33 end-reason string (localized) |
 | `developer/planning_debug_info` | Bumper/cliff/mop-collision sensor debug |
 
@@ -573,14 +575,13 @@ rest are known-to-exist and unexplored — good starting points for anyone probi
 | 63 | `/status/download_status` | R→C | Status | ✓ |
 | 64 | `/status/time_line_status` | R→C | Status | ✓ |
 | 65 | `/status/app_status_heartbeat` | R→C | Status | ✓ |
-| 66 | `/status/point_navi_plan_traj` | R→C | Status | |
 | 67 | `/report/clean_report` | C→R | Report | |
 | 68 | `/clean/report` | C→R | Report | |
 | 69 | `/developer/ping` | C→R | Developer | ✓ |
 | 70 | `/developer/take_picture` | C→R | Developer | ✓ |
 | 71 | `/developer/take_picture/response` | R→C | Developer | ✓ |
 | 72 | `/developer/led_control` | C→R | Developer | ✓ |
-| 73 | `/developer/planning_debug_info` | R→C | Developer | ✓ |
+| 73 | `/developer/planning_debug_info` | R→C | Developer | |
 | 74 | `/info/get_clean_time_line` | C→R | Status | |
 | 75 | `/info/get_clean_time_line/response` | R→C | Status | |
 

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -122,6 +122,7 @@ def _clean_session_context(state: NarwalState) -> bool:
         or state.working_status in ACTIVE_CLEANING_STATUSES
         or state.working_status == WorkingStatus.TASK_COMPLETED
         or state.has_recent_active_working_status
+        or state.has_paused_clean_task_context
         or state.is_returning
     )
 
@@ -133,13 +134,20 @@ def _robot_work_blocks_generic_dock_stop(state: NarwalState) -> bool:
         or state.has_assumed_robot_clean
         or state.working_status in ACTIVE_CLEANING_STATUSES
         or state.has_recent_active_working_status
+        or state.has_paused_clean_task_context
         or state.is_returning
     )
 
 
 def _robot_start_blocked(state: NarwalState) -> bool:
-    """Return true when a private guard or dock task blocks a start."""
-    return state.has_assumed_robot_clean or state.blocks_robot_start_for_dock_task
+    """Return true unless fresh state permits dispatching a robot start."""
+    return (
+        state.has_error
+        or state.working_status in (WorkingStatus.UNKNOWN, WorkingStatus.ERROR)
+        or not state.is_docked
+        or _clean_session_context(state)
+        or state.blocks_robot_start_for_dock_task
+    )
 
 
 def _can_force_end_scoped_dock_task(state: NarwalState, task: str | None) -> bool:
@@ -177,33 +185,6 @@ def _base_status_working_status(decoded: dict[str, Any] | object) -> WorkingStat
         return WorkingStatus(int(field3["1"]))
     except (TypeError, ValueError):
         return None
-
-
-def _base_status_confirms_docked(
-    decoded: dict[str, Any] | object, status: WorkingStatus | None
-) -> bool:
-    """Return true when a terminal status also carries live dock indicators."""
-    if not isinstance(decoded, dict) or status not in _STALE_DOCK_BASE_STATUSES:
-        return False
-
-    field3 = decoded.get("3")
-    if isinstance(field3, list):
-        field3 = field3[0] if field3 else None
-    field3 = field3 if isinstance(field3, dict) else {}
-
-    def int_field(container: dict[str, Any], field: str) -> int:
-        try:
-            return int(container.get(field, 0))
-        except (TypeError, ValueError):
-            return 0
-
-    return (
-        int_field(decoded, "11") >= 2
-        or int_field(decoded, "47") in (1, 3)
-        or int_field(field3, "3") in (1, 6)
-        or int_field(field3, "10") == 1
-        or int_field(field3, "12") > 0
-    )
 
 
 def _base_status_payload(response: CommandResponse) -> dict[str, Any] | None:
@@ -360,7 +341,6 @@ class NarwalClient:
         if (
             self.state.has_recent_active_working_status
             and status in _STALE_DOCK_BASE_STATUSES
-            and not _base_status_confirms_docked(decoded, status)
         ):
             self.state.update_battery_from_base_status(decoded)
             _LOGGER.debug(
@@ -1226,14 +1206,14 @@ class NarwalClient:
         Newer firmware answers SUCCESS there and does nothing, so this path
         fails clearly when no room list is available instead (#69).
         """
+        if not self.connected:
+            raise NarwalConnectionError("Not connected to vacuum")
         if _robot_start_blocked(self.state):
             _LOGGER.warning(
                 "start: robot or dock task active (%s); not starting whole-house clean",
                 self.state.active_dock_task_keys or "unmapped",
             )
             return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
-        if not self.connected:
-            raise NarwalConnectionError("Not connected to vacuum")
         room_ids = await self._all_room_ids()
         if not room_ids:
             _LOGGER.warning("start(): no map rooms available")
@@ -1518,7 +1498,11 @@ class NarwalClient:
 
             map_data = self.state.map_data
             if not map_data or not map_data.map_id:
-                map_data = await self.get_map()
+                try:
+                    map_data = await self.get_map()
+                except NarwalCommandError as err:
+                    _LOGGER.warning("start_rooms: map fetch failed: %s", err)
+                    map_data = self.state.map_data
             map_id = map_data.map_id if map_data else 0
             if not map_id:
                 _LOGGER.warning(
@@ -1541,6 +1525,11 @@ class NarwalClient:
             except ValueError as err:
                 _LOGGER.warning("start_rooms: %s", err)
                 return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+            if _robot_start_blocked(self.state):
+                _LOGGER.warning(
+                    "start_rooms: state changed before dispatch; not starting room clean"
+                )
+                return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
             resp = await self.send_command(
                 TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
             )
@@ -1556,6 +1545,11 @@ class NarwalClient:
                     break
                 _LOGGER.info("start_rooms: robot docking/settling, retrying clean/start_clean")
                 await asyncio.sleep(3.0)
+                if _robot_start_blocked(self.state):
+                    _LOGGER.warning(
+                        "start_rooms: state changed before retry; not starting room clean"
+                    )
+                    return CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
                 resp = await self.send_command(
                     TOPIC_CMD_CLEAN_TASK, payload=payload, timeout=10.0,
                 )

--- a/narwal_client/client.py
+++ b/narwal_client/client.py
@@ -351,6 +351,17 @@ class NarwalClient:
 
         self.state.update_from_base_status(decoded)
 
+    def _update_from_display_map_broadcast(self, decoded: dict[str, Any]) -> None:
+        """Apply a display-map broadcast and mark the trajectory as fresh."""
+        self.state.map_display_data = MapDisplayData.from_broadcast(decoded)
+        self._last_display_map_time = time.monotonic()
+        _LOGGER.debug(
+            "display_map received: robot=(%.2f, %.2f) ts=%d",
+            self.state.map_display_data.robot_x,
+            self.state.map_display_data.robot_y,
+            self.state.map_display_data.timestamp,
+        )
+
     async def connect(self) -> None:
         """Establish WebSocket connection to the vacuum.
 
@@ -646,14 +657,7 @@ class NarwalClient:
         elif short_topic == "status/download_status":
             self.state.update_from_download_status(decoded)
         elif short_topic == "map/display_map":
-            self.state.map_display_data = MapDisplayData.from_broadcast(decoded)
-            self._last_display_map_time = time.monotonic()
-            _LOGGER.debug(
-                "display_map received: robot=(%.2f, %.2f) ts=%d",
-                self.state.map_display_data.robot_x,
-                self.state.map_display_data.robot_y,
-                self.state.map_display_data.timestamp,
-            )
+            self._update_from_display_map_broadcast(decoded)
         if self.on_state_update:
             self.on_state_update(self.state)
 
@@ -706,7 +710,7 @@ class NarwalClient:
         """Encode a protobuf string field."""
         return cls._encode_bytes_field(field_num, text.encode("utf-8"))
 
-    # All broadcast topics the robot can send — used for active_robot_publish
+    # Broadcast topics needed for state, maps and diagnostics.
     _ALL_BROADCAST_TOPICS = [
         "status/robot_base_status",
         "status/working_status",
@@ -714,8 +718,6 @@ class NarwalClient:
         "status/download_status",
         "map/display_map",
         "status/time_line_status",
-        "status/point_navi_plan_traj",
-        "developer/planning_debug_info",
     ]
 
     def _build_topic_subscription(self, duration: int = 600) -> bytes:
@@ -1142,7 +1144,7 @@ class NarwalClient:
             elif short_topic == "status/download_status":
                 self.state.update_from_download_status(decoded)
             elif short_topic == "map/display_map":
-                self.state.map_display_data = MapDisplayData.from_broadcast(decoded)
+                self._update_from_display_map_broadcast(decoded)
 
         raise NarwalCommandError(
             f"No field5 response within {timeout}s"

--- a/narwal_client/const.py
+++ b/narwal_client/const.py
@@ -68,7 +68,6 @@ TOPIC_UPGRADE_STATUS = "upgrade/upgrade_status"
 TOPIC_DOWNLOAD_STATUS = "status/download_status"
 TOPIC_DISPLAY_MAP = "map/display_map"
 TOPIC_TIMELINE_STATUS = "status/time_line_status"
-TOPIC_PLANNING_DEBUG = "developer/planning_debug_info"
 
 # --- Command topics (client → robot, confirmed working) ---
 # Common

--- a/narwal_client/map_renderer.py
+++ b/narwal_client/map_renderer.py
@@ -18,6 +18,10 @@ import io
 import logging
 import math
 import zlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from PIL import Image, ImageDraw
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -123,7 +127,7 @@ def _load_font(image_font: object, size: int):
     for path in FONT_PATHS:
         try:
             return image_font.truetype(path, size)
-        except (IOError, OSError):
+        except OSError:
             continue
     return image_font.load_default()
 
@@ -135,7 +139,7 @@ def _scaled_coord(value: float, scale: float, size: int) -> int:
 
 
 def _draw_label(
-    draw: "ImageDraw.ImageDraw",
+    draw: ImageDraw.ImageDraw,
     xy: tuple[int, int],
     text: str,
     font: object,
@@ -388,7 +392,7 @@ def _darken(color: tuple[int, int, int], amount: int = 80) -> tuple[int, int, in
 
 
 def _draw_dock(
-    draw: "ImageDraw.ImageDraw",
+    draw: ImageDraw.ImageDraw,
     dock_x: int,
     dock_y: int,
     size: int = 6,
@@ -428,7 +432,7 @@ def _draw_dock(
 
 
 def _draw_robot(
-    draw: "ImageDraw.ImageDraw",
+    draw: ImageDraw.ImageDraw,
     rx: int,
     ry: int,
     heading: float | None,
@@ -482,7 +486,6 @@ def _draw_robot(
     )
 
     # Flow-style front sensor bar, rotated with heading.
-    front_centre = point(radius * 0.58, 0)
     bar_half_width = radius * 0.38
     bar_half_height = max(2, radius * 0.13)
     bar = [
@@ -594,10 +597,11 @@ def render_map_png(
             room_id = val >> 8
             ptype = val & 0xFF
 
-            if 1 <= room_id <= len(ROOM_COLORS):
-                base = ROOM_COLORS[room_id - 1]
-            else:
-                base = COLOR_FALLBACK
+            base = (
+                ROOM_COLORS[room_id - 1]
+                if 1 <= room_id <= len(ROOM_COLORS)
+                else COLOR_FALLBACK
+            )
 
             if ptype & 0x10:  # wall/border edge
                 px[x, y] = _opaque(_darken(base))
@@ -691,13 +695,13 @@ def render_base_map(
     dock_x: float | None = None,
     dock_y: float | None = None,
     room_names: dict[int, str] | None = None,
-    obstacles: "list | None" = None,
+    obstacles: list | None = None,
     origin_x: int = 0,
     origin_y: int = 0,
     show_obstacle_labels: bool = True,
     show_room_labels: bool = True,
     show_dock: bool = True,
-) -> "Image.Image | None":
+) -> Image.Image | None:
     """Render the static floor plan as a PIL Image (no robot overlay).
 
     Returns a PIL Image that can be cached and reused across frames.
@@ -750,10 +754,11 @@ def render_base_map(
             room_id = val >> 8
             ptype = val & 0xFF
 
-            if 1 <= room_id <= len(ROOM_COLORS):
-                base = ROOM_COLORS[room_id - 1]
-            else:
-                base = COLOR_FALLBACK
+            base = (
+                ROOM_COLORS[room_id - 1]
+                if 1 <= room_id <= len(ROOM_COLORS)
+                else COLOR_FALLBACK
+            )
 
             if ptype & 0x10:
                 px[x, y] = _opaque(_darken(base))
@@ -847,7 +852,7 @@ def render_base_map(
 
 
 def render_overlay(
-    base_img: "Image.Image",
+    base_img: Image.Image,
     height: int,
     robot_x: float | None = None,
     robot_y: float | None = None,
@@ -867,7 +872,7 @@ def render_overlay(
         robot_x: Robot X in grid coordinates.
         robot_y: Robot Y in grid coordinates.
         robot_heading: Heading in degrees.
-        trail: List of (grid_x, grid_y) positions to draw as cleaning path.
+        trail: Narwal-native display_map trajectory points in grid coordinates.
         rotation_degrees: Clockwise map rotation in degrees.
         zoom: Centre zoom factor.
         room_labels: Room label centre points in grid coordinates.
@@ -910,10 +915,9 @@ def render_overlay(
         tx, ty = transformed
         return int(round(tx)), int(round(ty))
 
-    # Draw trail, splitting at invalid samples or impossible jumps.
+    # Draw the Narwal-native trajectory, skipping invalid or discontinuous points.
     if trail and len(trail) >= 2:
-        recent_start = max(len(trail) - 200, 0)
-        trail_width = max(3, int(round(2 * scale)))
+        trail_width = max(1, int(round(scale)))
         previous_grid: tuple[float, float] | None = None
         previous_point: tuple[int, int] | None = None
         for i in range(len(trail) - 1):
@@ -935,12 +939,11 @@ def render_overlay(
                     grid_y - previous_grid[1],
                 )
                 if distance <= max_grid_segment:
-                    color = (
-                        (255, 255, 255, 220)
-                        if i >= recent_start
-                        else (215, 220, 225, 130)
+                    draw.line(
+                        [previous_point, point],
+                        fill=(255, 255, 255, 220),
+                        width=trail_width,
                     )
-                    draw.line([previous_point, point], fill=color, width=trail_width)
 
             previous_grid = (grid_x, grid_y)
             previous_point = point
@@ -1000,10 +1003,10 @@ def render_overlay(
 
 
 def _apply_view_transform(
-    img: "Image.Image",
+    img: Image.Image,
     rotation_degrees: int = 0,
     zoom: float = 1.0,
-) -> "Image.Image":
+) -> Image.Image:
     """Apply final map rotation and centre zoom."""
     rotation = _normalize_rotation(rotation_degrees)
     if rotation:

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import math
 import struct
 import time
+import zlib
 from dataclasses import dataclass, field
 from typing import Any, ClassVar
 
@@ -251,12 +253,132 @@ def _to_float32(val: Any) -> float | None:
     return None
 
 
+def overlay_to_grid(value: float, origin: int) -> float | None:
+    """Convert a Narwal map/display_map coordinate to a grid coordinate."""
+    if not math.isfinite(value):
+        return None
+    return value - origin
+
+
 def _optional_int(value: Any) -> int | None:
     """Coerce a protobuf scalar to int when possible."""
     try:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+def _packed_float32_values(value: Any) -> list[float]:
+    """Decode a protobuf packed fixed32/float stream."""
+    if isinstance(value, (bytes, bytearray)):
+        raw = bytes(value)
+        return [
+            struct.unpack_from("<f", raw, offset)[0]
+            for offset in range(0, len(raw) - len(raw) % 4, 4)
+        ]
+    if isinstance(value, str):
+        raw = value.encode("latin-1", "ignore")
+        return [
+            struct.unpack_from("<f", raw, offset)[0]
+            for offset in range(0, len(raw) - len(raw) % 4, 4)
+        ]
+    if isinstance(value, list):
+        values: list[float] = []
+        for item in value:
+            parsed = _to_float32(item)
+            if parsed is not None:
+                values.append(parsed)
+        return values
+    return []
+
+
+def _packed_float32_bytes(value: Any) -> bytes:
+    """Return raw packed float32 bytes from a protobuf field."""
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value)
+    if isinstance(value, str):
+        return value.encode("latin-1", "ignore")
+    if isinstance(value, list):
+        raw = bytearray()
+        for item in value:
+            parsed = _to_float32(item)
+            raw.extend(struct.pack("<f", parsed if parsed is not None else float("nan")))
+        return bytes(raw)
+    return b""
+
+
+def _decode_trajectory(
+    x_values: bytes,
+    y_values: bytes,
+) -> list[tuple[float, float]]:
+    """Decode map/display_map field 2 into Narwal-native trajectory points."""
+    import math
+
+    xs = _packed_float32_values(x_values)
+    ys = _packed_float32_values(y_values)
+    # X/Y are parallel streams. Filter after zipping so one invalid value
+    # drops that coordinate pair instead of shifting the axes.
+    return [
+        (x, y)
+        for x, y in zip(xs, ys, strict=False)
+        if math.isfinite(x) and math.isfinite(y)
+    ]
+
+
+def _trajectory_window_streams(
+    decoded: dict[str, Any],
+) -> tuple[
+    bytes,
+    bytes,
+    tuple[int, int, int] | tuple[()],
+    tuple[int, ...],
+]:
+    """Return one native trajectory window and its deterministic signature."""
+    raw = decoded.get("2")
+    if not isinstance(raw, dict):
+        return b"", b"", (), ()
+    x_values = _packed_float32_bytes(raw.get("1"))
+    y_values = _packed_float32_bytes(raw.get("2"))
+    pair_bytes = min(len(x_values), len(y_values))
+    pair_bytes -= pair_bytes % 4
+    if pair_bytes <= 0:
+        return b"", b"", (), ()
+    finite_x = bytearray()
+    finite_y = bytearray()
+    breaks: list[int] = []
+    pending_break = False
+    for offset in range(0, pair_bytes, 4):
+        x_chunk = x_values[offset : offset + 4]
+        y_chunk = y_values[offset : offset + 4]
+        x = struct.unpack("<f", x_chunk)[0]
+        y = struct.unpack("<f", y_chunk)[0]
+        if not (math.isfinite(x) and math.isfinite(y)):
+            pending_break = bool(finite_x)
+            continue
+        if pending_break:
+            breaks.append(len(finite_x) // 4)
+            pending_break = False
+        finite_x.extend(x_chunk)
+        finite_y.extend(y_chunk)
+    if not finite_x:
+        return b"", b"", (), ()
+    x_values = bytes(finite_x)
+    y_values = bytes(finite_y)
+    trajectory_breaks = tuple(breaks)
+    break_bytes = b"".join(
+        index.to_bytes(4, "little", signed=False) for index in trajectory_breaks
+    )
+    return (
+        x_values,
+        y_values,
+        (
+            len(x_values) // 4,
+            zlib.crc32(x_values) & 0xFFFFFFFF,
+            zlib.crc32(break_bytes, zlib.crc32(y_values)) & 0xFFFFFFFF,
+        ),
+        trajectory_breaks,
+    )
+
 
 
 def _dock_drying_timers(decoded: dict[str, Any]) -> dict[str, DockTaskTimer]:
@@ -447,7 +569,8 @@ class MapData:
 
         # Extract origin offsets from field 6 (coordinate transform).
         # Field 6: {1: origin_y, 2: ?, 3: origin_x, 4: resolution}
-        # Positions are in grid-offset units: pixel = raw - origin
+        # field 6 provides grid origin offsets used by live map overlays:
+        # pixel = value - origin
         origin_x = 0
         origin_y = 0
         field6 = payload.get("6")
@@ -458,10 +581,10 @@ class MapData:
                 origin_y = int(field6.get("1", 0))
 
         # Parse dock position from field 8 (dock/charging station location).
-        # Field 8 structure: {1: {1: x_dm, 2: y_dm}, 2: heading_rad}
-        # Coordinates are in decimeters (same as display_map field 5).
+        # Field 8 structure: {1: {1: x, 2: y}, 2: heading_rad}
+        # Coordinates use the same live map units as display_map field 5.
         # Matches display_map field 5 (confirmed via live capture cross-reference).
-        # Pixel transform: px = (x_dm * 10) / cm_per_pixel - origin
+        # Pixel transform: px = value - origin
         dock_x = None
         dock_y = None
         field8 = payload.get("8")
@@ -469,11 +592,11 @@ class MapData:
             pos = field8.get("1")
             if isinstance(pos, dict) and "1" in pos and "2" in pos:
                 try:
-                    x_dm = _to_float32(pos["1"])
-                    y_dm = _to_float32(pos["2"])
-                    if x_dm is not None and y_dm is not None:
-                        dock_x = x_dm - origin_x
-                        dock_y = y_dm - origin_y
+                    x_pos = _to_float32(pos["1"])
+                    y_pos = _to_float32(pos["2"])
+                    if x_pos is not None and y_pos is not None:
+                        dock_x = overlay_to_grid(x_pos, origin_x)
+                        dock_y = overlay_to_grid(y_pos, origin_y)
                 except (struct.error, OverflowError, ValueError, TypeError):
                     pass
 
@@ -505,35 +628,60 @@ class MapData:
 class MapDisplayData:
     """Real-time robot position from map/display_map broadcasts.
 
-    Sent every ~1.5s during active cleaning. Contains robot position in cm,
+    Sent every ~1.5s during active cleaning. Contains robot position,
     heading in radians, and a small cleaned-area grid overlay (NOT the full
     house map — that comes from get_map).
 
     Validated field layout (live capture 2026-02-28, 13 broadcasts):
-      field 1.1: {1: x_cm, 2: y_cm} — robot position as float32 centimeters
+      field 1.1: {1: x, 2: y} — robot position as float32 map coordinates
       field 1.2: heading as float32 radians
+      field 2: rolling trajectory window {1: x_bytes, 2: y_bytes}
       field 5: dock/reference position (constant, same format)
       field 7: cleaned-area grid {1: width, 2: height, 3: compressed_bytes}
       field 10: timestamp in milliseconds since epoch
       field 12: active room list
     """
 
-    robot_x: float = 0.0  # decimeters, world coordinates
-    robot_y: float = 0.0  # decimeters, world coordinates
+    robot_x: float = 0.0  # live map X coordinate
+    robot_y: float = 0.0  # live map Y coordinate
     robot_heading: float = 0.0  # degrees (converted from radians for renderer)
     timestamp: int = 0  # milliseconds since epoch (field 10)
     # Dock/reference position from field 5 (same coordinate system as robot)
     dock_ref_x: float = 0.0
     dock_ref_y: float = 0.0
+    trajectory_x_values: bytes = b""
+    trajectory_y_values: bytes = b""
+    trajectory_signature: tuple[int, int, int] | tuple[()] = ()
+    trajectory_breaks: tuple[int, ...] = ()
+
+    @property
+    def has_trajectory(self) -> bool:
+        """Return true when display_map carried a native trajectory."""
+        return bool(self.trajectory_signature)
+
+    def trajectory_points(self) -> list[tuple[float, float]]:
+        """Decode Narwal-native trajectory points from display_map field 2."""
+        return _decode_trajectory(
+            self.trajectory_x_values,
+            self.trajectory_y_values,
+        )
+
+    def trajectory_render_points(self) -> list[tuple[float, float]]:
+        """Return trajectory points with invalid sentinels at segment breaks."""
+        points = self.trajectory_points()
+        for index in reversed(self.trajectory_breaks):
+            if 0 < index < len(points):
+                points.insert(index, (float("nan"), float("nan")))
+        return points
 
     def to_grid_coords(
         self, resolution: int, origin_x: int, origin_y: int,
     ) -> tuple[float, float] | None:
-        """Convert world-coordinate position (dm) to grid pixel coordinates.
+        """Convert live map position to grid pixel coordinates.
 
-        display_map positions are in decimeters (validated via live capture).
+        display_map positions already use the static map coordinate scale.
         Same coordinate system as get_map field 8 (dock position).
-          pixel = (x_dm * 10) / cm_per_pixel - origin_offset
+          pixel = value - origin_offset
 
         Args:
             resolution: Map resolution in mm/pixel (e.g. 60).
@@ -547,9 +695,10 @@ class MapDisplayData:
             return None
         if resolution <= 0:
             return None
-        # Positions are in grid-offset units: pixel = raw - origin
-        px = self.robot_x - origin_x
-        py = self.robot_y - origin_y
+        px = overlay_to_grid(self.robot_x, origin_x)
+        py = overlay_to_grid(self.robot_y, origin_y)
+        if px is None or py is None:
+            return None
         return (px, py)
 
     @classmethod
@@ -576,6 +725,16 @@ class MapDisplayData:
                 h_f = _to_float32(heading_raw)
                 if h_f is not None and math.isfinite(h_f):
                     result.robot_heading = math.degrees(h_f)
+
+        # Rolling cleaning trajectory window from Narwal itself. Keep raw
+        # streams here so HA can join exact overlapping windows without
+        # sampling robot positions or decoding the route on the event loop.
+        (
+            result.trajectory_x_values,
+            result.trajectory_y_values,
+            result.trajectory_signature,
+            result.trajectory_breaks,
+        ) = _trajectory_window_streams(decoded)
 
         # Dock/reference position — field 5 (same format as field 1)
         field5 = decoded.get("5", {})
@@ -1047,6 +1206,7 @@ class NarwalState:
     def assume_robot_clean(self) -> None:
         """Temporarily reserve robot-clean command context after an accepted start."""
         self.assumed_robot_clean_until = time.monotonic() + _ROBOT_START_ASSUME_TTL
+        self.map_display_data = None
 
     def clear_assumed_robot_clean(self) -> None:
         """Clear the local robot-clean command reservation."""

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -1207,6 +1207,11 @@ class NarwalState:
                     self.working_status = WorkingStatus.UNKNOWN
                 if self.working_status not in ACTIVE_CLEANING_STATUSES:
                     self.last_active_working_status_time = 0.0
+                if self.working_status in {
+                    WorkingStatus.TASK_COMPLETED,
+                    WorkingStatus.ERROR,
+                }:
+                    self.clear_assumed_robot_clean()
             # Sub-field 2: paused overlay (0 or absent = not paused, 1 = paused)
             self.is_paused = bool(field3.get("2"))
             # Sub-field 7: returning to dock on old FW (value 1 = returning).

--- a/narwal_client/models.py
+++ b/narwal_client/models.py
@@ -23,9 +23,15 @@ _LOGGER = logging.getLogger(__name__)
 _WARNED_WORKING_STATUS: set[Any] = set()
 
 _ACTIVE_WORKING_STATUS_TTL = 15.0
+_TERMINAL_WORKING_STATUS_TTL = 15.0
 _DOCK_DRYING_STATUS_TTL = 180.0
 _DOCK_TASK_ASSUME_TTL = 30.0
-_ROBOT_START_ASSUME_TTL = 30.0
+# clean/start_clean can be accepted long before working_status metrics arrive.
+_ROBOT_START_ASSUME_TTL = 180.0
+# Live hardware has taken about 50 seconds to leave a stale docked status after
+# accepting a room clean. After this handoff window, repeated idle dock
+# telemetry is stronger evidence than the accepted-command reservation.
+_ROBOT_START_DOCKED_HANDOFF_GRACE = 60.0
 _KNOWN_DOCK_ACTIVITY_VALUES = {0, 2, 3, 4, 6}
 
 DOCK_TASK_EMPTY_DUSTBIN = "empty_dustbin"
@@ -649,6 +655,15 @@ class NarwalState:
     cleaning_area: float = 0.0  # m² (coveredArea)
     cleaning_time: int = 0  # seconds
     last_active_working_status_time: float = 0.0
+    last_terminal_working_status_time: float = 0.0
+    pending_active_working_status: dict[str, Any] | None = field(
+        default=None, repr=False
+    )
+    pending_active_working_status_time: float = 0.0
+    task_progress_percent: int | None = None
+    task_elapsed_time: int = 0
+    task_remaining_time: int = 0
+    current_room_aux_name: str = ""
 
     # Consumables / station / fault (base_status; present on dock and during cleaning)
     dust_bag_health: float = 0.0  # field 35 stationBagHealthScore (%)
@@ -743,8 +758,6 @@ class NarwalState:
     @property
     def has_recent_active_working_status(self) -> bool:
         """True while live working_status task metrics are still fresh."""
-        if self.working_status not in ACTIVE_CLEANING_STATUSES:
-            return False
         if self.last_active_working_status_time <= 0:
             return False
         return (
@@ -753,13 +766,24 @@ class NarwalState:
         )
 
     @property
+    def has_recent_terminal_working_status(self) -> bool:
+        """True just after authoritative terminal base-status telemetry."""
+        if self.last_terminal_working_status_time <= 0:
+            return False
+        return (
+            time.monotonic() - self.last_terminal_working_status_time
+            <= _TERMINAL_WORKING_STATUS_TTL
+        )
+
+    @property
     def has_paused_clean_task_context(self) -> bool:
         """True when a paused overlay still has retained robot clean details."""
-        if not self.is_paused or self.is_docked:
+        if not self.is_paused:
             return False
         return (
             getattr(self, "task_progress_percent", None) is not None
-            or getattr(self, "task_elapsed_time", self.cleaning_time) > 0
+            or getattr(self, "task_elapsed_time", 0) > 0
+            or self.cleaning_time > 0
             or getattr(self, "task_remaining_time", 0) > 0
             or self.current_room_id is not None
             or bool(getattr(self, "current_room_aux_name", ""))
@@ -775,7 +799,7 @@ class NarwalState:
         return (
             self.working_status in ACTIVE_CLEANING_STATUSES
             and not self.is_paused
-            and not self.is_returning_to_dock
+            and not self.is_returning
         )
 
     @property
@@ -810,14 +834,14 @@ class NarwalState:
         cleaning is not active, since the robot can report unmapped states
         (e.g. self-test) while physically docked.
         """
+        if self.has_recent_active_working_status:
+            return False
         if self.has_explicit_off_dock_signal:
             return False
         if self.working_status in (
             WorkingStatus.DOCKED, WorkingStatus.CHARGED, WorkingStatus.DOCKED_V2,
         ):
             return True
-        if self.has_recent_active_working_status:
-            return False
         if self.working_status in ACTIVE_CLEANING_STATUSES:
             return False
         # For STANDBY, UNKNOWN, or any other status: check dock field signals.
@@ -871,6 +895,12 @@ class NarwalState:
     @property
     def is_station_active(self) -> bool:
         """True when the dock/base station is running a dock-side task."""
+        if self.has_recent_active_working_status:
+            return (
+                self.station_activity in (1, 2, 3)
+                or self.is_washing_mop
+                or bool(self.active_dock_drying_tasks)
+            )
         return (
             self.is_washing_mop
             or self.is_drying_mop
@@ -895,9 +925,9 @@ class NarwalState:
         if not telemetry_tasks:
             return False
         return not (
-            telemetry_tasks == {DOCK_TASK_DRY_DOCK_BAG}
+            telemetry_tasks.issubset(_DOCK_DRYING_TASK_ORDER)
             and self.has_recent_dock_drying_status
-            and self.dock_task_timer(DOCK_TASK_DRY_DOCK_BAG) is not None
+            and all(self.dock_task_timer(task) is not None for task in telemetry_tasks)
         )
 
     @property
@@ -926,12 +956,17 @@ class NarwalState:
     def telemetry_dock_task_keys(self) -> tuple[str, ...]:
         """Return active dock task keys from robot telemetry only."""
         tasks: list[str] = []
-        if self.station_activity == 1:
-            tasks.append(DOCK_TASK_EMPTY_DUSTBIN)
-        if self.is_washing_mop:
-            tasks.append(DOCK_TASK_WASH_MOP)
+        if not self.has_recent_active_working_status:
+            if self.station_activity == 1:
+                tasks.append(DOCK_TASK_EMPTY_DUSTBIN)
+            if self.is_washing_mop:
+                tasks.append(DOCK_TASK_WASH_MOP)
         tasks.extend(self.telemetry_dock_drying_tasks)
-        if self.is_drying_mop and DOCK_TASK_DRY_MOP not in tasks:
+        if (
+            not self.has_recent_active_working_status
+            and self.is_drying_mop
+            and DOCK_TASK_DRY_MOP not in tasks
+        ):
             tasks.append(DOCK_TASK_DRY_MOP)
         active = set(tasks)
         return tuple(task for task in DOCK_TASK_KEYS if task in active)
@@ -1017,6 +1052,39 @@ class NarwalState:
         """Clear the local robot-clean command reservation."""
         self.assumed_robot_clean_until = 0.0
 
+    def _clear_assumed_robot_clean_on_terminal_base_status(
+        self,
+        *,
+        is_paused: bool,
+    ) -> None:
+        """Clear accepted-start context once base status proves it is terminal."""
+        if not self.has_assumed_robot_clean:
+            return
+        if self.has_error or self.working_status == WorkingStatus.ERROR:
+            self.clear_assumed_robot_clean()
+            return
+        if self.working_status == WorkingStatus.TASK_COMPLETED:
+            self.clear_assumed_robot_clean()
+            return
+        handoff_ends = (
+            self.assumed_robot_clean_until
+            - _ROBOT_START_ASSUME_TTL
+            + _ROBOT_START_DOCKED_HANDOFF_GRACE
+        )
+        if (
+            not is_paused
+            and time.monotonic() >= handoff_ends
+            and self.working_status
+            in (
+                WorkingStatus.STANDBY,
+                WorkingStatus.DOCKED,
+                WorkingStatus.CHARGED,
+                WorkingStatus.DOCKED_V2,
+            )
+            and self.is_docked
+        ):
+            self.clear_assumed_robot_clean()
+
     def dock_task_timer(self, task: str) -> DockTaskTimer | None:
         """Return timer details for one active dock task."""
         timer = self.dock_drying_tasks.get(task)
@@ -1074,11 +1142,68 @@ class NarwalState:
         if self.current_room_id is None:
             return None
         if self.map_data is None:
-            return None
+            return self.current_room_aux_name or None
         for room in self.map_data.rooms:
             if room.room_id == self.current_room_id:
                 return room.display_name
+        return self.current_room_aux_name or None
+
+    def clear_task_details(self) -> None:
+        """Clear active robot-task detail fields."""
+        self.is_paused = False
+        self.cleaning_area = 0.0
+        self.cleaning_time = 0
+        self.task_progress_percent = None
+        self.task_elapsed_time = 0
+        self.task_remaining_time = 0
+        self.current_room_id = None
+        self.current_room_aux_name = ""
+
+    @staticmethod
+    def _task_progress_percent(value: Any) -> int | None:
+        """Return a percent for task progress encoded as percent or 0..1 float."""
+        if isinstance(value, float):
+            if 0.0 <= value <= 1.0:
+                return round(value * 100)
+            if 0.0 <= value <= 100.0:
+                return round(value)
+        progress = _optional_int(value)
+        if progress is not None and 0 <= progress <= 100:
+            return progress
+        progress_float = _to_float32(value)
+        if progress_float is None:
+            return None
+        if 0.0 <= progress_float <= 1.0:
+            return round(progress_float * 100)
+        if 0.0 <= progress_float <= 100.0:
+            return round(progress_float)
         return None
+
+    def _update_current_room(self, payload: dict[str, Any]) -> None:
+        """Parse scalar and nested current-room working-status fields."""
+        room = payload.get("6")
+        if not isinstance(room, dict):
+            room = payload.get("8")
+        if isinstance(room, dict):
+            room_id = _optional_int(room.get("1"))
+            if room_id is not None:
+                self.current_room_id = room_id or None
+            name = room.get("3")
+            if isinstance(name, (bytes, bytearray)):
+                self.current_room_aux_name = bytes(name).decode(
+                    "utf-8", errors="replace"
+                )
+            else:
+                self.current_room_aux_name = str(name) if name else ""
+                if (
+                    self.current_room_aux_name.startswith("b'")
+                    and self.current_room_aux_name.endswith("'")
+                ):
+                    self.current_room_aux_name = self.current_room_aux_name[2:-1]
+        else:
+            room_id = _optional_int(payload.get("6"))
+            if room_id is not None:
+                self.current_room_id = room_id or None
 
     def update_from_working_status(self, decoded: dict[str, Any]) -> None:
         """Update state from a decoded working_status message.
@@ -1092,8 +1217,29 @@ class NarwalState:
         not area — reading it as area is why the sensor was stuck at 1.8 m².
         """
         self.raw_working_status = decoded
+        reported_task_details: dict[str, Any] = {}
+        previous_task_details = (
+            self.task_progress_percent,
+            self.cleaning_area,
+            self.cleaning_time,
+            self.task_remaining_time,
+            self.current_room_id,
+            self.current_room_aux_name,
+        )
+        progress = self._task_progress_percent(decoded.get("1"))
+        if progress is not None:
+            self.task_progress_percent = max(0, min(100, progress))
+            reported_task_details["progress"] = self.task_progress_percent
+        remaining = _optional_int(decoded.get("4"))
+        if remaining is not None:
+            self.task_remaining_time = max(0, remaining)
+            reported_task_details["remaining"] = self.task_remaining_time
+        has_robot_side_drying = False
         if _has_dock_drying_timer_fields(decoded):
             timers = _dock_drying_timers(decoded)
+            has_robot_side_drying = bool(
+                timers.keys() & {DOCK_TASK_DRY_MOP, DOCK_TASK_DRY_DUST_BIN}
+            )
             self.dock_drying_tasks = timers
             self.has_dock_drying_timer_snapshot = True
             self.has_unmapped_dock_drying_timer = _has_unmapped_dock_drying_timer(
@@ -1109,6 +1255,8 @@ class NarwalState:
         if "3" in decoded:
             try:
                 self.cleaning_time = int(decoded["3"])
+                self.task_elapsed_time = self.cleaning_time
+                reported_task_details["elapsed"] = self.cleaning_time
                 active_payload = active_payload or self.cleaning_time > 0
             except (ValueError, TypeError):
                 pass
@@ -1116,29 +1264,97 @@ class NarwalState:
             area = _to_float32(decoded["2"])
             if area is not None and area >= 0:
                 self.cleaning_area = area
+                reported_task_details["area"] = self.cleaning_area
                 active_payload = active_payload or area > 0
-        if "6" in decoded:
-            # Field 6 = current target room_id (confirmed 2026-04-24 from live capture:
-            # value changed 4→1 as robot moved from Corridor to Living Room).
-            try:
-                room_id = int(decoded["6"])
-                self.current_room_id = room_id if room_id != 0 else None
-            except (ValueError, TypeError):
-                pass
-        if active_payload:
-            if self.working_status != WorkingStatus.CUSTOM_CLEANING:
-                self.working_status = WorkingStatus.CLEANING
-            self.last_active_working_status_time = time.monotonic()
-            self.clear_assumed_robot_clean()
-            self.is_paused = False
-            self.is_returning_to_dock = False
-            self.dock_sub_state = 0
+        if "6" in decoded or isinstance(decoded.get("8"), dict):
+            # Field 6 is a scalar room id on Flow 2 and a nested room detail
+            # message on other firmware; field 8 is the alternate nested shape.
+            self._update_current_room(decoded)
+            reported_task_details["room"] = (
+                self.current_room_id,
+                self.current_room_aux_name,
+            )
+        current_task_details = (
+            self.task_progress_percent,
+            self.cleaning_area,
+            self.cleaning_time,
+            self.task_remaining_time,
+            self.current_room_id,
+            self.current_room_aux_name,
+        )
+        task_details_changed = previous_task_details != current_task_details
+        # Clean counters can arrive late from the previous session. Fresh
+        # empty/wash telemetry is authoritative because raw clean commands
+        # cannot start robot work during either task.
+        has_blocking_station_task = (
+            self.station_activity in (1, 2, 3)
+            or self.dock_activity == 3
+            or has_robot_side_drying
+            or self.assumed_active_dock_task
+            in (DOCK_TASK_EMPTY_DUSTBIN, DOCK_TASK_WASH_MOP)
+        )
+        explicit_terminal_status = self.working_status in {
+            WorkingStatus.TASK_COMPLETED,
+            WorkingStatus.ERROR,
+        }
+        now = time.monotonic()
+        pending_candidate = self.pending_active_working_status
+        pending_candidate_fresh = (
+            pending_candidate is not None
+            and now - self.pending_active_working_status_time
+            <= _TERMINAL_WORKING_STATUS_TTL
+        )
+        confirmed_external_clean = (
+            active_payload
+            and not explicit_terminal_status
+            and self.has_recent_terminal_working_status
+            and pending_candidate_fresh
+            and pending_candidate is not None
+            and any(
+                key in pending_candidate and pending_candidate[key] != value
+                for key, value in reported_task_details.items()
+            )
+        )
+        has_terminal_robot_status = not self.has_assumed_robot_clean and (
+            explicit_terminal_status
+            or (
+                self.has_recent_terminal_working_status
+                and not confirmed_external_clean
+            )
+        )
+        if (
+            active_payload
+            and not has_blocking_station_task
+            and not has_terminal_robot_status
+        ):
+            if task_details_changed:
+                self.last_active_working_status_time = now
+                self.is_paused = False
+            self.last_terminal_working_status_time = 0.0
+            self.pending_active_working_status = None
+            self.pending_active_working_status_time = 0.0
             self.dock_activity = 0
             self.station_activity = 0
             self.clear_assumed_dock_task()
-            self.dock_presence = 2
-            self.dock_field11 = 1
-            self.dock_field47 = 2
+        elif has_terminal_robot_status:
+            if active_payload and not explicit_terminal_status:
+                if not pending_candidate_fresh:
+                    self.pending_active_working_status = dict(reported_task_details)
+                    self.pending_active_working_status_time = now
+                else:
+                    assert pending_candidate is not None
+                    pending_candidate.update(reported_task_details)
+            else:
+                self.pending_active_working_status = None
+                self.pending_active_working_status_time = 0.0
+            self.clear_task_details()
+
+    def _update_battery_level(self, raw_value: Any) -> None:
+        """Update battery level from base-status telemetry."""
+        bat = _to_float32(raw_value)
+        if bat is None:
+            return
+        self.battery_level = round(bat)
 
     def update_from_base_status(self, decoded: dict[str, Any]) -> None:
         """Update state from a decoded robot_base_status message.
@@ -1162,6 +1378,8 @@ class NarwalState:
         Note: field 32 mirrors field 3 exactly (redundant).
         """
         self.raw_base_status = decoded
+        if "2" in decoded:
+            self._update_battery_level(decoded["2"])
         # Field 11 = dock indicator (2=docked, 1=undocked)
         if "11" in decoded:
             try:
@@ -1190,10 +1408,40 @@ class NarwalState:
         field3 = decoded.get("3")
         if isinstance(field3, list):
             field3 = field3[0] if field3 else None
+        current_reports_docked = False
         if isinstance(field3, dict):
+            is_paused = bool(field3.get("2"))
+            current_presence = _optional_int(field3.get("3"))
+            current_sub_state = _optional_int(field3.get("10"))
+            current_field11 = _optional_int(decoded.get("11"))
+            current_field47 = _optional_int(decoded.get("47"))
+            if current_presence is not None:
+                self.dock_presence = current_presence
+            if current_sub_state is not None:
+                self.dock_sub_state = current_sub_state
+            current_reports_docked = (
+                current_presence in (1, 6)
+                or current_sub_state == 1
+                or (current_field11 is not None and current_field11 >= 2)
+                or current_field47 in (1, 3)
+            )
+            current_reports_off_dock = (
+                current_presence == 2
+                or current_sub_state == 2
+                or (current_field11 == 1 and current_field47 == 2)
+            )
+            if current_reports_docked or current_reports_off_dock:
+                if current_presence is None:
+                    self.dock_presence = 0
+                if current_sub_state is None:
+                    self.dock_sub_state = 0
+                if current_field11 is None:
+                    self.dock_field11 = 0
+                if current_field47 is None:
+                    self.dock_field47 = 0
             if "1" in field3:
                 try:
-                    self.working_status = WorkingStatus(int(field3["1"]))
+                    next_working_status = WorkingStatus(int(field3["1"]))
                 except (ValueError, TypeError):
                     raw_val = field3["1"]
                     if raw_val not in _WARNED_WORKING_STATUS:
@@ -1203,24 +1451,46 @@ class NarwalState:
                             "Please report this value at the GitHub repo. "
                             "(further occurrences of this value are suppressed)",
                             raw_val,
-                        )
-                    self.working_status = WorkingStatus.UNKNOWN
-                if self.working_status not in ACTIVE_CLEANING_STATUSES:
+                    )
+                    next_working_status = WorkingStatus.UNKNOWN
+                self.working_status = next_working_status
+                terminal_robot = self.working_status in {
+                    WorkingStatus.TASK_COMPLETED,
+                    WorkingStatus.ERROR,
+                }
+                terminal_dock = self.working_status in {
+                    WorkingStatus.DOCKED,
+                    WorkingStatus.CHARGED,
+                    WorkingStatus.DOCKED_V2,
+                }
+                if terminal_robot or (
+                    terminal_dock and not self.has_explicit_off_dock_signal
+                ):
+                    self.last_terminal_working_status_time = time.monotonic()
+                elif (
+                    terminal_dock
+                    or current_reports_off_dock
+                    or self.working_status in ACTIVE_CLEANING_STATUSES
+                ):
+                    self.last_terminal_working_status_time = 0.0
+                if (
+                    self.working_status not in ACTIVE_CLEANING_STATUSES
+                    and not is_paused
+                    and not self.has_assumed_robot_clean
+                ):
                     self.last_active_working_status_time = 0.0
+                    self.clear_task_details()
                 if self.working_status in {
                     WorkingStatus.TASK_COMPLETED,
                     WorkingStatus.ERROR,
                 }:
                     self.clear_assumed_robot_clean()
             # Sub-field 2: paused overlay (0 or absent = not paused, 1 = paused)
-            self.is_paused = bool(field3.get("2"))
+            self.is_paused = is_paused
             # Sub-field 7: returning to dock on old FW (value 1 = returning).
             # On newer FW, field 7 is repurposed (e.g. value 7 during cleaning).
             # Only treat value 1 as returning — other values are not the flag.
             self.is_returning_to_dock = field3.get("7") == 1
-            if "10" in field3:
-                with contextlib.suppress(ValueError, TypeError):
-                    self.dock_sub_state = int(field3["10"])
             if "12" in field3:
                 with contextlib.suppress(ValueError, TypeError):
                     self.dock_activity = int(field3["12"])
@@ -1230,9 +1500,6 @@ class NarwalState:
             if "18" in field3:
                 with contextlib.suppress(ValueError, TypeError):
                     self.station_activity = int(field3["18"])
-            if "3" in field3:
-                with contextlib.suppress(ValueError, TypeError):
-                    self.dock_presence = int(field3["3"])
             if self.working_status in ACTIVE_CLEANING_STATUSES:
                 self.clear_assumed_robot_clean()
                 if "10" not in field3:
@@ -1299,12 +1566,41 @@ class NarwalState:
                 "Please report this at the GitHub repo.",
                 type(field3).__name__, field3,
             )
-        if "2" in decoded:
-            # Field 2 = real-time battery SOC as float32 (batteryPercentage)
-            # (e.g. 1118175232 → 83.0%; bbp may return int or float)
-            bat = _to_float32(decoded["2"])
-            if bat is not None:
-                self.battery_level = round(bat)
+        if isinstance(field3, dict) and "1" in field3:
+            self._clear_assumed_robot_clean_on_terminal_base_status(
+                is_paused=bool(field3.get("2"))
+            )
+        standby_docked = (
+            isinstance(field3, dict)
+            and self.working_status == WorkingStatus.STANDBY
+            and not self.is_paused
+            and not self.has_assumed_robot_clean
+            and current_reports_docked
+        )
+        has_current_working_status = isinstance(field3, dict) and "1" in field3
+        terminal_docked = standby_docked or (
+            has_current_working_status
+            and self.working_status
+            in (
+                WorkingStatus.DOCKED,
+                WorkingStatus.CHARGED,
+                WorkingStatus.DOCKED_V2,
+            )
+        )
+        terminal_robot = has_current_working_status and self.working_status in (
+            WorkingStatus.TASK_COMPLETED,
+            WorkingStatus.ERROR,
+        )
+        if standby_docked:
+            self.last_terminal_working_status_time = time.monotonic()
+        if (
+            (terminal_robot or (terminal_docked and not self.has_explicit_off_dock_signal))
+            and not self.has_assumed_robot_clean
+        ):
+            # The paused overlay can remain set after docking. A terminal
+            # base-status packet is authoritative over retained task context.
+            self.last_active_working_status_time = 0.0
+            self.clear_task_details()
         self._update_consumables(decoded)
         if "13" in decoded:
             raw = decoded["13"]
@@ -1381,9 +1677,7 @@ class NarwalState:
         """
         self.raw_base_status = decoded
         if "2" in decoded:
-            bat = _to_float32(decoded["2"])
-            if bat is not None:
-                self.battery_level = round(bat)
+            self._update_battery_level(decoded["2"])
         self._update_consumables(decoded)
 
     def update_from_upgrade_status(self, decoded: dict[str, Any]) -> None:

--- a/tests/ha_stubs.py
+++ b/tests/ha_stubs.py
@@ -57,8 +57,15 @@ def install() -> None:
     ha_const.ATTR_ENTITY_ID = "entity_id"  # type: ignore[attr-defined]
     ha_const.PERCENTAGE = "%"  # type: ignore[attr-defined]
     ha_const.STATE_ON = "on"  # type: ignore[attr-defined]
-    ha_const.UnitOfArea = MagicMock()  # type: ignore[attr-defined]
-    ha_const.UnitOfTime = MagicMock()  # type: ignore[attr-defined]
+
+    class _UnitOfArea:
+        SQUARE_METERS = "m²"
+
+    class _UnitOfTime:
+        SECONDS = "s"
+
+    ha_const.UnitOfArea = _UnitOfArea  # type: ignore[attr-defined]
+    ha_const.UnitOfTime = _UnitOfTime  # type: ignore[attr-defined]
 
     class _EntityCategory:
         CONFIG = "config"
@@ -108,7 +115,7 @@ def install() -> None:
     # homeassistant.data_entry_flow
     ha_def = _mod("homeassistant.data_entry_flow", ha)
 
-    class _AbortFlow(Exception):
+    class _AbortFlow(Exception):  # noqa: N818
         def __init__(self, reason: str) -> None:
             self.reason = reason
             super().__init__(reason)
@@ -184,6 +191,7 @@ def install() -> None:
 
     ha_er = _mod("homeassistant.helpers.entity_registry", ha_helpers)
     ha_er.async_get = MagicMock()  # type: ignore[attr-defined]
+    ha_er.async_entries_for_config_entry = MagicMock(return_value=())  # type: ignore[attr-defined]
 
     ha_service = _mod("homeassistant.helpers.service", ha_helpers)
     ha_service.async_extract_entity_ids = MagicMock()  # type: ignore[attr-defined]
@@ -271,7 +279,7 @@ def install() -> None:
     class _Segment:
         """Stub for homeassistant.components.vacuum.Segment."""
 
-        def __init__(self, *, id: str, name: str, group: str | None = None) -> None:
+        def __init__(self, *, id: str, name: str, group: str | None = None) -> None:  # noqa: A002
             self.id = id
             self.name = name
             self.group = group

--- a/tests/ha_stubs.py
+++ b/tests/ha_stubs.py
@@ -165,6 +165,9 @@ def install() -> None:
         def _handle_coordinator_update(self) -> None:
             pass
 
+        async def async_will_remove_from_hass(self) -> None:
+            pass
+
     ha_uc.CoordinatorEntity = _CoordinatorEntity  # type: ignore[attr-defined]
 
     ha_storage = _mod("homeassistant.helpers.storage", ha_helpers)

--- a/tests/ha_stubs.py
+++ b/tests/ha_stubs.py
@@ -196,6 +196,24 @@ def install() -> None:
     ha_service = _mod("homeassistant.helpers.service", ha_helpers)
     ha_service.async_extract_entity_ids = MagicMock()  # type: ignore[attr-defined]
 
+    ha_storage = _mod("homeassistant.helpers.storage", ha_helpers)
+
+    class _Store:
+        """Stub for Home Assistant Store helper."""
+
+        def __init__(self, hass: object, version: int, key: str) -> None:
+            self.hass = hass
+            self.version = version
+            self.key = key
+            self.data: object | None = None
+
+        async def async_load(self) -> object | None:
+            return self.data
+
+        async def async_save(self, data: object) -> None:
+            self.data = data
+
+    ha_storage.Store = _Store  # type: ignore[attr-defined]
     ha_ep = _mod("homeassistant.helpers.entity_platform", ha_helpers)
     ha_ep.AddConfigEntryEntitiesCallback = MagicMock  # type: ignore[attr-defined]
 
@@ -279,7 +297,13 @@ def install() -> None:
     class _Segment:
         """Stub for homeassistant.components.vacuum.Segment."""
 
-        def __init__(self, *, id: str, name: str, group: str | None = None) -> None:  # noqa: A002
+        def __init__(  # noqa: A002
+            self,
+            *,
+            id: str,  # noqa: A002
+            name: str,
+            group: str | None = None,
+        ) -> None:
             self.id = id
             self.name = name
             self.group = group

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,0 +1,323 @@
+"""Tests for Narwal map camera trail handling."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import struct
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import tests.ha_stubs
+
+tests.ha_stubs.install()
+
+from custom_components.narwal.camera import (  # noqa: E402
+    _NATIVE_TRAIL_MAX_POINTS,
+    NarwalMapCamera,
+)
+from narwal_client.const import WorkingStatus  # noqa: E402
+from narwal_client.models import MapData, MapDisplayData, NarwalState  # noqa: E402
+
+
+def _float_stream(*values: float) -> bytes:
+    """Encode a packed float32 stream as display_map field 2 uses it."""
+    return b"".join(struct.pack("<f", value) for value in values)
+
+
+def _camera(state: NarwalState) -> NarwalMapCamera:
+    """Create a NarwalMapCamera with mocked coordinator and render hook."""
+    camera = object.__new__(NarwalMapCamera)
+    camera.coordinator = MagicMock()
+    camera.coordinator.client.state = state
+    camera.coordinator.config_entry = MagicMock()
+    camera.coordinator.config_entry.options = {}
+    camera.hass = MagicMock()
+    camera.hass.async_create_task = MagicMock()
+    camera.async_write_ha_state = MagicMock()
+    camera.async_update_token = MagicMock()
+    camera._cached_image = None
+    camera._cache_key = ()
+    camera._last_render_time = 0.0
+    camera._render_count = 0
+    camera._pending_render = None
+    camera._render_task = None
+    camera._async_render = MagicMock(return_value="render-task")
+    camera._base_map_image = None
+    camera._base_map_ts = 0
+    camera._base_map_options_key = (True, True, True)
+    camera._room_label_points = []
+    return camera
+
+
+def test_native_trajectory_grid_points_convert_and_dedupe() -> None:
+    """Narwal-native trajectory points are converted using the map origin."""
+    static_map = MapData(width=100, height=100, origin_x=2, origin_y=4)
+
+    points = NarwalMapCamera._native_trajectory_grid_points(
+        [(3.0, 5.0), (3.1, 5.1), (4.0, 6.0), (200.0, 200.0)],
+        static_map,
+    )
+
+    assert points == [(1.0, 1.0), (2.0, 2.0)]
+
+
+def test_native_trajectory_grid_points_preserve_segment_breaks() -> None:
+    """Discontinuous native windows remain separated for the renderer."""
+    static_map = MapData(width=100, height=100, origin_x=2, origin_y=4)
+
+    points = NarwalMapCamera._native_trajectory_grid_points(
+        [(3.0, 5.0), (4.0, 6.0), (float("nan"), float("nan")), (5.0, 7.0)],
+        static_map,
+    )
+
+    assert points[:2] == [(1.0, 1.0), (2.0, 2.0)]
+    assert math.isnan(points[2][0])
+    assert math.isnan(points[2][1])
+    assert points[3] == (3.0, 3.0)
+
+
+def test_native_trajectory_grid_points_break_at_out_of_bounds_sample() -> None:
+    """Missing off-map samples cannot connect otherwise nearby valid points."""
+    static_map = MapData(width=100, height=100)
+
+    points = NarwalMapCamera._native_trajectory_grid_points(
+        [(10.0, 10.0), (101.0, 10.0), (11.0, 10.0)],
+        static_map,
+    )
+
+    assert points[0] == (10.0, 10.0)
+    assert math.isnan(points[1][0])
+    assert math.isnan(points[1][1])
+    assert points[2] == (11.0, 10.0)
+
+
+def test_trajectory_cache_key_changes_for_same_length_native_update() -> None:
+    """Same-length native trajectory updates must repaint the map overlay."""
+    first = MapDisplayData.from_broadcast(
+        {"2": {"1": _float_stream(1.0, 2.0), "2": _float_stream(1.0, 2.0)}}
+    )
+    corrected = MapDisplayData.from_broadcast(
+        {"2": {"1": _float_stream(1.0, 3.0), "2": _float_stream(1.0, 2.0)}}
+    )
+
+    assert NarwalMapCamera._trajectory_cache_key(first) != (
+        NarwalMapCamera._trajectory_cache_key(corrected)
+    )
+
+
+def test_native_trajectory_grid_points_decimates_long_route_and_preserves_tail() -> None:
+    """Long native trajectories retain the latest Narwal point when capped."""
+    static_map = MapData(width=_NATIVE_TRAIL_MAX_POINTS + 20, height=10)
+    points = [(float(index), 1.0) for index in range(_NATIVE_TRAIL_MAX_POINTS + 10)]
+
+    converted = NarwalMapCamera._native_trajectory_grid_points(points, static_map)
+
+    assert len(converted) == _NATIVE_TRAIL_MAX_POINTS
+    assert converted[0] == (0.0, 1.0)
+    assert converted[-1] == (float(_NATIVE_TRAIL_MAX_POINTS + 9), 1.0)
+    assert converted[-200:] == [
+        (float(index), 1.0)
+        for index in range(_NATIVE_TRAIL_MAX_POINTS - 190, _NATIVE_TRAIL_MAX_POINTS + 10)
+    ]
+
+
+def test_handle_update_passes_native_trail_to_renderer_outside_cleaning() -> None:
+    """The HA-retained native trajectory is rendered whenever present."""
+    state = NarwalState(working_status=WorkingStatus.CHARGED)
+    state.map_data = MapData(
+        width=100,
+        height=100,
+        resolution=50,
+        origin_x=2,
+        origin_y=4,
+        compressed_map=b"\x01",
+    )
+    state.map_display_data = MapDisplayData.from_broadcast(
+        {
+            "1": {"1": {"1": 4.0, "2": 6.0}},
+            "2": {
+                "1": _float_stream(3.0, 4.0),
+                "2": _float_stream(5.0, 6.0),
+            },
+        }
+    )
+    camera = _camera(state)
+    camera._schedule_render = MagicMock()
+
+    with patch.object(
+        NarwalMapCamera,
+        "_native_trajectory_grid_points",
+        side_effect=AssertionError("callback must not process full native route"),
+    ):
+        camera._handle_coordinator_update()
+
+    camera._schedule_render.assert_called_once()
+    render_display, render_key = camera._schedule_render.call_args.args
+    assert render_display is state.map_display_data
+    assert render_key[-1] == state.map_display_data.trajectory_signature
+    camera.hass.async_create_task.assert_not_called()
+
+
+def test_handle_update_without_native_trajectory_renders_no_trail() -> None:
+    """A live robot position alone must not draw a trail."""
+    state = NarwalState(working_status=WorkingStatus.CLEANING)
+    state.map_data = MapData(
+        width=100,
+        height=100,
+        resolution=50,
+        origin_x=2,
+        origin_y=4,
+        compressed_map=b"\x01",
+    )
+    state.map_display_data = MapDisplayData(robot_x=4.0, robot_y=6.0)
+    camera = _camera(state)
+    camera._schedule_render = MagicMock()
+
+    camera._handle_coordinator_update()
+
+    camera._schedule_render.assert_called_once()
+    render_display, render_key = camera._schedule_render.call_args.args
+    assert render_display is state.map_display_data
+    assert render_key[-1] == ()
+
+
+def test_schedule_render_coalesces_while_render_is_running() -> None:
+    """Only the latest native trajectory render is kept while a render is active."""
+    camera = _camera(NarwalState())
+    running_task = MagicMock()
+    running_task.done.return_value = False
+    camera._render_task = running_task
+    first = MapDisplayData(robot_x=1.0)
+    latest = MapDisplayData(robot_x=2.0)
+
+    camera._schedule_render(first, ("first",))
+    camera._schedule_render(latest, ("latest",))
+
+    assert camera._pending_render == (latest, ("latest",))
+    camera.hass.async_create_task.assert_not_called()
+
+
+def test_handle_update_replaces_pending_render_when_state_returns_to_cache() -> None:
+    """A rollback to the cached key cancels any queued intermediate render."""
+    state = NarwalState()
+    state.map_data = MapData(
+        width=100,
+        height=100,
+        resolution=50,
+        created_at=123,
+        compressed_map=b"\x01",
+    )
+    state.map_display_data = MapDisplayData(robot_x=4.0, robot_y=6.0)
+    camera = _camera(state)
+    cached_key = (
+        123,
+        (True, False, False),
+        (0, 1.0),
+        4.0,
+        6.0,
+        0.0,
+        (),
+    )
+    camera._cached_image = b"old"
+    camera._cache_key = cached_key
+    running_task = MagicMock()
+    running_task.done.return_value = False
+    camera._render_task = running_task
+    camera._pending_render = (MapDisplayData(robot_x=9.0), ("intermediate",))
+
+    camera._handle_coordinator_update()
+
+    assert camera._pending_render == (state.map_display_data, cached_key)
+    camera.hass.async_create_task.assert_not_called()
+
+
+async def test_render_pending_delays_throttled_native_update() -> None:
+    """Throttled rendering coalesces again after waiting."""
+    camera = _camera(NarwalState())
+    camera._cached_image = b"old"
+    camera._cache_key = (1, (True, True, True), (0, 1.0), 1.0)
+    camera._last_render_time = 100.0
+    first = MapDisplayData(robot_x=2.0)
+    first_key = (1, (True, True, True), (0, 1.0), 2.0)
+    latest = MapDisplayData(robot_x=3.0)
+    latest_key = (1, (True, True, True), (0, 1.0), 3.0)
+    camera._pending_render = (
+        first,
+        first_key,
+    )
+    camera._async_render = AsyncMock()
+
+    async def queue_latest(_delay: float) -> None:
+        camera._pending_render = (latest, latest_key)
+
+    with (
+        patch("custom_components.narwal.camera.time.monotonic", return_value=101.0),
+        patch(
+            "custom_components.narwal.camera.asyncio.sleep",
+            new_callable=AsyncMock,
+            side_effect=queue_latest,
+        ) as sleep,
+    ):
+        await camera._async_render_pending()
+
+    sleep.assert_awaited_once_with(1.0)
+    camera._async_render.assert_awaited_once_with(latest, latest_key)
+    assert camera._render_task is None
+
+
+async def test_remove_camera_cancels_pending_render_task() -> None:
+    """Entity removal cannot leave a render that later writes stale state."""
+    camera = _camera(NarwalState())
+    render_started = asyncio.Event()
+    keep_rendering = asyncio.Event()
+
+    async def blocked_render(_display, _key) -> None:
+        render_started.set()
+        await keep_rendering.wait()
+
+    camera._async_render = blocked_render
+    camera._pending_render = (MapDisplayData(robot_x=1.0), ("pending",))
+    render_task = asyncio.create_task(camera._async_render_pending())
+    camera._render_task = render_task
+    await render_started.wait()
+
+    await camera.async_will_remove_from_hass()
+
+    assert render_task.cancelled()
+    assert camera._render_task is None
+    assert camera._pending_render is None
+
+
+async def test_render_keeps_camera_access_token_stable() -> None:
+    """Rendered frames rely on state updates without invalidating image URLs."""
+    state = NarwalState()
+    state.map_data = MapData(
+        width=100,
+        height=100,
+        resolution=50,
+        origin_x=2,
+        origin_y=4,
+        created_at=123,
+        compressed_map=b"\x01",
+    )
+    camera = _camera(state)
+    camera._async_render = NarwalMapCamera._async_render.__get__(
+        camera, NarwalMapCamera
+    )
+
+    async def executor_job(fn, *args):
+        if getattr(fn, "__name__", "") == "render_base_map":
+            return object()
+        if getattr(fn, "__name__", "") == "room_label_points":
+            return []
+        return b"png"
+
+    camera.hass.async_add_executor_job = AsyncMock(side_effect=executor_job)
+
+    with patch.object(NarwalMapCamera, "_render_overlay_image", return_value=b"png"):
+        await camera._async_render(MapDisplayData(robot_x=4.0, robot_y=6.0), ("key",))
+
+    assert camera._cached_image == b"png"
+    assert camera.extra_state_attributes == {"render_count": 1}
+    camera.async_update_token.assert_not_called()
+    camera.async_write_ha_state.assert_called_once()

--- a/tests/test_clean_settings_entities.py
+++ b/tests/test_clean_settings_entities.py
@@ -165,8 +165,9 @@ def _state(
     state.has_recent_active_working_status = recent
     state.is_returning = returning
     state.is_cleaning = working_status == WorkingStatus.CLEANING and not returning
-    state.is_charging_to_resume = False
     state.is_station_active = False
+    state.has_unmapped_active_dock_task = False
+    state.assumed_active_dock_task = None
     state.map_data = None
     return state
 
@@ -231,8 +232,8 @@ class TestNarwalSelect:
         }
 
     async def test_water_applies_live_while_cleaning(self) -> None:
-        coord = _coordinator(state=MagicMock(is_cleaning=True))
-        coord.active_clean_work_mode = WorkMode.VACUUM_AND_MOP
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        coord.active_clean_work_mode = WorkMode.MOP
         coord.client.set_mop_humidity = AsyncMock(
             return_value=CommandResponse(result_code=CommandResult.SUCCESS)
         )
@@ -272,8 +273,8 @@ class TestNarwalSelect:
         assert water.current_option == "Wet"
 
     async def test_water_accepts_live_accepted_response(self) -> None:
-        coord = _coordinator(state=MagicMock(is_cleaning=True))
-        coord.active_clean_work_mode = WorkMode.VACUUM_AND_MOP
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
+        coord.active_clean_work_mode = WorkMode.MOP
         coord.client.set_mop_humidity = AsyncMock(
             return_value=CommandResponse(result_code=0)
         )
@@ -315,14 +316,12 @@ class TestNarwalSelect:
 
         coord.client.set_mop_humidity.assert_not_awaited()
 
-    async def test_live_water_hides_unknown_active_mode(self) -> None:
-        """A reload cannot expose water before the accepted task mode is known."""
+    async def test_live_water_rejects_unknown_active_mode(self) -> None:
+        """Unknown active mode must not expose a cross-mode water command."""
         coord = _coordinator(state=_state(WorkingStatus.CLEANING))
         coord.clean_settings.work_mode = WorkMode.MOP
         coord.active_clean_work_mode = None
-        coord.client.set_mop_humidity = AsyncMock(
-            return_value=CommandResponse(result_code=0)
-        )
+        coord.client.set_mop_humidity = AsyncMock()
         sel = NarwalSelect(coord, _DESCS["water"])
 
         assert not sel.available
@@ -350,8 +349,7 @@ class TestNarwalSelect:
         coord.client.set_mop_humidity.assert_awaited_once_with(MopHumidity.WET)
 
     async def test_rejected_live_water_change_does_not_update_settings(self) -> None:
-        coord = _coordinator(state=MagicMock(is_cleaning=True))
-        coord.active_clean_work_mode = WorkMode.VACUUM_AND_MOP
+        coord = _coordinator(state=_state(WorkingStatus.CLEANING))
         coord.clean_settings.water = MopHumidity.NORMAL
         coord.client.set_mop_humidity = AsyncMock(
             return_value=CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
@@ -368,7 +366,7 @@ class TestNarwalSelect:
         assert coord.clean_settings.water == MopHumidity.NORMAL
 
     async def test_no_live_setter_when_not_cleaning(self) -> None:
-        coord = _coordinator(state=MagicMock(is_cleaning=False))
+        coord = _coordinator(state=_state())
         coord.client.set_mop_humidity = AsyncMock()
         sel = NarwalSelect(coord, _DESCS["water"])
         await sel.async_select_option("dry")
@@ -522,13 +520,11 @@ class TestLegacyNarwalSettingSelect:
 
         coord.client.set_fan_speed.assert_not_awaited()
 
-    async def test_legacy_live_suction_hides_unknown_active_mode(self) -> None:
+    async def test_legacy_live_suction_rejects_unknown_active_mode(self) -> None:
         coord = _coordinator(state=_state(WorkingStatus.CLEANING))
         coord.clean_settings.work_mode = WorkMode.VACUUM
         coord.active_clean_work_mode = None
-        coord.client.set_fan_speed = AsyncMock(
-            return_value=CommandResponse(result_code=0)
-        )
+        coord.client.set_fan_speed = AsyncMock()
         sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"])
 
         assert not sel.available
@@ -610,6 +606,22 @@ class TestLegacyNarwalSettingSelect:
         get_last_state.assert_not_awaited()
         assert coord.clean_settings.fan == FanLevel.SUPER
 
+    async def test_four_tier_suction_extra_restore_clamps_level_five(self) -> None:
+        coord = _coordinator(
+            settings=CleanSettings(fan=FanLevel.NORMAL),
+            product_key="qV6BujoYLz",
+        )
+        sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"])
+        extra = SettingRestoreData(value=int(FanLevel.SUPER))
+
+        with patch.object(
+            sel, "async_get_last_extra_data", AsyncMock(return_value=extra)
+        ):
+            await sel.async_added_to_hass()
+
+        assert coord.clean_settings.fan == FanLevel.DEEP
+        assert sel.current_option == "Super Powerful"
+
     async def test_unversioned_suction_restore_keeps_v105_meaning(self) -> None:
         coord = _coordinator(settings=CleanSettings(fan=FanLevel.NORMAL))
         sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"])
@@ -637,6 +649,23 @@ class TestLegacyNarwalSettingSelect:
             await sel.async_added_to_hass()
 
         assert coord.clean_settings.fan == FanLevel.DEEP
+
+    async def test_four_tier_unversioned_ultra_clamps_level_five(self) -> None:
+        coord = _coordinator(
+            settings=CleanSettings(fan=FanLevel.NORMAL),
+            product_key="qV6BujoYLz",
+        )
+        sel = LegacyNarwalSettingSelect(coord, _LEGACY_DESCS["suction"])
+
+        with patch.object(
+            sel,
+            "async_get_last_state",
+            AsyncMock(return_value=MagicMock(state="Ultra")),
+        ):
+            await sel.async_added_to_hass()
+
+        assert coord.clean_settings.fan == FanLevel.DEEP
+        assert sel.current_option == "Super Powerful"
 
     async def test_select_option_refreshes_related_setting_entities(self) -> None:
         coord = _coordinator(state=_state())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
+import struct
 import time
 from unittest.mock import AsyncMock, patch
 
@@ -37,6 +39,11 @@ from narwal_client.models import (
     RoomInfo,
 )
 from narwal_client.protocol import PROTOBUF_FIELD5_TAG, build_frame
+
+
+def _float_stream(*values: float) -> bytes:
+    """Encode a packed float32 stream as display_map field 2 uses it."""
+    return b"".join(struct.pack("<f", value) for value in values)
 
 
 class TestNarwalClientInit:
@@ -90,6 +97,106 @@ class TestNarwalClientInit:
         assert result.data == {"1": 1}
         assert result.raw_payload == b"raw"
         mock_send.assert_awaited_once_with(TOPIC_CMD_GET_BASE_STATUS)
+
+    def test_topic_subscription_excludes_planned_route_trails(self) -> None:
+        """Map trails come only from map/display_map's native trajectory window."""
+        client = NarwalClient("10.0.0.1")
+        payload = client._build_topic_subscription()
+
+        assert b"map/display_map" in payload
+        assert b"status/point_navi_plan_traj" not in payload
+        assert b"developer/planning_debug_info" not in payload
+
+    @pytest.mark.asyncio
+    async def test_display_map_trajectory_updates_visual_data_only(self) -> None:
+        """display_map field 2 must not infer robot task state."""
+        client = NarwalClient("10.0.0.1", device_id="device")
+        frame = build_frame(client._full_topic("map/display_map"), b"payload")
+        client.state.working_status = WorkingStatus.CHARGED
+        client.state.station_activity = 2
+        client.state.dock_field11 = 3
+        client.state.dock_field47 = 1
+        client.state.task_progress_percent = 48
+
+        with patch.object(
+            client,
+            "_decode_protobuf",
+            return_value={
+                "1": {"1": {"1": 1.25, "2": 1.0}},
+                "2": {
+                    "1": _float_stream(1.0, 1.25),
+                    "2": _float_stream(2.0, 2.25),
+                },
+            },
+        ):
+            await client._handle_message(frame)
+
+        assert client.state.map_display_data is not None
+        assert client.state.map_display_data.trajectory_points() == [
+            (1.0, 2.0),
+            (1.25, 2.25),
+        ]
+        assert not client.state.is_cleaning
+        assert client.state.is_docked
+        assert client.state.is_station_active
+        assert not hasattr(client.state, "last_map_robot_movement")
+
+    @pytest.mark.asyncio
+    async def test_display_map_non_finite_pair_preserves_trajectory_break(self) -> None:
+        """Invalid native coordinates must not join the surrounding route."""
+        client = NarwalClient("10.0.0.1", device_id="device")
+        frame = build_frame(client._full_topic("map/display_map"), b"payload")
+
+        with patch.object(
+            client,
+            "_decode_protobuf",
+            return_value={
+                "2": {
+                    "1": _float_stream(1.0, float("nan"), 2.0),
+                    "2": _float_stream(1.0, 1.5, 2.0),
+                },
+            },
+        ):
+            await client._handle_message(frame)
+
+        display = client.state.map_display_data
+        assert display is not None
+        assert display.trajectory_points() == [(1.0, 1.0), (2.0, 2.0)]
+        assert display.trajectory_breaks == (1,)
+        render_points = display.trajectory_render_points()
+        assert math.isnan(render_points[1][0])
+        assert math.isnan(render_points[1][1])
+
+    @pytest.mark.asyncio
+    async def test_wait_for_response_marks_display_map_fresh(self) -> None:
+        """display_map packets consumed while waiting for an ack are fresh."""
+        client = NarwalClient("10.0.0.1", device_id="device")
+        display_frame = build_frame(client._full_topic("map/display_map"), b"display")
+        response_frame = bytearray(build_frame(client._full_topic("cmd/test"), b"ack"))
+        response_frame[2] = PROTOBUF_FIELD5_TAG
+        client._ws = AsyncMock()
+        client._ws.recv = AsyncMock(side_effect=[display_frame, bytes(response_frame)])
+
+        with patch.object(
+            client,
+            "_decode_protobuf",
+            return_value={
+                "1": {"1": {"1": 1.25, "2": 1.0}},
+                "2": {
+                    "1": _float_stream(1.0, 1.25),
+                    "2": _float_stream(2.0, 2.25),
+                },
+            },
+        ):
+            msg = await client._wait_for_field5_response(1.0)
+
+        assert msg.payload == b"ack"
+        assert client.state.map_display_data is not None
+        assert client.state.map_display_data.trajectory_points() == [
+            (1.0, 2.0),
+            (1.25, 2.25),
+        ]
+        assert client.last_display_map_age < 1.0
 
     def test_unconfirmed_idle_base_status_preserves_active_metrics(self) -> None:
         """Stale idle base_status must not hide a fresh working_status task."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -100,18 +100,24 @@ class TestNarwalClientInit:
             {"3": {"1": 1}, "11": 1, "47": 2, "2": 87.0}
         )
 
-        assert client.state.working_status == WorkingStatus.CLEANING
+        assert client.state.working_status == WorkingStatus.UNKNOWN
         assert client.state.battery_level == 87
         assert client.state.is_cleaning
 
-    def test_confirmed_dock_base_status_ends_active_metrics(self) -> None:
-        """Fresh dock indicators are trusted even after active task metrics."""
+    def test_confirmed_dock_base_status_waits_for_active_metrics_to_expire(self) -> None:
+        """Dock indicators win after fresh task-metric activity expires."""
         client = NarwalClient("10.0.0.1")
-        client._update_from_working_status_broadcast({"3": 120})
+        with patch("narwal_client.models.time.monotonic", return_value=100.0):
+            client._update_from_working_status_broadcast({"3": 120})
 
-        client._update_from_base_status_broadcast(
-            {"3": {"1": 10}, "11": 2, "47": 3}
-        )
+        docked = {"3": {"1": 10}, "11": 2, "47": 3}
+        with patch("narwal_client.models.time.monotonic", return_value=101.0):
+            client._update_from_base_status_broadcast(docked)
+            assert client.state.working_status == WorkingStatus.UNKNOWN
+            assert client.state.is_cleaning
+
+        with patch("narwal_client.models.time.monotonic", return_value=116.0):
+            client._update_from_base_status_broadcast(docked)
 
         assert client.state.working_status == WorkingStatus.DOCKED
         assert not client.state.has_recent_active_working_status
@@ -290,6 +296,9 @@ class TestWholeHouseStart:
         client = NarwalClient("127.0.0.1")
         client._ws = AsyncMock()
         client._connected.set()
+        client.state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.DOCKED), "10": 1}, "11": 2}
+        )
         return client
 
     @pytest.mark.asyncio
@@ -499,16 +508,28 @@ class TestWholeHouseStart:
         assert client.state.has_assumed_robot_clean
         mock_send.assert_awaited_once()
 
+    @pytest.mark.parametrize(
+        ("task", "fields"),
+        (
+            (DOCK_TASK_DRY_MOP, ("8", "9")),
+            (DOCK_TASK_DRY_DUST_BIN, ("10", "11")),
+            (DOCK_TASK_DRY_DOCK_BAG, ("12", "13")),
+        ),
+    )
     @pytest.mark.asyncio
-    async def test_start_rooms_allows_typed_dock_bag_drying(self) -> None:
-        """Dock-bag drying is the one known dock task compatible with robot start."""
+    async def test_start_rooms_allows_typed_drying(
+        self,
+        task: str,
+        fields: tuple[str, str],
+    ) -> None:
+        """Each typed drying task is compatible with robot start."""
         client = self._connected_client()
         client.state.map_data = MapData(map_id=1, rooms=[RoomInfo(room_id=2)])
         client.state.set_dock_drying_task(
-            DOCK_TASK_DRY_DOCK_BAG,
+            task,
             elapsed=60,
             target=180,
-            fields=("12", "13"),
+            fields=fields,
         )
         success = CommandResponse(result_code=CommandResult.SUCCESS)
 
@@ -818,6 +839,26 @@ class TestDockTaskCommands:
 
         assert result.result_code == CommandResult.NOT_APPLICABLE
         mock_status.assert_awaited_once_with(full_update=True)
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_direct_dock_command_rejects_retained_paused_clean(self) -> None:
+        """Expired metric freshness does not make a paused clean dock-idle."""
+        client = self._docked_client()
+        client.state.working_status = WorkingStatus.STANDBY
+        client.state.is_paused = True
+        client.state.cleaning_time = 120
+        client.state.task_elapsed_time = 120
+
+        with patch.object(
+            client, "get_status", new_callable=AsyncMock
+        ) as mock_status, patch.object(
+            client, "send_command", new_callable=AsyncMock
+        ) as mock_send:
+            result = await client.empty_dustbin()
+
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+        mock_status.assert_not_awaited()
         mock_send.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -1484,6 +1525,137 @@ class TestDockTaskCommands:
             await client._refresh_before_dock_stop(None)
 
         mock_status.assert_awaited_once_with(full_update=False)
+
+    def test_statusless_base_broadcast_preserves_fresh_clean_metrics(self) -> None:
+        """Battery-only telemetry cannot apply a cached terminal status."""
+        client = NarwalClient("127.0.0.1")
+        client.state.working_status = WorkingStatus.DOCKED
+        client.state.last_terminal_working_status_time = 0.0
+        client.state.update_from_working_status({"3": 120, "4": 600})
+
+        client._update_from_base_status_broadcast({"2": 75.0})
+
+        assert client.state.battery_level == 75
+        assert client.state.is_cleaning
+        assert client.state.task_elapsed_time == 120
+        assert client.state.task_remaining_time == 600
+
+    def test_external_start_survives_delayed_docked_base_broadcast(self) -> None:
+        """Fresh native task metrics outrank delayed dock confirmation."""
+        client = NarwalClient("127.0.0.1")
+        with patch("narwal_client.models.time.monotonic", return_value=100.0):
+            client.state.update_from_base_status(
+                {"3": {"1": int(WorkingStatus.DOCKED)}, "11": 2, "47": 3}
+            )
+        with patch("narwal_client.models.time.monotonic", return_value=101.0):
+            client.state.update_from_working_status({"1": 25, "3": 120, "6": 4})
+            assert not client.state.is_cleaning
+        with patch("narwal_client.models.time.monotonic", return_value=102.0):
+            client._update_from_base_status_broadcast(
+                {
+                    "3": {"1": int(WorkingStatus.DOCKED), "10": 1},
+                    "11": 2,
+                    "47": 3,
+                }
+            )
+            assert client.state.working_status == WorkingStatus.DOCKED
+            assert not client.state.is_cleaning
+        with patch("narwal_client.models.time.monotonic", return_value=102.5):
+            client.state.update_from_working_status({"3": 120})
+            assert not client.state.is_cleaning
+        with patch("narwal_client.models.time.monotonic", return_value=103.0):
+            client.state.update_from_working_status({"1": 26, "3": 121, "6": 4})
+            assert client.state.is_cleaning
+        with patch("narwal_client.models.time.monotonic", return_value=104.0):
+            client._update_from_base_status_broadcast(
+                {
+                    "3": {"1": int(WorkingStatus.DOCKED), "10": 1},
+                    "11": 2,
+                    "47": 3,
+                }
+            )
+            assert client.state.is_cleaning
+        assert client.state.task_progress_percent == 26
+        assert client.state.task_elapsed_time == 121
+        assert client.state.current_room_id == 4
+
+    def test_expired_external_start_candidate_requires_new_progression(self) -> None:
+        """An old candidate cannot confirm a later metric packet by itself."""
+        client = NarwalClient("127.0.0.1")
+        docked = {
+            "3": {"1": int(WorkingStatus.DOCKED), "10": 1},
+            "11": 2,
+            "47": 3,
+        }
+        with patch("narwal_client.models.time.monotonic", return_value=100.0):
+            client.state.update_from_base_status(docked)
+        with patch("narwal_client.models.time.monotonic", return_value=101.0):
+            client.state.update_from_working_status({"1": 25, "3": 120})
+        with patch("narwal_client.models.time.monotonic", return_value=500.0):
+            client._update_from_base_status_broadcast(docked)
+        with patch("narwal_client.models.time.monotonic", return_value=501.0):
+            client.state.update_from_working_status({"1": 26, "3": 121})
+            assert not client.state.is_cleaning
+        with patch("narwal_client.models.time.monotonic", return_value=502.0):
+            client.state.update_from_working_status({"1": 27, "3": 122})
+            assert client.state.is_cleaning
+
+    def test_repeated_final_metrics_cannot_mask_confirmed_docking(self) -> None:
+        """Unchanged final counters expire so repeated dock evidence can win."""
+        client = NarwalClient("127.0.0.1")
+        with patch("narwal_client.models.time.monotonic", return_value=100.0):
+            client.state.update_from_base_status(
+                {"3": {"1": int(WorkingStatus.CLEANING)}, "11": 1, "47": 2}
+            )
+            client.state.update_from_working_status({"1": 75, "3": 900, "6": 4})
+
+        docked = {
+            "3": {"1": int(WorkingStatus.DOCKED), "10": 1},
+            "11": 2,
+            "47": 3,
+        }
+        with patch("narwal_client.models.time.monotonic", return_value=101.0):
+            client._update_from_base_status_broadcast(docked)
+        assert client.state.is_cleaning
+
+        with patch("narwal_client.models.time.monotonic", return_value=105.0):
+            client.state.update_from_working_status({"1": 75, "3": 900, "6": 4})
+        with patch("narwal_client.models.time.monotonic", return_value=116.0):
+            client.state.update_from_working_status({"1": 75, "3": 900, "6": 4})
+            client._update_from_base_status_broadcast(docked)
+
+        assert client.state.working_status == WorkingStatus.DOCKED
+        assert client.state.is_docked
+        assert not client.state.is_cleaning
+
+    def test_statusless_pause_broadcast_applies_during_fresh_clean(self) -> None:
+        """A pause overlay remains authoritative without a coarse status enum."""
+        client = NarwalClient("127.0.0.1")
+        client.state.working_status = WorkingStatus.DOCKED
+        client.state.last_terminal_working_status_time = 0.0
+        client.state.update_from_working_status({"3": 120, "4": 600})
+
+        client._update_from_base_status_broadcast({"3": {"2": 1}})
+
+        assert client.state.is_paused
+        assert client.state.task_elapsed_time == 120
+        assert client.state.task_remaining_time == 600
+
+    def test_statusless_packet_does_not_reuse_standby_dock_evidence(self) -> None:
+        """Cached dock fields cannot make a status-less packet terminal."""
+        client = NarwalClient("127.0.0.1")
+        client.state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.STANDBY), "3": 6}}
+        )
+        client.state.last_terminal_working_status_time = 0.0
+        client.state.update_from_working_status({"3": 120, "4": 600})
+
+        client._update_from_base_status_broadcast({"3": {"7": 0}, "2": 80.0})
+
+        assert client.state.is_cleaning
+        assert client.state.task_elapsed_time == 120
+        assert client.state.task_remaining_time == 600
+        assert not client.state.has_recent_terminal_working_status
 
     @pytest.mark.asyncio
     async def test_stop_dock_task_rejects_ambiguous_generic_stop(self) -> None:

--- a/tests/test_client_rooms.py
+++ b/tests/test_client_rooms.py
@@ -7,13 +7,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import blackboxprotobuf
 import pytest
 
-from narwal_client.client import NarwalClient, RoomCleanSettings
+from narwal_client.client import NarwalClient, NarwalCommandError, RoomCleanSettings
 from narwal_client.const import (
     CleaningRoute,
     CommandResult,
     FanLevel,
     MopHumidity,
     MopStrengthLevel,
+    WorkingStatus,
     WorkMode,
 )
 from narwal_client.models import CommandResponse
@@ -161,6 +162,9 @@ class TestStartRooms:
     def _client(self) -> NarwalClient:
         client = NarwalClient("127.0.0.1")
         client._ws = AsyncMock()
+        client.state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.DOCKED), "10": 1}, "11": 2}
+        )
         client.state.map_data = MagicMock(map_id=1)
         return client
 
@@ -257,6 +261,19 @@ class TestStartRooms:
         assert result.result_code == CommandResult.NOT_APPLICABLE
 
     @pytest.mark.asyncio
+    async def test_map_fetch_error_returns_not_applicable(self) -> None:
+        """A failed map refresh bails out without sending a room-clean command."""
+        client = self._client()
+        client.state.map_data = None
+        with patch.object(client, "get_map", new_callable=AsyncMock) as mock_get_map, \
+             patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            mock_get_map.side_effect = NarwalCommandError("no active map")
+            result = await client.start_rooms([5])
+        mock_get_map.assert_awaited_once()
+        mock_send.assert_not_awaited()
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+
+    @pytest.mark.asyncio
     async def test_not_ready_retries_while_docked(self) -> None:
         """NOT_READY on the dock retries clean/start_clean (dock settling)."""
         client = self._client()
@@ -272,16 +289,65 @@ class TestStartRooms:
         assert result is success
 
     @pytest.mark.asyncio
-    async def test_not_ready_off_dock_does_not_retry(self) -> None:
-        """NOT_READY off the dock surfaces as-is — start_clean needs the dock."""
+    async def test_off_dock_does_not_dispatch(self) -> None:
+        """An off-dock robot is rejected before dispatch."""
         client = self._client()
+        client.state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.STANDBY)}, "11": 1, "47": 2}
+        )
+        client.state.dock_presence = 2
+        client.state.dock_sub_state = 2
         assert not client.state.is_docked
-        not_ready = CommandResponse(result_code=CommandResult.NOT_READY)
         with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
-            mock_send.return_value = not_ready
             result = await client.start_rooms([5])
-        mock_send.assert_awaited_once()
-        assert result.result_code == CommandResult.NOT_READY
+        mock_send.assert_not_awaited()
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+
+    @pytest.mark.asyncio
+    async def test_active_clean_does_not_dispatch(self) -> None:
+        """A second start is rejected while robot cleaning is active."""
+        client = self._client()
+        client.state.working_status = WorkingStatus.CLEANING
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            result = await client.start_rooms([5])
+
+        mock_send.assert_not_awaited()
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+
+    @pytest.mark.asyncio
+    async def test_error_status_does_not_dispatch(self) -> None:
+        """An explicit robot error is rejected even without an error payload."""
+        client = self._client()
+        client.state.working_status = WorkingStatus.ERROR
+        client.state.error_code = 0
+
+        with patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            result = await client.start_rooms([5])
+
+        mock_send.assert_not_awaited()
+        assert result.result_code == CommandResult.NOT_APPLICABLE
+
+    @pytest.mark.asyncio
+    async def test_state_change_during_map_fetch_does_not_dispatch(self) -> None:
+        """State is checked again after the asynchronous map fetch."""
+        client = self._client()
+        client.state.map_data = None
+
+        async def change_state_during_map_fetch():
+            client.state.working_status = WorkingStatus.CLEANING
+            return MagicMock(map_id=1)
+
+        with patch.object(
+            client,
+            "get_map",
+            new_callable=AsyncMock,
+            side_effect=change_state_during_map_fetch,
+        ), patch.object(client, "send_command", new_callable=AsyncMock) as mock_send:
+            result = await client.start_rooms([5])
+
+        mock_send.assert_not_awaited()
+        assert result.result_code == CommandResult.NOT_APPLICABLE
 
     @pytest.mark.asyncio
     async def test_conflict_surfaces_without_retry(self) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7,9 +7,13 @@ UpdateFailed after the threshold, and resets counters on success/push.
 from __future__ import annotations
 
 import asyncio
+import math
+import struct
 import sys
 import time
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from collections.abc import Coroutine
+from dataclasses import replace
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, call, patch
 
 import pytest
 
@@ -29,6 +33,7 @@ from custom_components.narwal.coordinator import (  # noqa: E402
     can_prepare_clean_start,
     can_start_cleaning,
     is_clean_session_context,
+    is_confirmed_terminal_clean_state,
     is_live_clean_setting_available,
     is_narwal_task_busy,
 )  # noqa: E402
@@ -36,6 +41,8 @@ from custom_components.narwal.narwal_client import (  # noqa: E402
     CommandResponse,
     CommandResult,
     FanLevel,
+    MapData,
+    MapDisplayData,
     MopHumidity,
     NarwalConnectionError,
     NarwalState,
@@ -84,6 +91,71 @@ def _docked_state() -> NarwalState:
     state.dock_presence = 6
     state.dock_field11 = 2
     return state
+
+
+class _FakeStore:
+    """Store test double that records saved payloads."""
+
+    def __init__(self, data: object | None = None) -> None:
+        self.data = data
+        self.saved: list[object] = []
+
+    async def async_load(self) -> object | None:
+        return self.data
+
+    async def async_save(self, data: object) -> None:
+        self.saved.append(data)
+        self.data = data
+
+
+def _trajectory_state() -> NarwalState:
+    """Return a state with static map and native display-map trajectory."""
+    state = NarwalState()
+    state.map_data = MapData(
+        map_id=12,
+        width=100,
+        height=100,
+        created_at=34,
+        compressed_map=b"\x01",
+    )
+    state.map_display_data = MapDisplayData(
+        robot_x=1.25,
+        robot_y=2.5,
+        robot_heading=90.0,
+        timestamp=123456,
+        dock_ref_x=3.0,
+        dock_ref_y=4.0,
+        trajectory_x_values=b"xxxx",
+        trajectory_y_values=b"yyyy",
+        trajectory_signature=(4, 4, 99),
+    )
+    return state
+
+
+def _trajectory_display(
+    *points: tuple[float, float], timestamp: int = 0
+) -> MapDisplayData:
+    """Return native packed trajectory data for coordinator cache tests."""
+    return MapDisplayData.from_broadcast(
+        {
+            "1": {"1": {"1": points[-1][0], "2": points[-1][1]}},
+            "2": {
+                "1": b"".join(struct.pack("<f", point[0]) for point in points),
+                "2": b"".join(struct.pack("<f", point[1]) for point in points),
+            },
+            "10": timestamp,
+        }
+    )
+
+
+def _close_background_task(_hass: object, coro: object, _name: str) -> MagicMock:
+    """Consume scheduled coroutine objects in coordinator unit tests."""
+    close = getattr(coro, "close", None)
+    if close is not None:
+        close()
+    task = MagicMock()
+    task.done.return_value = True
+    return task
 
 
 def test_non_broadcast_product_key_configures_polling_client() -> None:
@@ -831,6 +903,2017 @@ def test_terminal_status_does_not_expose_live_clean_settings(
     assert not is_live_clean_setting_available(state)
 
 
+def test_map_display_cache_payload_round_trips_native_trajectory() -> None:
+    """Native display-map trails can be serialized through HA storage."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    state = _trajectory_state()
+    state.map_display_data.trajectory_breaks = (1,)
+
+    payload = coordinator._map_display_cache_payload(state)
+    restored = NarwalCoordinator._map_display_from_cache(payload)
+
+    assert payload is not None
+    assert restored is not None
+    assert payload["map_id"] == 12
+    assert payload["map_created_at"] == 34
+    assert payload["active_clean"] is False
+    assert restored.robot_x == 0.0
+    assert restored.robot_y == 0.0
+    assert restored.robot_heading == 0.0
+    assert restored.timestamp == state.map_display_data.timestamp
+    assert restored.dock_ref_x == state.map_display_data.dock_ref_x
+    assert restored.dock_ref_y == state.map_display_data.dock_ref_y
+    assert restored.trajectory_x_values == b"xxxx"
+    assert restored.trajectory_y_values == b"yyyy"
+    assert restored.trajectory_signature == (4, 4, 99)
+    assert restored.trajectory_breaks == (1,)
+
+
+def test_native_trajectory_windows_are_joined_by_exact_overlap() -> None:
+    """Rolling robot windows extend the HA-retained native route once."""
+    previous = _trajectory_display(
+        (1.0, 1.0),
+        (2.0, 2.0),
+        (3.0, 3.0),
+        timestamp=100,
+    )
+    current = _trajectory_display(
+        (3.0, 3.0),
+        (4.0, 4.0),
+        (5.0, 5.0),
+        timestamp=200,
+    )
+
+    merged = NarwalCoordinator._merge_native_trajectory_windows(previous, current)
+
+    assert merged.trajectory_points() == [
+        (1.0, 1.0),
+        (2.0, 2.0),
+        (3.0, 3.0),
+        (4.0, 4.0),
+        (5.0, 5.0),
+    ]
+    assert merged.trajectory_signature[0] == 5
+    assert merged.robot_x == 5.0
+    assert merged.timestamp == 200
+
+
+def test_overlapping_window_preserves_break_inside_matched_points() -> None:
+    """A native discontinuity in the overlap remains in retained geometry."""
+    previous = _trajectory_display(
+        (1.0, 1.0),
+        (2.0, 2.0),
+        (3.0, 3.0),
+        timestamp=100,
+    )
+    current = _trajectory_display(
+        (2.0, 2.0),
+        (3.0, 3.0),
+        (4.0, 4.0),
+        timestamp=200,
+    )
+    current.trajectory_breaks = (1,)
+
+    merged = NarwalCoordinator._merge_native_trajectory_windows(previous, current)
+
+    assert merged.trajectory_points() == [
+        (1.0, 1.0),
+        (2.0, 2.0),
+        (3.0, 3.0),
+        (4.0, 4.0),
+    ]
+    assert merged.trajectory_breaks == (2,)
+
+
+def test_native_trajectory_overlap_is_bounded_at_retention_limit() -> None:
+    """Maximum-size unrelated windows do not require quadratic byte copying."""
+    point_count = 50_000
+    previous = MapDisplayData(
+        trajectory_x_values=struct.pack("<I", 1) * point_count,
+        trajectory_y_values=struct.pack("<I", 2) * point_count,
+    )
+    current = MapDisplayData(
+        trajectory_x_values=struct.pack("<I", 3) * point_count,
+        trajectory_y_values=struct.pack("<I", 4) * point_count,
+    )
+
+    assert NarwalCoordinator._native_trajectory_overlap(previous, current) == 0
+
+
+def test_repeated_native_trajectory_window_does_not_duplicate_route() -> None:
+    """Repeated display_map windows update pose without growing the route."""
+    previous = _trajectory_display(
+        (1.0, 1.0),
+        (2.0, 2.0),
+        (3.0, 3.0),
+        timestamp=100,
+    )
+    current = _trajectory_display(
+        (1.0, 1.0),
+        (2.0, 2.0),
+        (3.0, 3.0),
+        timestamp=200,
+    )
+
+    merged = NarwalCoordinator._merge_native_trajectory_windows(previous, current)
+
+    assert merged.trajectory_points() == previous.trajectory_points()
+    assert merged.trajectory_signature[0] == 3
+    assert merged.timestamp == 200
+
+
+def test_extending_full_trajectory_reuses_robot_window() -> None:
+    """An accumulated Narwal route does not rebuild its retained prefix."""
+    previous = _trajectory_display(
+        (1.0, 1.0), (2.0, 2.0), (3.0, 3.0), timestamp=100
+    )
+    current = _trajectory_display(
+        (1.0, 1.0), (2.0, 2.0), (3.0, 3.0), (4.0, 4.0), timestamp=200
+    )
+
+    merged = NarwalCoordinator._merge_native_trajectory_windows(previous, current)
+
+    assert merged is current
+
+
+def test_extending_full_trajectory_preserves_retained_breaks() -> None:
+    """Exact prefix growth must not reconnect a gap retained by HA."""
+    previous = _trajectory_display(
+        (1.0, 1.0), (2.0, 2.0), (3.0, 3.0), timestamp=100
+    )
+    previous.trajectory_breaks = (2,)
+    current = _trajectory_display(
+        (1.0, 1.0), (2.0, 2.0), (3.0, 3.0), (4.0, 4.0), timestamp=200
+    )
+
+    merged = NarwalCoordinator._merge_native_trajectory_windows(previous, current)
+
+    assert merged.trajectory_points() == current.trajectory_points()
+    assert merged.trajectory_breaks == (2,)
+
+
+def test_retained_trajectory_is_compacted_with_recent_tail_and_breaks() -> None:
+    """Long routes retain their full shape without unbounded callback work."""
+    display = _trajectory_display(
+        *((float(index), float(index)) for index in range(10)), timestamp=200
+    )
+
+    compact_x, compact_y, compact_breaks = (
+        NarwalCoordinator._compact_native_trajectory(
+            display.trajectory_x_values,
+            display.trajectory_y_values,
+            (5,),
+            max_points=6,
+            recent_tail_points=2,
+        )
+    )
+    compact = replace(
+        display,
+        trajectory_x_values=compact_x,
+        trajectory_y_values=compact_y,
+        trajectory_breaks=compact_breaks,
+    )
+
+    assert compact.trajectory_points() == [
+        (0.0, 0.0),
+        (2.0, 2.0),
+        (5.0, 5.0),
+        (7.0, 7.0),
+        (8.0, 8.0),
+        (9.0, 9.0),
+    ]
+    assert compact_breaks == (2,)
+
+
+def test_accumulated_robot_route_extends_after_retained_compaction() -> None:
+    """Later full Narwal windows replace, rather than append to, compacted routes."""
+    previous = _trajectory_display(
+        *((float(index), float(index)) for index in range(6)), timestamp=100
+    )
+    first_extension = _trajectory_display(
+        *((float(index), float(index)) for index in range(7)), timestamp=200
+    )
+    second_extension = _trajectory_display(
+        *((float(index), float(index)) for index in range(8)), timestamp=300
+    )
+
+    with (
+        patch(
+            "custom_components.narwal.coordinator.NATIVE_TRAJECTORY_MAX_POINTS", 6
+        ),
+        patch(
+            "custom_components.narwal.coordinator."
+            "NATIVE_TRAJECTORY_RECENT_TAIL_POINTS",
+            2,
+        ),
+    ):
+        compacted = NarwalCoordinator._merge_native_trajectory_windows(
+            previous, first_extension
+        )
+        merged = NarwalCoordinator._merge_native_trajectory_windows(
+            compacted, second_extension
+        )
+
+    assert len(merged.trajectory_points()) == 6
+    assert merged.trajectory_points()[0] == (0.0, 0.0)
+    assert merged.trajectory_points()[-2:] == [(6.0, 6.0), (7.0, 7.0)]
+
+
+def test_rolling_window_containing_compacted_tail_appends_only_new_points() -> None:
+    """A window starting before the retained tail must not duplicate old geometry."""
+    full_previous = _trajectory_display(
+        *((float(index), float(index)) for index in range(10)), timestamp=100
+    )
+    current = _trajectory_display(
+        *((float(index), float(index)) for index in range(6, 12)), timestamp=200
+    )
+
+    with (
+        patch(
+            "custom_components.narwal.coordinator.NATIVE_TRAJECTORY_MAX_POINTS", 6
+        ),
+        patch(
+            "custom_components.narwal.coordinator."
+            "NATIVE_TRAJECTORY_RECENT_TAIL_POINTS",
+            2,
+        ),
+    ):
+        compact_x, compact_y, compact_breaks = (
+            NarwalCoordinator._compact_native_trajectory(
+                full_previous.trajectory_x_values,
+                full_previous.trajectory_y_values,
+                (),
+            )
+        )
+        compacted = replace(
+            full_previous,
+            trajectory_x_values=compact_x,
+            trajectory_y_values=compact_y,
+            trajectory_breaks=compact_breaks,
+        )
+        merged = NarwalCoordinator._merge_native_trajectory_windows(
+            compacted, current
+        )
+
+    assert merged.trajectory_points() == [
+        (0.0, 0.0),
+        (5.0, 5.0),
+        (7.0, 7.0),
+        (9.0, 9.0),
+        (10.0, 10.0),
+        (11.0, 11.0),
+    ]
+    assert not merged.trajectory_breaks
+
+
+def test_accumulated_robot_route_replaces_compacted_route_with_breaks() -> None:
+    """A later complete Narwal window resolves gaps retained before compaction."""
+    retained = _trajectory_display(
+        *((float(index), float(index)) for index in range(8)), timestamp=200
+    )
+    retained.trajectory_breaks = (3,)
+    second_extension = _trajectory_display(
+        *((float(index), float(index)) for index in range(9)), timestamp=300
+    )
+
+    with (
+        patch(
+            "custom_components.narwal.coordinator.NATIVE_TRAJECTORY_MAX_POINTS", 6
+        ),
+        patch(
+            "custom_components.narwal.coordinator."
+            "NATIVE_TRAJECTORY_RECENT_TAIL_POINTS",
+            2,
+        ),
+    ):
+        compact_x, compact_y, compact_breaks = (
+            NarwalCoordinator._compact_native_trajectory(
+                retained.trajectory_x_values,
+                retained.trajectory_y_values,
+                retained.trajectory_breaks,
+            )
+        )
+        compacted = replace(
+            retained,
+            trajectory_x_values=compact_x,
+            trajectory_y_values=compact_y,
+            trajectory_breaks=compact_breaks,
+        )
+        assert compacted.trajectory_breaks
+        merged = NarwalCoordinator._merge_native_trajectory_windows(
+            compacted, second_extension
+        )
+
+    assert len(merged.trajectory_points()) == 6
+    assert merged.trajectory_points()[0] == (0.0, 0.0)
+    assert merged.trajectory_points()[-2:] == [(7.0, 7.0), (8.0, 8.0)]
+    assert not merged.trajectory_breaks
+
+
+def test_equal_size_robot_route_replaces_compacted_route() -> None:
+    """A full route at the retention cap must not append compacted data."""
+    retained = _trajectory_display(
+        *((float(index), float(index)) for index in range(9)), timestamp=200
+    )
+    current = _trajectory_display(
+        (0.0, 0.0),
+        (1.0, 1.0),
+        (2.0, 2.0),
+        (3.0, 3.0),
+        (7.0, 7.0),
+        (8.0, 8.0),
+        timestamp=300,
+    )
+
+    with (
+        patch(
+            "custom_components.narwal.coordinator.NATIVE_TRAJECTORY_MAX_POINTS", 6
+        ),
+        patch(
+            "custom_components.narwal.coordinator."
+            "NATIVE_TRAJECTORY_RECENT_TAIL_POINTS",
+            2,
+        ),
+    ):
+        compact_x, compact_y, compact_breaks = (
+            NarwalCoordinator._compact_native_trajectory(
+                retained.trajectory_x_values,
+                retained.trajectory_y_values,
+                retained.trajectory_breaks,
+            )
+        )
+        compacted = replace(
+            retained,
+            trajectory_x_values=compact_x,
+            trajectory_y_values=compact_y,
+            trajectory_breaks=compact_breaks,
+        )
+        merged = NarwalCoordinator._merge_native_trajectory_windows(
+            compacted, current
+        )
+
+    assert merged.trajectory_points() == current.trajectory_points()
+
+
+def test_compacted_route_tail_matches_repeated_x_coordinates() -> None:
+    """Compacted replacement matches complete points, not the first X bytes."""
+    compacted = _trajectory_display(
+        (0.0, 0.0),
+        (1.0, 1.0),
+        (2.0, 2.0),
+        (3.0, 3.0),
+        (5.0, 10.0),
+        (5.0, 11.0),
+        timestamp=200,
+    )
+    compacted.trajectory_breaks = (3,)
+    current = _trajectory_display(
+        (0.0, 0.0),
+        (5.0, 99.0),
+        (5.0, 100.0),
+        (4.0, 4.0),
+        (5.0, 10.0),
+        (5.0, 11.0),
+        (6.0, 6.0),
+        timestamp=300,
+    )
+
+    with (
+        patch(
+            "custom_components.narwal.coordinator.NATIVE_TRAJECTORY_MAX_POINTS", 6
+        ),
+        patch(
+            "custom_components.narwal.coordinator."
+            "NATIVE_TRAJECTORY_RECENT_TAIL_POINTS",
+            2,
+        ),
+    ):
+        merged = NarwalCoordinator._merge_native_trajectory_windows(
+            compacted, current
+        )
+
+    assert (3.0, 3.0) not in merged.trajectory_points()
+    assert merged.trajectory_points()[-2:] == [(5.0, 11.0), (6.0, 6.0)]
+    assert not merged.trajectory_breaks
+
+
+def test_active_cached_trajectory_requires_live_window_overlap() -> None:
+    """A clean started during HA downtime must not inherit the previous route."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    previous = _trajectory_display((1.0, 1.0), (2.0, 2.0), timestamp=100)
+    current = _trajectory_display((8.0, 8.0), (9.0, 9.0), timestamp=200)
+    state = NarwalState(working_status=WorkingStatus.CLEANING)
+    state.map_display_data = current
+    coordinator._retained_map_display = previous
+    coordinator._map_display_cache_signature = previous.trajectory_signature
+    coordinator._map_display_cache_restored = True
+    coordinator._map_display_cache_restored_from_active = True
+
+    coordinator._retain_native_trajectory(state)
+
+    assert state.map_display_data is current
+    assert coordinator._retained_map_display is current
+    assert not coordinator._map_display_cache_restored
+    assert not coordinator._map_display_cache_restored_from_active
+
+
+def test_active_cached_trajectory_merges_overlapping_live_window() -> None:
+    """An overlapping first live window proves an active-cache reconnect."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    previous = _trajectory_display(
+        (1.0, 1.0), (2.0, 2.0), (3.0, 3.0), (4.0, 4.0), timestamp=100
+    )
+    current = _trajectory_display(
+        (2.0, 2.0), (3.0, 3.0), (4.0, 4.0), (5.0, 5.0), timestamp=200
+    )
+    state = NarwalState(working_status=WorkingStatus.CLEANING)
+    state.map_display_data = current
+    coordinator._retained_map_display = previous
+    coordinator._map_display_cache_signature = previous.trajectory_signature
+    coordinator._map_display_cache_restored = True
+    coordinator._map_display_cache_restored_from_active = True
+
+    coordinator._retain_native_trajectory(state)
+
+    assert state.map_display_data.trajectory_points() == [
+        (1.0, 1.0),
+        (2.0, 2.0),
+        (3.0, 3.0),
+        (4.0, 4.0),
+        (5.0, 5.0),
+    ]
+    assert not coordinator._map_display_cache_restored
+    assert not coordinator._map_display_cache_restored_from_active
+
+
+def test_active_compacted_cache_accepts_full_live_window_after_restart() -> None:
+    """A retained recent tail validates a compacted active route after restart."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    full_previous = _trajectory_display(
+        *((float(index), float(index)) for index in range(10)), timestamp=100
+    )
+    current = _trajectory_display(
+        *((float(index), float(index)) for index in range(12)), timestamp=200
+    )
+    with (
+        patch(
+            "custom_components.narwal.coordinator.NATIVE_TRAJECTORY_MAX_POINTS", 6
+        ),
+        patch(
+            "custom_components.narwal.coordinator."
+            "NATIVE_TRAJECTORY_RECENT_TAIL_POINTS",
+            2,
+        ),
+    ):
+        compact_x, compact_y, compact_breaks = (
+            NarwalCoordinator._compact_native_trajectory(
+                full_previous.trajectory_x_values,
+                full_previous.trajectory_y_values,
+                (),
+            )
+        )
+        previous = replace(
+            full_previous,
+            trajectory_x_values=compact_x,
+            trajectory_y_values=compact_y,
+            trajectory_breaks=compact_breaks,
+        )
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.map_display_data = current
+        coordinator._retained_map_display = previous
+        coordinator._map_display_cache_signature = previous.trajectory_signature
+        coordinator._map_display_cache_restored = True
+        coordinator._map_display_cache_restored_from_active = True
+
+        coordinator._retain_native_trajectory(state)
+
+    assert state.map_display_data.trajectory_points()[-1] == (11.0, 11.0)
+    assert not coordinator._map_display_cache_restored
+    assert not coordinator._map_display_cache_restored_from_active
+
+
+def test_metric_only_overlap_completes_active_cache_validation() -> None:
+    """An overlapping live window validates a route despite coarse standby."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    previous = _trajectory_display(
+        (1.0, 1.0), (2.0, 2.0), (3.0, 3.0), (4.0, 4.0), timestamp=100
+    )
+    current = _trajectory_display(
+        (2.0, 2.0), (3.0, 3.0), (4.0, 4.0), (5.0, 5.0), timestamp=200
+    )
+    state = NarwalState(working_status=WorkingStatus.STANDBY)
+    state.update_from_working_status({"3": 120})
+    state.map_display_data = current
+    coordinator._retained_map_display = previous
+    coordinator._map_display_cache_signature = previous.trajectory_signature
+    coordinator._map_display_cache_restored = True
+    coordinator._map_display_cache_restored_from_active = True
+
+    coordinator._retain_native_trajectory(state)
+
+    assert state.map_display_data.trajectory_points()[-1] == (5.0, 5.0)
+    assert not coordinator._map_display_cache_restored
+    assert not coordinator._map_display_cache_restored_from_active
+
+
+def test_active_cached_trajectory_rejects_single_point_overlap() -> None:
+    """One coincidental point cannot join routes from different clean sessions."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    previous = _trajectory_display(
+        (1.0, 1.0), (2.0, 2.0), (3.0, 3.0), timestamp=100
+    )
+    current = _trajectory_display(
+        (3.0, 3.0), (8.0, 8.0), (9.0, 9.0), timestamp=200
+    )
+    state = NarwalState(working_status=WorkingStatus.CLEANING)
+    state.map_display_data = current
+    coordinator._retained_map_display = previous
+    coordinator._map_display_cache_signature = previous.trajectory_signature
+    coordinator._map_display_cache_restored = True
+    coordinator._map_display_cache_restored_from_active = True
+
+    coordinator._retain_native_trajectory(state)
+
+    assert state.map_display_data is current
+    assert not coordinator._map_display_cache_restored_from_active
+
+
+def test_active_cached_trajectory_waits_for_validation_window() -> None:
+    """A tiny first live window defers the restored-route decision."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    previous = _trajectory_display(
+        (1.0, 1.0), (2.0, 2.0), (3.0, 3.0), timestamp=100
+    )
+    current = _trajectory_display((3.0, 3.0), timestamp=200)
+    current.robot_heading = 45.0
+    state = NarwalState(working_status=WorkingStatus.CLEANING)
+    state.map_display_data = current
+    coordinator._retained_map_display = previous
+    coordinator._map_display_cache_signature = previous.trajectory_signature
+    coordinator._map_display_cache_restored = True
+    coordinator._map_display_cache_restored_from_active = True
+
+    coordinator._retain_native_trajectory(state)
+
+    assert state.map_display_data.trajectory_points() == previous.trajectory_points()
+    assert state.map_display_data.robot_x == 3.0
+    assert state.map_display_data.robot_y == 3.0
+    assert state.map_display_data.robot_heading == 45.0
+    assert state.map_display_data.timestamp == 200
+    assert coordinator._map_display_cache_restored_from_active
+
+    # Reprocessing the state published above is not new trajectory evidence.
+    coordinator._retain_native_trajectory(state)
+    assert coordinator._map_display_cache_restored_from_active
+
+    unrelated = _trajectory_display(
+        (8.0, 8.0), (9.0, 9.0), (10.0, 10.0), timestamp=300
+    )
+    state.map_display_data = unrelated
+    coordinator._retain_native_trajectory(state)
+
+    assert state.map_display_data is unrelated
+    assert not coordinator._map_display_cache_restored_from_active
+
+
+def test_active_cached_trajectory_ignores_pose_only_window_for_validation() -> None:
+    """A pose-only packet cannot validate a route restored after restart."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    previous = _trajectory_display((1.0, 1.0), (2.0, 2.0), timestamp=100)
+    coordinator._retained_map_display = previous
+    coordinator._map_display_cache_signature = previous.trajectory_signature
+    coordinator._map_display_cache_restored = True
+    coordinator._map_display_cache_restored_from_active = True
+    state = NarwalState(working_status=WorkingStatus.CLEANING)
+    state.map_display_data = MapDisplayData(robot_x=3.0, robot_y=3.0, timestamp=150)
+
+    coordinator._retain_native_trajectory(state)
+
+    assert coordinator._map_display_cache_restored_from_active
+    assert state.map_display_data.trajectory_points() == [(1.0, 1.0), (2.0, 2.0)]
+
+    state.map_display_data = _trajectory_display(
+        (8.0, 8.0), (9.0, 9.0), timestamp=200
+    )
+    coordinator._retain_native_trajectory(state)
+
+    assert state.map_display_data.trajectory_points() == [(8.0, 8.0), (9.0, 9.0)]
+    assert not coordinator._map_display_cache_restored_from_active
+
+
+def test_empty_native_trajectory_window_preserves_completed_route() -> None:
+    """A terminal pose-only packet must not discard the completed trail."""
+    previous = _trajectory_display((1.0, 1.0), (2.0, 2.0), timestamp=100)
+    current = MapDisplayData(robot_x=9.0, robot_y=8.0, timestamp=200)
+
+    merged = NarwalCoordinator._merge_native_trajectory_windows(previous, current)
+
+    assert merged.trajectory_points() == previous.trajectory_points()
+    assert merged.robot_x == 9.0
+    assert merged.robot_y == 8.0
+    assert merged.timestamp == 200
+
+
+def test_nonoverlapping_window_after_restart_keeps_both_native_sections() -> None:
+    """A reboot gap retains native points before and after the missed window."""
+    previous = _trajectory_display((1.0, 1.0), (2.0, 2.0), timestamp=100)
+    current = _trajectory_display((8.0, 8.0), (9.0, 9.0), timestamp=200)
+
+    merged = NarwalCoordinator._merge_native_trajectory_windows(previous, current)
+
+    assert merged.trajectory_points() == [
+        (1.0, 1.0),
+        (2.0, 2.0),
+        (8.0, 8.0),
+        (9.0, 9.0),
+    ]
+    assert merged.trajectory_breaks == (2,)
+    render_points = merged.trajectory_render_points()
+    assert len(render_points) == 5
+    assert math.isnan(render_points[2][0])
+    assert math.isnan(render_points[2][1])
+
+
+def test_retain_native_trajectory_updates_shared_state() -> None:
+    """Coordinator state and persistence see the accumulated native route."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator._retained_map_display = _trajectory_display(
+        (1.0, 1.0), (2.0, 2.0), timestamp=100
+    )
+    state = NarwalState()
+    state.map_display_data = _trajectory_display(
+        (2.0, 2.0), (3.0, 3.0), timestamp=200
+    )
+
+    coordinator._retain_native_trajectory(state)
+
+    assert state.map_display_data is coordinator._retained_map_display
+    assert state.map_display_data.trajectory_points() == [
+        (1.0, 1.0),
+        (2.0, 2.0),
+        (3.0, 3.0),
+    ]
+
+
+def test_retain_native_trajectory_clears_when_active_map_changes() -> None:
+    """A route from one floor must not be retained against another map."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    state = NarwalState()
+    state.map_data = MapData(map_id=13, created_at=35)
+    state.map_display_data = _trajectory_display(
+        (8.0, 8.0), (9.0, 9.0), timestamp=200
+    )
+    coordinator.client = MagicMock()
+    coordinator.client.state = state
+    coordinator._retained_map_display = _trajectory_display(
+        (1.0, 1.0), (2.0, 2.0), timestamp=100
+    )
+    coordinator._retained_map_identity = (12, 34)
+    coordinator._pending_map_display_cache_snapshot = None
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_signature = (2, 1, 1)
+    coordinator._map_display_cache_active_clean = False
+    coordinator._map_display_cache_restored = True
+    coordinator._map_display_cache_restored_from_active = False
+    coordinator._schedule_map_display_cache_clear = MagicMock()
+
+    coordinator._retain_native_trajectory(state)
+
+    assert state.map_display_data is None
+    assert coordinator._retained_map_display is None
+    assert coordinator._retained_map_identity == (13, 35)
+    assert coordinator._map_display_cache_signature == ()
+    coordinator._schedule_map_display_cache_clear.assert_called_once_with(None)
+
+    new_map_window = _trajectory_display((10.0, 10.0), timestamp=300)
+    state.map_display_data = new_map_window
+    coordinator._retain_native_trajectory(state)
+
+    assert state.map_display_data is new_map_window
+    assert coordinator._retained_map_display is new_map_window
+
+
+def test_retained_trajectory_adopts_delayed_static_map_identity() -> None:
+    """A map loaded after the first route still scopes later trajectory data."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    state = NarwalState()
+    state.map_data = MapData(map_id=12, created_at=34)
+    state.map_display_data = _trajectory_display(
+        (2.0, 2.0), (3.0, 3.0), timestamp=200
+    )
+    coordinator.client = MagicMock()
+    coordinator.client.state = state
+    coordinator._retained_map_display = _trajectory_display(
+        (1.0, 1.0), (2.0, 2.0), timestamp=100
+    )
+    coordinator._retained_map_identity = None
+    coordinator._map_display_cache_restored_from_active = False
+    coordinator._schedule_map_display_cache_clear = MagicMock()
+
+    coordinator._retain_native_trajectory(state)
+
+    assert coordinator._retained_map_identity == (12, 34)
+    assert state.map_display_data.trajectory_points() == [
+        (1.0, 1.0),
+        (2.0, 2.0),
+        (3.0, 3.0),
+    ]
+
+    state.map_data = MapData(map_id=13, created_at=35)
+    state.map_display_data = _trajectory_display((8.0, 8.0), timestamp=300)
+    coordinator._retain_native_trajectory(state)
+
+    assert coordinator._retained_map_identity == (13, 35)
+    assert coordinator._retained_map_display is None
+    assert state.map_display_data is None
+    coordinator._schedule_map_display_cache_clear.assert_called_once_with(None)
+
+
+def test_remapping_trajectory_does_not_replace_retained_clean_route() -> None:
+    """Map-building geometry must not contaminate the cleaning trail."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    retained = _trajectory_display((1.0, 1.0), (2.0, 2.0), timestamp=100)
+    coordinator._retained_map_display = retained
+    state = NarwalState(working_status=WorkingStatus.REMAPPING)
+    remapping = _trajectory_display(
+        (8.0, 8.0), (9.0, 9.0), timestamp=200
+    )
+    remapping.robot_heading = 45.0
+    remapping.dock_ref_x = 4.0
+    remapping.dock_ref_y = 5.0
+    state.map_display_data = remapping
+
+    coordinator._retain_native_trajectory(state)
+
+    assert state.map_display_data.trajectory_points() == retained.trajectory_points()
+    assert state.map_display_data.robot_x == 9.0
+    assert state.map_display_data.robot_y == 9.0
+    assert state.map_display_data.robot_heading == 45.0
+    assert state.map_display_data.timestamp == 200
+    assert state.map_display_data.dock_ref_x == 4.0
+    assert state.map_display_data.dock_ref_y == 5.0
+    assert coordinator._retained_map_display is state.map_display_data
+    assert coordinator._map_display_cache_snapshot(state) is None
+
+
+def test_remapping_without_retained_route_keeps_live_pose_only() -> None:
+    """Map rebuilding keeps the marker without adopting mapping geometry."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator._retained_map_display = None
+    state = NarwalState(working_status=WorkingStatus.REMAPPING)
+    remapping = _trajectory_display((8.0, 8.0), (9.0, 9.0), timestamp=200)
+    remapping.robot_heading = 45.0
+    state.map_display_data = remapping
+
+    coordinator._retain_native_trajectory(state)
+
+    assert state.map_display_data is not None
+    assert not state.map_display_data.has_trajectory
+    assert state.map_display_data.robot_x == 9.0
+    assert state.map_display_data.robot_y == 9.0
+    assert state.map_display_data.robot_heading == 45.0
+    assert state.map_display_data.timestamp == 200
+    assert coordinator._retained_map_display is None
+
+
+def test_new_clean_drops_pre_status_trajectory_window() -> None:
+    """A display packet before clean status is dropped to avoid stale routes."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.hass = MagicMock()
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.async_create_background_task = MagicMock(
+        side_effect=_close_background_task
+    )
+    coordinator.client = MagicMock()
+    coordinator.client.last_display_map_age = 1.0
+    coordinator.client.state = NarwalState(working_status=WorkingStatus.STANDBY)
+    coordinator._retained_map_display = _trajectory_display(
+        (1.0, 1.0), (2.0, 2.0), timestamp=100
+    )
+    coordinator._map_display_cache_store = _FakeStore({"old": "trail"})
+    coordinator._pending_map_display_cache_snapshot = None
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_signature = (2, 1, 1)
+    coordinator._map_display_cache_restored = False
+    coordinator._map_display_cache_restored_from_active = False
+    coordinator._map_display_cache_save_task = None
+    coordinator._map_display_cache_last_save = time.monotonic()
+
+    raw_window = _trajectory_display((8.0, 8.0), (9.0, 9.0), timestamp=200)
+    coordinator.client.state.map_display_data = raw_window
+    coordinator._retain_native_trajectory(coordinator.client.state)
+
+    assert coordinator.client.state.map_display_data.trajectory_points() == [
+        (1.0, 1.0),
+        (2.0, 2.0),
+        (8.0, 8.0),
+        (9.0, 9.0),
+    ]
+
+    coordinator.client.state.working_status = WorkingStatus.CLEANING
+    coordinator._clear_map_display_cache_for_new_clean()
+
+    assert coordinator.client.state.map_display_data is None
+    assert coordinator._retained_map_display is None
+    assert coordinator._pending_map_display_cache_snapshot is None
+
+
+async def test_restore_map_display_cache_restores_matching_static_map() -> None:
+    """A saved trail is restored after restart when the static map matches."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    source = _trajectory_state()
+    coordinator.client = MagicMock()
+    coordinator.client.state = NarwalState()
+    coordinator.client.state.map_data = source.map_data
+    coordinator._map_display_cache_store = _FakeStore(
+        coordinator._map_display_cache_payload(source)
+    )
+    coordinator._map_display_cache_signature = ()
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_restored = False
+
+    await coordinator._async_restore_map_display_cache()
+
+    restored = coordinator.client.state.map_display_data
+    assert restored is not None
+    assert restored.trajectory_signature == (4, 4, 99)
+    assert coordinator._retained_map_identity == (12, 34)
+    assert coordinator._map_display_cache_signature == (4, 4, 99)
+    assert coordinator._map_display_cache_restored
+
+
+async def test_restore_map_display_cache_rejects_inactive_route_during_clean() -> None:
+    """A completed saved route cannot seed a clean already active at startup."""
+    source = _trajectory_state()
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.client = MagicMock()
+    coordinator.client.state = NarwalState(working_status=WorkingStatus.CLEANING)
+    coordinator.client.state.map_data = source.map_data
+    coordinator._map_display_cache_store = _FakeStore(
+        coordinator._map_display_cache_payload(source)
+    )
+    coordinator._map_display_cache_signature = ()
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_restored = False
+    coordinator._map_display_cache_restored_from_active = False
+
+    await coordinator._async_restore_map_display_cache()
+
+    assert coordinator.client.state.map_display_data is None
+    assert coordinator._map_display_cache_signature == ()
+    assert not coordinator._map_display_cache_restored
+
+
+async def test_restore_map_display_cache_preserves_live_pose_only_packet() -> None:
+    """Cached route bytes must not replace the robot's live startup pose."""
+    cached = _trajectory_state()
+    cached.working_status = WorkingStatus.CLEANING
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.client = MagicMock()
+    coordinator.client.state = NarwalState(working_status=WorkingStatus.CLEANING)
+    coordinator.client.state.map_data = cached.map_data
+    coordinator.client.state.map_display_data = MapDisplayData(
+        robot_x=9.0,
+        robot_y=8.0,
+        robot_heading=45.0,
+        timestamp=200,
+    )
+    coordinator._map_display_cache_store = _FakeStore(
+        coordinator._map_display_cache_payload(cached)
+    )
+    coordinator._map_display_cache_signature = ()
+    coordinator._pending_map_display_cache_snapshot = None
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_restored = False
+    coordinator._map_display_cache_restored_from_active = False
+
+    await coordinator._async_restore_map_display_cache()
+
+    restored = coordinator.client.state.map_display_data
+    assert restored is not None
+    assert restored.trajectory_points() == cached.map_display_data.trajectory_points()
+    assert (restored.robot_x, restored.robot_y) == (9.0, 8.0)
+    assert restored.robot_heading == 45.0
+    assert restored.timestamp == 200
+
+
+async def test_restore_map_display_cache_does_not_overwrite_live_trail() -> None:
+    """A live display_map packet received during startup wins over stored routes."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    cached = _trajectory_state()
+    cached.map_display_data = MapDisplayData(
+        robot_x=5.0,
+        robot_y=6.0,
+        robot_heading=180.0,
+        timestamp=123457,
+        dock_ref_x=3.0,
+        dock_ref_y=4.0,
+        trajectory_x_values=b"aa",
+        trajectory_y_values=b"bb",
+        trajectory_signature=(2, 2, 77),
+    )
+    coordinator.client = MagicMock()
+    coordinator.client.state = _trajectory_state()
+    coordinator._map_display_cache_store = _FakeStore(
+        coordinator._map_display_cache_payload(cached)
+    )
+    coordinator._map_display_cache_signature = ()
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_restored = False
+    coordinator._map_display_cache_restored_from_active = False
+
+    await coordinator._async_restore_map_display_cache()
+
+    assert coordinator.client.state.map_display_data.trajectory_signature == (4, 4, 99)
+    assert coordinator._map_display_cache_signature == ()
+    assert not coordinator._map_display_cache_restored
+
+
+async def test_restore_active_cache_merges_early_live_window() -> None:
+    """An early startup window validates and extends an active saved prefix."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    cached = _trajectory_state()
+    cached.working_status = WorkingStatus.CLEANING
+    cached.map_display_data = _trajectory_display(
+        *((float(index), float(index)) for index in range(1, 31)),
+        timestamp=100,
+    )
+    payload = coordinator._map_display_cache_payload(cached)
+    assert payload is not None
+    assert payload["active_clean"] is True
+
+    coordinator.client = MagicMock()
+    coordinator.client.state = _trajectory_state()
+    coordinator.client.state.working_status = WorkingStatus.CLEANING
+    coordinator.client.state.map_display_data = _trajectory_display(
+        *((float(index), float(index)) for index in range(27, 57)),
+        timestamp=200,
+    )
+    coordinator._map_display_cache_store = _FakeStore(payload)
+    coordinator._map_display_cache_signature = ()
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_restored = False
+    coordinator._map_display_cache_restored_from_active = False
+    coordinator._retained_map_display = None
+    coordinator._retained_map_identity = None
+
+    await coordinator._async_restore_map_display_cache()
+
+    assert coordinator.client.state.map_display_data.trajectory_points() == [
+        (float(index), float(index)) for index in range(1, 57)
+    ]
+    assert not coordinator._map_display_cache_restored_from_active
+
+
+async def test_stale_startup_status_keeps_validated_active_cache_until_cleaning() -> None:
+    """A late cleaning status cannot clear a prefix validated while STANDBY."""
+    cached = _trajectory_state()
+    cached.working_status = WorkingStatus.CLEANING
+    cached.map_display_data = _trajectory_display(
+        *((float(index), float(index)) for index in range(1, 31)),
+        timestamp=100,
+    )
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    payload = coordinator._map_display_cache_payload(cached)
+    assert payload is not None
+
+    coordinator.client = MagicMock()
+    coordinator.client.state = _trajectory_state()
+    coordinator.client.state.working_status = WorkingStatus.STANDBY
+    coordinator.client.state.map_display_data = _trajectory_display(
+        *((float(index), float(index)) for index in range(27, 57)),
+        timestamp=200,
+    )
+    coordinator._map_display_cache_store = _FakeStore(payload)
+    coordinator._map_display_cache_signature = ()
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_restored = False
+    coordinator._map_display_cache_restored_from_active = False
+    coordinator._retained_map_display = None
+    coordinator._retained_map_identity = None
+    coordinator._clean_session_active = False
+    coordinator._clear_map_display_cache_for_new_clean = MagicMock()
+
+    await coordinator._async_restore_map_display_cache()
+
+    assert coordinator.client.state.map_display_data.trajectory_points() == [
+        (float(index), float(index)) for index in range(1, 57)
+    ]
+    assert coordinator._pending_map_display_cache_snapshot is not None
+    assert coordinator._pending_map_display_cache_snapshot.display.trajectory_points() == [
+        (float(index), float(index)) for index in range(1, 57)
+    ]
+    assert coordinator._map_display_cache_restored_from_active
+    persisted = coordinator._map_display_cache_payload(coordinator.client.state)
+    assert persisted is not None
+    assert persisted["active_clean"] is True
+
+    restarted = NarwalCoordinator.__new__(NarwalCoordinator)
+    restarted.client = MagicMock()
+    restarted.client.state = NarwalState(working_status=WorkingStatus.CLEANING)
+    restarted.client.state.map_data = cached.map_data
+    restarted._map_display_cache_store = _FakeStore(persisted)
+    restarted._map_display_cache_signature = ()
+    restarted._pending_map_display_cache_restore = None
+    restarted._map_display_cache_restored = False
+    restarted._map_display_cache_restored_from_active = False
+
+    await restarted._async_restore_map_display_cache()
+
+    assert restarted.client.state.map_display_data is not None
+    assert restarted._map_display_cache_restored_from_active
+
+    coordinator.client.state.working_status = WorkingStatus.CLEANING
+    coordinator._handle_working_status_transition(coordinator.client.state)
+
+    coordinator._clear_map_display_cache_for_new_clean.assert_not_called()
+    coordinator.client.state.map_display_data = _trajectory_display(
+        *((float(index), float(index)) for index in range(53, 83)),
+        timestamp=300,
+    )
+    coordinator._retain_native_trajectory(coordinator.client.state)
+
+    assert coordinator.client.state.map_display_data.trajectory_points() == [
+        (float(index), float(index)) for index in range(1, 83)
+    ]
+    assert not coordinator._map_display_cache_restored_from_active
+
+
+@pytest.mark.parametrize(
+    ("working_status", "dock_presence", "dock_field11", "expected_active"),
+    (
+        (WorkingStatus.STANDBY, 6, 2, False),
+        (WorkingStatus.ERROR, 0, 0, False),
+        (WorkingStatus.DOCKED_V2, 2, 0, True),
+    ),
+)
+def test_restored_active_cache_uses_reconciled_terminal_state(
+    working_status: WorkingStatus,
+    dock_presence: int,
+    dock_field11: int,
+    expected_active: bool,
+) -> None:
+    """Dock evidence and explicit off-dock evidence override a bare status enum."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    state = _trajectory_state()
+    state.working_status = working_status
+    state.dock_presence = dock_presence
+    state.dock_field11 = dock_field11
+    state.last_active_working_status_time = time.monotonic()
+    if working_status == WorkingStatus.STANDBY:
+        state.last_terminal_working_status_time = time.monotonic()
+    coordinator._map_display_cache_restored_from_active = True
+
+    payload = coordinator._map_display_cache_payload(state)
+
+    assert payload is not None
+    assert payload["active_clean"] is expected_active
+
+
+def test_off_dock_docked_v2_does_not_end_clean_session() -> None:
+    """Explicit off-dock telemetry preserves continuity across a stale dock enum."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    state = _trajectory_state()
+    state.working_status = WorkingStatus.DOCKED_V2
+    state.dock_presence = 2
+    state.last_active_working_status_time = time.monotonic()
+    coordinator._clean_session_active = True
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_restored_from_active = False
+    coordinator._clear_map_display_cache_for_new_clean = MagicMock()
+
+    coordinator._handle_working_status_transition(state)
+    state.working_status = WorkingStatus.CLEANING
+    coordinator._handle_working_status_transition(state)
+
+    assert coordinator._clean_session_active
+    coordinator._clear_map_display_cache_for_new_clean.assert_not_called()
+
+
+async def test_restore_map_display_cache_waits_for_static_map() -> None:
+    """A saved trail is not restored until the active static map is known."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    source = _trajectory_state()
+    coordinator.client = MagicMock()
+    coordinator.client.state = NarwalState()
+    coordinator._map_display_cache_store = _FakeStore(
+        coordinator._map_display_cache_payload(source)
+    )
+    coordinator._map_display_cache_signature = ()
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_restored = False
+
+    await coordinator._async_restore_map_display_cache()
+
+    assert coordinator.client.state.map_display_data is None
+    assert coordinator._pending_map_display_cache_restore is not None
+    assert coordinator._map_display_cache_signature == ()
+    assert not coordinator._map_display_cache_restored
+
+    coordinator.client.state.map_data = source.map_data
+    coordinator._restore_pending_map_display_cache()
+
+    restored = coordinator.client.state.map_display_data
+    assert restored is not None
+    assert restored.trajectory_signature == (4, 4, 99)
+    assert coordinator._pending_map_display_cache_restore is None
+    assert coordinator._map_display_cache_restored
+
+
+async def test_restore_map_display_cache_ignores_different_static_map() -> None:
+    """A saved trail from another map must not be overlaid."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    source = _trajectory_state()
+    coordinator.client = MagicMock()
+    coordinator.client.state = NarwalState()
+    coordinator.client.state.map_data = MapData(
+        map_id=13,
+        width=100,
+        height=100,
+        created_at=34,
+        compressed_map=b"\x01",
+    )
+    coordinator._map_display_cache_store = _FakeStore(
+        coordinator._map_display_cache_payload(source)
+    )
+    coordinator._map_display_cache_signature = ()
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_restored = False
+
+    await coordinator._async_restore_map_display_cache()
+
+    assert coordinator.client.state.map_display_data is None
+    assert coordinator._map_display_cache_signature == ()
+    assert not coordinator._map_display_cache_restored
+
+
+async def test_restore_map_display_cache_rejects_missing_map_identity() -> None:
+    """An unscoped persisted route cannot be assigned to an arbitrary map."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    source = _trajectory_state()
+    payload = coordinator._map_display_cache_payload(source)
+    assert payload is not None
+    payload["map_id"] = 0
+    payload["map_created_at"] = 0
+    coordinator.client = MagicMock()
+    coordinator.client.state = NarwalState()
+    coordinator.client.state.map_data = source.map_data
+    coordinator._map_display_cache_store = _FakeStore(payload)
+    coordinator._map_display_cache_signature = ()
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_restored = False
+
+    await coordinator._async_restore_map_display_cache()
+
+    assert coordinator.client.state.map_display_data is None
+    assert not coordinator._map_display_cache_restored
+
+
+async def test_setup_retains_trajectory_received_with_initial_map() -> None:
+    """The first native window participates in later rolling-window merges."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.hass = MagicMock()
+    coordinator.config_entry = MagicMock()
+    coordinator.client = MagicMock()
+    coordinator.client.state = _trajectory_state()
+    coordinator.client.state.map_display_data = _trajectory_display(
+        *((float(index), float(index)) for index in range(1, 31)),
+        timestamp=100,
+    )
+    coordinator.client.state.working_status = WorkingStatus.CLEANING
+    coordinator.client.connect = AsyncMock()
+    coordinator.client.get_device_info = AsyncMock()
+    coordinator.client.get_status = AsyncMock(
+        return_value=CommandResponse(
+            data={"2": {"3": {"1": int(WorkingStatus.CLEANING)}}}
+        )
+    )
+    coordinator.client.get_map = AsyncMock()
+    async def get_consumable_info() -> None:
+        coordinator.client.state.map_display_data = _trajectory_display(
+            *((float(index), float(index)) for index in range(27, 57)),
+            timestamp=200,
+        )
+
+    coordinator.client.get_consumable_info = AsyncMock(side_effect=get_consumable_info)
+    coordinator.client.supports_broadcasts = False
+    coordinator.client.robot_awake = True
+    coordinator.client.start_listening = AsyncMock()
+    coordinator._async_restore_room_selections = AsyncMock()
+    coordinator._async_restore_map_display_cache = AsyncMock()
+    coordinator._mark_dock_status_refresh_succeeded = MagicMock()
+    coordinator._mark_dock_status_refresh_failed = MagicMock()
+    coordinator._schedule_map_display_cache_save = MagicMock()
+    coordinator.async_set_updated_data = MagicMock()
+    coordinator._retained_map_display = None
+    coordinator._retained_map_identity = None
+    coordinator._map_display_cache_restored_from_active = False
+    coordinator._map_display_cache_restored = False
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._clean_session_active = False
+    coordinator._prev_working_status = WorkingStatus.UNKNOWN
+    coordinator._listen_task = None
+    coordinator._fast_poll_remaining = 0
+    coordinator.config_entry.async_create_background_task.side_effect = (
+        lambda _hass, coro, _name: (coro.close(), MagicMock(done=lambda: False))[1]
+    )
+
+    await coordinator.async_setup()
+
+    assert coordinator._retained_map_display.trajectory_points() == [
+        (float(index), float(index)) for index in range(1, 57)
+    ]
+    coordinator._schedule_map_display_cache_save.assert_called_once_with(
+        coordinator.client.state
+    )
+
+
+async def test_clear_map_display_cache_clears_memory_and_store() -> None:
+    """Accepted clean starts clear both memory and persisted trail state."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.client = MagicMock()
+    coordinator.client.state = _trajectory_state()
+    coordinator._map_display_cache_store = _FakeStore({"old": "trail"})
+    coordinator._pending_map_display_cache_snapshot = (
+        coordinator._map_display_cache_snapshot(coordinator.client.state)
+    )
+    coordinator._pending_map_display_cache_restore = {"pending": "trail"}
+    coordinator._map_display_cache_signature = (4, 4, 99)
+    coordinator._map_display_cache_restored = True
+    coordinator._map_display_cache_restored_from_active = True
+    coordinator._map_display_cache_save_task = asyncio.create_task(asyncio.sleep(60))
+    coordinator._map_display_cache_clear_event = asyncio.Event()
+    coordinator._map_display_cache_clear_event.set()
+
+    await coordinator.async_clear_map_display_cache()
+
+    assert coordinator.client.state.map_display_data is None
+    assert coordinator._pending_map_display_cache_snapshot is None
+    assert coordinator._pending_map_display_cache_restore is None
+    assert coordinator._map_display_cache_signature == ()
+    assert not coordinator._map_display_cache_restored
+    assert coordinator._map_display_cache_save_task is None
+    assert coordinator._map_display_cache_store.saved == [{}]
+
+
+async def test_clear_waits_for_uncancellable_storage_write() -> None:
+    """A new-clean clear must land after an executor-backed stale save."""
+    write_started = asyncio.Event()
+    release_write = asyncio.Event()
+
+    class ExecutorBackedStore(_FakeStore):
+        async def async_save(self, data: object) -> None:
+            if data != {}:
+                async def finish_write() -> None:
+                    write_started.set()
+                    await release_write.wait()
+                    self.saved.append(data)
+                    self.data = data
+
+                await asyncio.shield(asyncio.create_task(finish_write()))
+                return
+            await super().async_save(data)
+
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.hass = MagicMock()
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.async_create_background_task.side_effect = (
+        lambda _hass, coro, _name: asyncio.create_task(coro)
+    )
+    coordinator.client = MagicMock()
+    coordinator.client.state = _trajectory_state()
+    coordinator._map_display_cache_store = ExecutorBackedStore()
+    coordinator._map_display_cache_signature = ()
+    coordinator._map_display_cache_active_clean = None
+    coordinator._map_display_cache_last_save = 0.0
+    coordinator._pending_map_display_cache_snapshot = None
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_restored = False
+    coordinator._map_display_cache_restored_from_active = False
+    coordinator._map_display_cache_save_task = None
+    coordinator._map_display_cache_clear_event = asyncio.Event()
+    coordinator._map_display_cache_clear_event.set()
+
+    coordinator._schedule_map_display_cache_save(
+        coordinator.client.state,
+        immediate=True,
+    )
+    save_task = coordinator._map_display_cache_save_task
+    assert save_task is not None
+    await write_started.wait()
+
+    clear_task = asyncio.create_task(coordinator.async_clear_map_display_cache())
+    await asyncio.sleep(0)
+    save_task.cancel()
+    await asyncio.sleep(0)
+    assert not clear_task.done()
+
+    release_write.set()
+    await clear_task
+
+    assert coordinator._map_display_cache_store.saved[-1] == {}
+
+
+async def test_new_clean_clear_preserves_later_trajectory_snapshot() -> None:
+    """A delayed clear cannot discard the first route window of a new clean."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.hass = MagicMock()
+    coordinator.config_entry = MagicMock()
+    coordinator.client = MagicMock()
+    coordinator.client.state = _trajectory_state()
+    coordinator._map_display_cache_store = _FakeStore({"old": "trail"})
+    coordinator._map_display_cache_signature = (4, 4, 99)
+    coordinator._map_display_cache_last_save = time.monotonic()
+    coordinator._pending_map_display_cache_snapshot = (
+        coordinator._map_display_cache_snapshot(coordinator.client.state)
+    )
+    coordinator._map_display_cache_save_task = asyncio.create_task(asyncio.sleep(60))
+    coordinator._map_display_cache_clear_event = asyncio.Event()
+    coordinator._map_display_cache_clear_event.set()
+    background_tasks: list[asyncio.Task[None]] = []
+
+    def create_background_task(
+        _hass: object, coro: Coroutine[object, object, None], _name: str
+    ) -> asyncio.Task[None]:
+        task = asyncio.create_task(coro)
+        background_tasks.append(task)
+        return task
+
+    coordinator.config_entry.async_create_background_task.side_effect = (
+        create_background_task
+    )
+
+    coordinator._schedule_map_display_cache_clear(None)
+    coordinator.client.state.map_display_data = _trajectory_display(
+        (8.0, 8.0), (9.0, 9.0), timestamp=200
+    )
+    new_signature = coordinator.client.state.map_display_data.trajectory_signature
+    coordinator._schedule_map_display_cache_save(
+        coordinator.client.state, immediate=True
+    )
+
+    await background_tasks[0]
+    await background_tasks[-1]
+
+    assert coordinator._map_display_cache_store.saved[0] == {}
+    assert coordinator._map_display_cache_store.saved[-1]["trajectory_signature"] == list(
+        new_signature
+    )
+    assert coordinator._pending_map_display_cache_snapshot is None
+
+
+async def test_overlapping_new_clean_clears_keep_route_writes_gated() -> None:
+    """Concurrent command/status clears finish before a new route is saved."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.hass = MagicMock()
+    coordinator.config_entry = MagicMock()
+    coordinator.client = MagicMock()
+    coordinator.client.state = _trajectory_state()
+    coordinator._map_display_cache_store = _FakeStore({"old": "trail"})
+    coordinator._map_display_cache_signature = (4, 4, 99)
+    coordinator._map_display_cache_last_save = time.monotonic()
+    coordinator._pending_map_display_cache_snapshot = None
+    coordinator._map_display_cache_save_task = None
+    background_tasks: list[asyncio.Task[None]] = []
+
+    def create_background_task(
+        _hass: object, coro: Coroutine[object, object, None], _name: str
+    ) -> asyncio.Task[None]:
+        task = asyncio.create_task(coro)
+        background_tasks.append(task)
+        return task
+
+    coordinator.config_entry.async_create_background_task.side_effect = (
+        create_background_task
+    )
+
+    coordinator._schedule_map_display_cache_clear(None)
+    coordinator._schedule_map_display_cache_clear(None)
+    coordinator.client.state.map_display_data = _trajectory_display(
+        (8.0, 8.0), (9.0, 9.0), timestamp=200
+    )
+    new_signature = coordinator.client.state.map_display_data.trajectory_signature
+    coordinator._schedule_map_display_cache_save(
+        coordinator.client.state, immediate=True
+    )
+
+    await asyncio.gather(*background_tasks[:2])
+    await background_tasks[-1]
+
+    assert coordinator._map_display_cache_store.saved[:2] == [{}, {}]
+    assert coordinator._map_display_cache_store.saved[-1]["trajectory_signature"] == list(
+        new_signature
+    )
+    assert coordinator._map_display_cache_clear_count == 0
+    assert coordinator._map_display_cache_clear_gate().is_set()
+
+
+def test_reconnect_into_running_clean_keeps_restored_trail() -> None:
+    """First cleaning update after restoring a cache is not a new clean start."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.client = MagicMock()
+    coordinator.client.state = _trajectory_state()
+    coordinator.client.last_display_map_age = float("inf")
+    coordinator._prev_working_status = WorkingStatus.UNKNOWN
+    coordinator._map_display_cache_restored = True
+    coordinator._map_display_cache_restored_from_active = True
+
+    state = coordinator.client.state
+    state.update_from_working_status({"3": 42})
+
+    assert not coordinator._is_new_clean_transition(state)
+
+
+def test_stale_docked_startup_keeps_active_trail_for_overlap_validation() -> None:
+    """A stale idle enum cannot clear an active cache before a native window."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator._prev_working_status = WorkingStatus.STANDBY
+    coordinator._clean_session_active = False
+    coordinator._map_display_cache_restored = True
+    coordinator._map_display_cache_restored_from_active = True
+    coordinator._map_display_cache_restored_at = 100.0
+    coordinator._clear_map_display_cache_for_new_clean = MagicMock()
+    state = _trajectory_state()
+    state.working_status = WorkingStatus.DOCKED
+    state.dock_presence = 6
+    state.dock_field11 = 2
+
+    with patch(
+        "custom_components.narwal.coordinator.time.monotonic", return_value=101.0
+    ):
+        coordinator._handle_working_status_transition(state)
+        payload = coordinator._map_display_cache_payload(state)
+
+    coordinator._clear_map_display_cache_for_new_clean.assert_not_called()
+    assert coordinator._map_display_cache_restored_from_active
+    assert payload is not None
+    assert payload["active_clean"] is True
+
+    state.working_status = WorkingStatus.CLEANING
+    state.dock_presence = 2
+    state.dock_field11 = 1
+    coordinator._handle_working_status_transition(state)
+
+    coordinator._clear_map_display_cache_for_new_clean.assert_not_called()
+    assert coordinator._clean_session_active
+
+
+def test_restored_active_trail_validation_grace_expires() -> None:
+    """Repeated terminal state revokes a restored-active marker after startup."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator._prev_working_status = WorkingStatus.UNKNOWN
+    coordinator._clean_session_active = False
+    coordinator._map_display_cache_restored = True
+    coordinator._map_display_cache_restored_from_active = True
+    coordinator._map_display_cache_restored_at = 100.0
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._clear_map_display_cache_for_new_clean = MagicMock()
+    state = NarwalState(working_status=WorkingStatus.DOCKED)
+    state.dock_presence = 6
+
+    with patch(
+        "custom_components.narwal.coordinator.time.monotonic", return_value=161.0
+    ):
+        coordinator._handle_working_status_transition(state)
+
+    assert not coordinator._map_display_cache_restored_from_active
+
+
+@pytest.mark.parametrize(
+    "working_status", (WorkingStatus.TASK_COMPLETED, WorkingStatus.ERROR)
+)
+def test_explicit_terminal_status_bypasses_active_trail_restore_grace(
+    working_status: WorkingStatus,
+) -> None:
+    """Completion and fault packets end a restored session immediately."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator._prev_working_status = WorkingStatus.UNKNOWN
+    coordinator._clean_session_active = False
+    coordinator._map_display_cache_restored = True
+    coordinator._map_display_cache_restored_from_active = True
+    coordinator._map_display_cache_restored_at = 100.0
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._clear_map_display_cache_for_new_clean = MagicMock()
+    state = _trajectory_state()
+    state.working_status = working_status
+
+    with patch(
+        "custom_components.narwal.coordinator.time.monotonic", return_value=101.0
+    ):
+        coordinator._handle_working_status_transition(state)
+        payload = coordinator._map_display_cache_payload(state)
+
+    assert not coordinator._map_display_cache_restored_from_active
+    assert payload is not None
+    assert payload["active_clean"] is False
+
+    coordinator._handle_working_status_transition(
+        NarwalState(working_status=WorkingStatus.CLEANING)
+    )
+    coordinator._clear_map_display_cache_for_new_clean.assert_called_once_with()
+
+
+def test_confirmed_terminal_revokes_restored_active_cache_exemption() -> None:
+    """A later clean cannot inherit a route after confirmed completion."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator._prev_working_status = WorkingStatus.CLEANING
+    coordinator._clean_session_active = True
+    coordinator._map_display_cache_restored = True
+    coordinator._map_display_cache_restored_from_active = True
+    coordinator._map_display_cache_active_clean = True
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._clear_map_display_cache_for_new_clean = MagicMock()
+
+    terminal = NarwalState(working_status=WorkingStatus.DOCKED_V2)
+    terminal.dock_presence = 6
+    coordinator._handle_working_status_transition(terminal)
+    coordinator._handle_working_status_transition(
+        NarwalState(working_status=WorkingStatus.CLEANING)
+    )
+
+    assert not coordinator._map_display_cache_restored_from_active
+    coordinator._clear_map_display_cache_for_new_clean.assert_called_once_with()
+
+
+def test_confirmed_terminal_revokes_pending_active_cache_without_map() -> None:
+    """An unscoped pending route cannot exempt a later clean after docking."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator._prev_working_status = WorkingStatus.UNKNOWN
+    coordinator._clean_session_active = False
+    coordinator._map_display_cache_restored = False
+    coordinator._map_display_cache_restored_from_active = False
+    coordinator._map_display_cache_active_clean = None
+    coordinator._pending_map_display_cache_restore = {
+        "active_clean": True,
+        "trajectory_x": "old",
+    }
+    coordinator._clear_map_display_cache_for_new_clean = MagicMock()
+
+    terminal = NarwalState(working_status=WorkingStatus.DOCKED_V2)
+    terminal.dock_presence = 6
+    coordinator._handle_working_status_transition(terminal)
+    coordinator._handle_working_status_transition(
+        NarwalState(working_status=WorkingStatus.CLEANING)
+    )
+
+    assert coordinator._pending_map_display_cache_restore["active_clean"] is False
+    coordinator._clear_map_display_cache_for_new_clean.assert_called_once_with()
+
+
+def test_unknown_to_cleaning_clears_inactive_restored_trail() -> None:
+    """A completed cached trail must not be treated as an active reconnect."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.client = MagicMock()
+    coordinator.client.state = _trajectory_state()
+    coordinator.client.last_display_map_age = float("inf")
+    coordinator._prev_working_status = WorkingStatus.UNKNOWN
+    coordinator._map_display_cache_restored = True
+    coordinator._map_display_cache_restored_from_active = False
+
+    state = coordinator.client.state
+    state.update_from_working_status({"3": 42})
+
+    assert coordinator._is_new_clean_transition(state)
+
+
+def test_repeated_metric_only_updates_clear_trail_once() -> None:
+    """A stale idle enum cannot reannounce one metric-only clean session."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator._prev_working_status = WorkingStatus.STANDBY
+    coordinator._clean_session_active = False
+    coordinator._map_display_cache_restored = False
+    coordinator._map_display_cache_restored_from_active = False
+    coordinator._clear_map_display_cache_for_new_clean = MagicMock()
+    state = NarwalState(working_status=WorkingStatus.STANDBY)
+    state.update_from_working_status({"3": 42})
+
+    coordinator._handle_working_status_transition(state)
+    coordinator._handle_working_status_transition(state)
+
+    coordinator._clear_map_display_cache_for_new_clean.assert_called_once_with()
+    assert coordinator._clean_session_active
+
+
+def test_paused_standby_resume_keeps_current_trajectory() -> None:
+    """An expired active-metric TTL while paused cannot split one clean."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator._prev_working_status = WorkingStatus.CLEANING
+    coordinator._clean_session_active = True
+    coordinator._map_display_cache_restored = False
+    coordinator._map_display_cache_restored_from_active = False
+    coordinator._clear_map_display_cache_for_new_clean = MagicMock()
+
+    paused = NarwalState(working_status=WorkingStatus.STANDBY)
+    paused.is_paused = True
+    paused.task_progress_percent = 42
+    paused.dock_presence = 6
+    paused.dock_field11 = 2
+    paused.dock_field47 = 3
+    assert not paused.has_recent_active_working_status
+    assert paused.has_paused_clean_task_context
+    assert not is_confirmed_terminal_clean_state(paused)
+
+    coordinator._handle_working_status_transition(paused)
+    coordinator._handle_working_status_transition(
+        NarwalState(working_status=WorkingStatus.CLEANING)
+    )
+
+    assert coordinator._clean_session_active
+    coordinator._clear_map_display_cache_for_new_clean.assert_not_called()
+
+
+def test_accepted_clean_latches_session_before_metric_handoff() -> None:
+    """Early task metrics cannot clear a route already reset by an HA start."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator._prev_working_status = WorkingStatus.STANDBY
+    coordinator._clean_session_active = False
+    coordinator._map_display_cache_restored = False
+    coordinator._map_display_cache_restored_from_active = False
+    coordinator._clear_map_display_cache_for_new_clean = MagicMock()
+    coordinator.active_clean_work_mode = None
+    coordinator.active_room_clean_settings = {}
+
+    coordinator.record_accepted_clean_start({4: RoomCleanSettings()})
+    state = NarwalState(working_status=WorkingStatus.STANDBY)
+    state.assume_robot_clean()
+    state.update_from_working_status({"3": 1})
+    coordinator._handle_working_status_transition(state)
+
+    coordinator._clear_map_display_cache_for_new_clean.assert_not_called()
+    assert coordinator._clean_session_active
+
+
+def test_accepted_clean_latch_survives_pre_status_display_packet() -> None:
+    """A cached dock status cannot end the accepted-start handoff."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator._prev_working_status = WorkingStatus.DOCKED_V2
+    coordinator._clean_session_active = True
+    coordinator._map_display_cache_restored = False
+    coordinator._map_display_cache_restored_from_active = False
+    coordinator._clear_map_display_cache_for_new_clean = MagicMock()
+    state = NarwalState(working_status=WorkingStatus.DOCKED_V2)
+    state.dock_presence = 6
+    state.assume_robot_clean()
+
+    coordinator._handle_working_status_transition(state)
+
+    assert coordinator._clean_session_active
+    coordinator._clear_map_display_cache_for_new_clean.assert_not_called()
+
+
+def test_terminal_late_metrics_do_not_clear_completed_trail() -> None:
+    """Late counters from a completed task cannot announce a new clean."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.client = MagicMock()
+    coordinator._prev_working_status = WorkingStatus.TASK_COMPLETED
+    coordinator._map_display_cache_restored = False
+    coordinator._map_display_cache_restored_from_active = False
+    state = NarwalState(working_status=WorkingStatus.TASK_COMPLETED)
+
+    state.update_from_working_status({"3": 42})
+
+    assert not state.has_recent_active_working_status
+    assert not coordinator._is_new_clean_transition(state)
+
+
+def test_assumed_clean_docked_handoff_is_not_terminal() -> None:
+    """Cached docking cannot override an accepted-start reservation."""
+    state = NarwalState(working_status=WorkingStatus.DOCKED_V2)
+    state.dock_presence = 6
+    state.assume_robot_clean()
+
+    assert not is_confirmed_terminal_clean_state(state)
+
+
+def test_returning_route_snapshot_remains_active() -> None:
+    """Returning to dock remains part of the persisted cleaning session."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator._map_display_cache_restored_from_active = False
+    state = _trajectory_state()
+    state.working_status = WorkingStatus.CLEANING
+    state.is_returning_to_dock = True
+    state.dock_sub_state = 2
+
+    snapshot = coordinator._map_display_cache_snapshot(state)
+
+    assert snapshot is not None
+    assert snapshot.active_clean
+
+
+def test_remapping_transition_does_not_clear_completed_trail() -> None:
+    """Map rebuilding is not a new cleaning session."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator._prev_working_status = WorkingStatus.STANDBY
+    coordinator._clear_map_display_cache_for_new_clean = MagicMock()
+    state = NarwalState(working_status=WorkingStatus.REMAPPING)
+
+    coordinator._handle_working_status_transition(state)
+
+    coordinator._clear_map_display_cache_for_new_clean.assert_not_called()
+    assert coordinator._prev_working_status == WorkingStatus.REMAPPING
+
+
+def test_remapping_to_cleaning_starts_a_new_retained_route() -> None:
+    """A clean after map rebuilding must clear the previous cleaning trail."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator._prev_working_status = WorkingStatus.REMAPPING
+    coordinator._map_display_cache_restored = False
+    coordinator._map_display_cache_restored_from_active = False
+    coordinator._clear_map_display_cache_for_new_clean = MagicMock()
+    state = NarwalState(working_status=WorkingStatus.CLEANING)
+
+    coordinator._handle_working_status_transition(state)
+
+    coordinator._clear_map_display_cache_for_new_clean.assert_called_once_with()
+    assert coordinator._prev_working_status == WorkingStatus.CLEANING
+
+
+def test_idle_to_cleaning_transition_clears_stale_restored_trail() -> None:
+    """A clean started while HA is running must drop the previous clean's trail."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.hass = MagicMock()
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.async_create_background_task = MagicMock()
+    coordinator.client = MagicMock()
+    coordinator.client.state = _trajectory_state()
+    coordinator.client.last_display_map_age = float("inf")
+    coordinator._map_display_cache_store = _FakeStore({"old": "trail"})
+    coordinator._pending_map_display_cache_snapshot = None
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_signature = (4, 4, 99)
+    coordinator._map_display_cache_restored = True
+    coordinator._map_display_cache_restored_from_active = False
+    coordinator._map_display_cache_save_task = None
+    coordinator._prev_working_status = WorkingStatus.STANDBY
+    coordinator.config_entry.async_create_background_task.side_effect = (
+        _close_background_task
+    )
+
+    state = coordinator.client.state
+    state.update_from_working_status({"3": 42})
+
+    assert coordinator._is_new_clean_transition(state)
+    coordinator._clear_map_display_cache_for_new_clean()
+
+    assert state.map_display_data is None
+    assert coordinator._map_display_cache_signature == ()
+    coordinator.config_entry.async_create_background_task.assert_called_once()
+
+
+def test_status_first_new_clean_drops_recent_previous_trajectory() -> None:
+    """A recent old packet is not a new-clean packet when status arrives first."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.hass = MagicMock()
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.async_create_background_task = MagicMock(
+        side_effect=_close_background_task
+    )
+    coordinator.client = MagicMock()
+    coordinator.client.state = _trajectory_state()
+    coordinator.client.last_display_map_age = 1.0
+    coordinator._retained_map_display = coordinator.client.state.map_display_data
+    coordinator._map_display_cache_store = _FakeStore({"old": "trail"})
+    coordinator._pending_map_display_cache_snapshot = None
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_signature = (4, 4, 99)
+    coordinator._map_display_cache_restored = True
+    coordinator._map_display_cache_restored_from_active = False
+    coordinator._map_display_cache_save_task = None
+    coordinator._prev_working_status = WorkingStatus.STANDBY
+
+    state = coordinator.client.state
+    state.update_from_working_status({"3": 42})
+    coordinator._clear_map_display_cache_for_new_clean()
+
+    assert state.map_display_data is None
+    assert coordinator._retained_map_display is None
+    assert coordinator._pending_map_display_cache_snapshot is None
+
+
+def test_new_clean_with_recent_inactive_trail_still_clears_cache() -> None:
+    """Recency alone cannot distinguish a late old packet from a new route."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.hass = MagicMock()
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.async_create_background_task = MagicMock()
+    coordinator.client = MagicMock()
+    coordinator.client.state = _trajectory_state()
+    coordinator.client.last_display_map_age = 1.0
+    coordinator._map_display_cache_store = _FakeStore({"old": "trail"})
+    coordinator._pending_map_display_cache_snapshot = None
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_signature = (1, 1, 1)
+    coordinator._map_display_cache_restored = True
+    coordinator._map_display_cache_restored_from_active = False
+    coordinator._map_display_cache_save_task = None
+    coordinator._map_display_cache_last_save = time.monotonic()
+    coordinator.config_entry.async_create_background_task.side_effect = (
+        _close_background_task
+    )
+
+    state = coordinator.client.state
+    state.update_from_working_status({"3": 42})
+
+    coordinator._clear_map_display_cache_for_new_clean()
+
+    assert state.map_display_data is None
+    assert coordinator._pending_map_display_cache_snapshot is None
+    assert coordinator._map_display_cache_store.saved == []
+    coordinator.config_entry.async_create_background_task.assert_called_once()
+
+
+def test_schedule_map_display_cache_save_defers_serialization() -> None:
+    """Scheduling cache persistence must not encode full routes in callbacks."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.hass = MagicMock()
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.async_create_background_task = MagicMock(
+        side_effect=_close_background_task
+    )
+    coordinator._map_display_cache_signature = ()
+    coordinator._pending_map_display_cache_snapshot = None
+    coordinator._map_display_cache_save_task = None
+    coordinator._map_display_cache_last_save = time.monotonic()
+
+    with patch.object(
+        NarwalCoordinator,
+        "_map_display_cache_payload_from_snapshot",
+        side_effect=AssertionError("serialization should be throttled"),
+    ):
+        coordinator._schedule_map_display_cache_save(_trajectory_state())
+
+    assert coordinator._pending_map_display_cache_snapshot is not None
+    coordinator.config_entry.async_create_background_task.assert_called_once()
+
+
+async def test_schedule_map_display_cache_save_persists_terminal_metadata() -> None:
+    """An unchanged completed route must replace its active cache marker."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.hass = MagicMock()
+    coordinator.config_entry = MagicMock()
+    coordinator._map_display_cache_store = _FakeStore()
+    coordinator._map_display_cache_signature = (4, 4, 99)
+    coordinator._map_display_cache_active_clean = True
+    coordinator._pending_map_display_cache_snapshot = None
+    coordinator._map_display_cache_save_task = None
+    coordinator._map_display_cache_last_save = 0.0
+    background_tasks: list[asyncio.Task[None]] = []
+
+    def create_background_task(
+        _hass: object, coro: Coroutine[object, object, None], _name: str
+    ) -> asyncio.Task[None]:
+        task = asyncio.create_task(coro)
+        background_tasks.append(task)
+        return task
+
+    coordinator.config_entry.async_create_background_task.side_effect = (
+        create_background_task
+    )
+
+    coordinator._schedule_map_display_cache_save(
+        _trajectory_state(), immediate=True
+    )
+    await background_tasks[0]
+
+    assert coordinator._map_display_cache_store.saved[-1]["active_clean"] is False
+    assert coordinator._map_display_cache_active_clean is False
+
+
+async def test_shutdown_flushes_current_display_map_cache() -> None:
+    """HA shutdown should persist the newest trail even when no save is queued."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.client = MagicMock()
+    coordinator.client.state = _trajectory_state()
+    coordinator._map_display_cache_store = _FakeStore()
+    coordinator._pending_map_display_cache_snapshot = None
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_save_task = None
+    coordinator._map_display_cache_signature = ()
+    coordinator._map_display_cache_last_save = 0.0
+
+    await coordinator._async_flush_map_display_cache()
+
+    assert coordinator._map_display_cache_store.saved
+    assert coordinator._map_display_cache_store.saved[-1]["trajectory_signature"] == [
+        4,
+        4,
+        99,
+    ]
+    assert coordinator._map_display_cache_signature == (4, 4, 99)
+
+
+async def test_shutdown_does_not_replace_scoped_cache_with_pre_map_route() -> None:
+    """A failed map fetch cannot make an existing route unrestorable."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    scoped_state = _trajectory_state()
+    existing = coordinator._map_display_cache_payload(scoped_state)
+    assert existing is not None
+    coordinator.client = MagicMock()
+    coordinator.client.state = _trajectory_state()
+    coordinator.client.state.map_data = None
+    coordinator._map_display_cache_store = _FakeStore(existing)
+    coordinator._pending_map_display_cache_snapshot = None
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_save_task = None
+    coordinator._map_display_cache_signature = (4, 4, 99)
+    coordinator._map_display_cache_last_save = 0.0
+
+    await coordinator._async_flush_map_display_cache()
+
+    assert coordinator._map_display_cache_store.data == existing
+    assert coordinator._map_display_cache_store.saved == []
+
+
+async def test_shutdown_retries_failed_trajectory_cache_clear() -> None:
+    """A failed clear remains pending when no replacement route arrives."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.client = MagicMock()
+    coordinator.client.state = NarwalState()
+    coordinator._map_display_cache_store = MagicMock()
+    coordinator._map_display_cache_store.async_save = AsyncMock(
+        side_effect=[OSError, None]
+    )
+    coordinator._pending_map_display_cache_snapshot = None
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_save_task = None
+    coordinator._map_display_cache_signature = (4, 4, 99)
+    coordinator._map_display_cache_last_save = 0.0
+    coordinator._map_display_cache_clear_event = asyncio.Event()
+    coordinator._map_display_cache_clear_event.set()
+    coordinator._map_display_cache_clear_lock = asyncio.Lock()
+    coordinator._map_display_cache_write_lock = asyncio.Lock()
+    coordinator._map_display_cache_clear_count = 0
+
+    await coordinator.async_clear_map_display_cache()
+
+    assert coordinator._map_display_cache_clear_pending
+    coordinator.client.state.map_display_data = _trajectory_display(
+        (1.0, 1.0), (2.0, 2.0), timestamp=200
+    )
+    await coordinator._async_flush_map_display_cache()
+
+    assert coordinator._map_display_cache_store.async_save.await_args_list == [
+        call({}),
+        call({}),
+    ]
+    assert not coordinator._map_display_cache_clear_pending
+
+
+async def test_shutdown_flush_waits_for_pending_cache_clear() -> None:
+    """A delayed clear cannot overwrite the route persisted during shutdown."""
+    coordinator = NarwalCoordinator.__new__(NarwalCoordinator)
+    coordinator.hass = MagicMock()
+    coordinator.config_entry = MagicMock()
+    coordinator.client = MagicMock()
+    coordinator.client.state = _trajectory_state()
+    coordinator._map_display_cache_store = _FakeStore({"old": "trail"})
+    coordinator._pending_map_display_cache_snapshot = None
+    coordinator._pending_map_display_cache_restore = None
+    coordinator._map_display_cache_save_task = None
+    coordinator._map_display_cache_signature = ()
+    coordinator._map_display_cache_last_save = 0.0
+    clear_started = asyncio.Event()
+    release_clear = asyncio.Event()
+    original_save = coordinator._map_display_cache_store.async_save
+
+    async def delayed_save(data: object) -> None:
+        if data == {}:
+            clear_started.set()
+            await release_clear.wait()
+        await original_save(data)
+
+    coordinator._map_display_cache_store.async_save = delayed_save
+    background_tasks: list[asyncio.Task[None]] = []
+
+    def create_background_task(
+        _hass: object, coro: Coroutine[object, object, None], _name: str
+    ) -> asyncio.Task[None]:
+        task = asyncio.create_task(coro)
+        background_tasks.append(task)
+        return task
+
+    coordinator.config_entry.async_create_background_task.side_effect = (
+        create_background_task
+    )
+
+    coordinator._schedule_map_display_cache_clear(None)
+    await clear_started.wait()
+    flush_task = asyncio.create_task(coordinator._async_flush_map_display_cache())
+    await asyncio.sleep(0)
+
+    assert not flush_task.done()
+
+    release_clear.set()
+    await asyncio.gather(background_tasks[0], flush_task)
+
+    assert coordinator._map_display_cache_store.saved[0] == {}
+    assert coordinator._map_display_cache_store.saved[-1]["trajectory_signature"] == [
+        4,
+        4,
+        99,
+    ]
+
+
 class TestCoordinatorResilience:
     """Tests for NarwalCoordinator failure buffering and availability."""
 
@@ -866,12 +2949,18 @@ class TestCoordinatorResilience:
         coordinator._prev_working_status = MagicMock()
         coordinator.active_clean_work_mode = None
         coordinator.active_room_clean_settings = {}
+        coordinator._map_display_cache_store = _FakeStore()
+        coordinator._map_display_cache_signature = ()
+        coordinator._pending_map_display_cache_snapshot = None
+        coordinator._pending_map_display_cache_restore = None
+        coordinator._map_display_cache_save_task = None
+        coordinator._map_display_cache_last_save = 0.0
+        coordinator._map_display_cache_restored = False
         coordinator.update_interval = None
         def _close_background_task(*args: object) -> None:
             for arg in args:
                 if hasattr(arg, "close"):
                     arg.close()
-
         mock_entry.async_create_background_task = MagicMock(
             side_effect=_close_background_task
         )
@@ -999,6 +3088,188 @@ class TestCoordinatorResilience:
         assert coordinator._consecutive_failures == 0
         assert result is coordinator.client.state
 
+    async def test_terminal_poll_refreshes_queued_cache_metadata(self) -> None:
+        """A graceful shutdown cannot flush stale active metadata after completion."""
+        coordinator = self._make_coordinator()
+        state = _trajectory_state()
+        state.working_status = WorkingStatus.CLEANING
+        coordinator.client.state = state
+        coordinator._map_display_cache_restored_from_active = False
+        coordinator._retained_map_display = state.map_display_data
+        coordinator._retained_map_identity = (12, 34)
+        coordinator._map_display_cache_active_clean = True
+        coordinator._pending_map_display_cache_snapshot = (
+            coordinator._map_display_cache_snapshot(state)
+        )
+        assert coordinator._pending_map_display_cache_snapshot is not None
+        assert coordinator._pending_map_display_cache_snapshot.active_clean
+        type(coordinator.client).connected = PropertyMock(return_value=True)
+
+        async def get_status(*, full_update: bool) -> CommandResponse:
+            assert full_update
+            state.working_status = WorkingStatus.TASK_COMPLETED
+            return CommandResponse(
+                data={
+                    "2": {
+                        "3": {"1": int(WorkingStatus.TASK_COMPLETED), "3": 6},
+                        "11": 2,
+                    }
+                }
+            )
+
+        coordinator.client.get_status = AsyncMock(side_effect=get_status)
+
+        await coordinator._async_update_data()
+
+        assert coordinator._pending_map_display_cache_snapshot is not None
+        assert not coordinator._pending_map_display_cache_snapshot.active_clean
+        assert coordinator._map_display_cache_active_clean is True
+
+        await coordinator._async_save_pending_map_display_cache(0)
+
+        assert coordinator._map_display_cache_store.saved[-1]["active_clean"] is False
+        assert coordinator._map_display_cache_active_clean is False
+
+    async def test_poll_map_fetch_restores_pending_display_cache(self) -> None:
+        """A fallback map fetch restores a route that was waiting for its map."""
+        coordinator = self._make_coordinator()
+        source = _trajectory_state()
+        payload = coordinator._map_display_cache_payload(source)
+        assert payload is not None
+
+        type(coordinator.client).connected = PropertyMock(return_value=True)
+        coordinator.client.supports_broadcasts = False
+        coordinator.client.get_status = AsyncMock(
+            return_value=CommandResponse(data={"2": {"3": {"1": 10}}})
+        )
+        coordinator.client.state.map_data = None
+        coordinator._pending_map_display_cache_restore = payload
+
+        async def get_map() -> None:
+            coordinator.client.state.map_data = source.map_data
+
+        coordinator.client.get_map = AsyncMock(side_effect=get_map)
+
+        await coordinator._async_update_data()
+
+        restored = coordinator.client.state.map_display_data
+        assert restored is not None
+        assert restored.trajectory_signature == (4, 4, 99)
+        assert coordinator._pending_map_display_cache_restore is None
+        assert coordinator._map_display_cache_restored
+
+    async def test_poll_restores_pending_active_route_before_clean_transition(self) -> None:
+        """Status recovery cannot erase an active route waiting for its map."""
+        coordinator = self._make_coordinator()
+        source = _trajectory_state()
+        source.working_status = WorkingStatus.CLEANING
+        payload = coordinator._map_display_cache_payload(source)
+        assert payload is not None
+        assert payload["active_clean"] is True
+
+        type(coordinator.client).connected = PropertyMock(return_value=True)
+        coordinator.client.supports_broadcasts = False
+        coordinator.client.state.map_data = None
+        coordinator._pending_map_display_cache_restore = payload
+        coordinator._clean_session_active = False
+
+        async def get_status(*, full_update: bool) -> CommandResponse:
+            coordinator.client.state.working_status = WorkingStatus.CLEANING
+            return CommandResponse(
+                data={"2": {"3": {"1": int(WorkingStatus.CLEANING)}}}
+            )
+
+        async def get_map() -> None:
+            coordinator.client.state.map_data = source.map_data
+
+        coordinator.client.get_status = AsyncMock(side_effect=get_status)
+        coordinator.client.get_map = AsyncMock(side_effect=get_map)
+
+        await coordinator._async_update_data()
+
+        assert coordinator.client.state.map_display_data is not None
+        assert coordinator._map_display_cache_restored_from_active
+        assert coordinator._pending_map_display_cache_restore is None
+
+    async def test_active_pending_route_survives_push_and_failed_map_retry(self) -> None:
+        """Push recovery cannot erase an active cache before its map is known."""
+        coordinator = self._make_coordinator()
+        source = _trajectory_state()
+        source.working_status = WorkingStatus.CLEANING
+        payload = coordinator._map_display_cache_payload(source)
+        assert payload is not None
+        assert payload["active_clean"] is True
+
+        coordinator.client.state.map_data = None
+        coordinator.client.state.working_status = WorkingStatus.CLEANING
+        coordinator.client.last_display_map_age = 0.0
+        coordinator._pending_map_display_cache_restore = payload
+        coordinator._clean_session_active = False
+        coordinator._map_fetch_pending = True
+        coordinator._clear_map_display_cache_for_new_clean = MagicMock()
+        coordinator.async_set_updated_data = MagicMock()
+
+        coordinator._on_state_update(coordinator.client.state)
+
+        coordinator._clear_map_display_cache_for_new_clean.assert_not_called()
+        assert coordinator._pending_map_display_cache_restore == payload
+
+        coordinator.client.get_map = AsyncMock(side_effect=OSError)
+        await coordinator._fetch_missing_map()
+
+        coordinator._clear_map_display_cache_for_new_clean.assert_not_called()
+        assert coordinator._pending_map_display_cache_restore == payload
+
+    async def test_poll_map_fetch_scopes_pending_live_snapshot(self) -> None:
+        """A delayed static map scopes a live snapshot queued before the fetch."""
+        coordinator = self._make_coordinator()
+        source = _trajectory_state()
+        coordinator.client.state.map_display_data = source.map_display_data
+        snapshot = coordinator._map_display_cache_snapshot(coordinator.client.state)
+        assert snapshot is not None
+        assert snapshot.map_id == 0
+        coordinator._pending_map_display_cache_snapshot = snapshot
+
+        type(coordinator.client).connected = PropertyMock(return_value=True)
+        coordinator.client.supports_broadcasts = False
+        coordinator.client.get_status = AsyncMock(
+            return_value=CommandResponse(data={"2": {"3": {"1": 10}}})
+        )
+
+        async def get_map() -> None:
+            coordinator.client.state.map_data = source.map_data
+
+        coordinator.client.get_map = AsyncMock(side_effect=get_map)
+
+        await coordinator._async_update_data()
+
+        scoped = coordinator._pending_map_display_cache_snapshot
+        assert scoped is not None
+        assert (scoped.map_id, scoped.map_created_at) == (12, 34)
+
+    async def test_background_map_fetch_scopes_pending_live_snapshot(self) -> None:
+        """The push-triggered map fetch also scopes a pre-map live snapshot."""
+        coordinator = self._make_coordinator()
+        source = _trajectory_state()
+        coordinator.client.state.map_display_data = source.map_display_data
+        snapshot = coordinator._map_display_cache_snapshot(coordinator.client.state)
+        assert snapshot is not None
+        assert snapshot.map_id == 0
+        coordinator._pending_map_display_cache_snapshot = snapshot
+        coordinator.client.supports_broadcasts = False
+        coordinator.async_set_updated_data = MagicMock()
+
+        async def get_map() -> None:
+            coordinator.client.state.map_data = source.map_data
+
+        coordinator.client.get_map = AsyncMock(side_effect=get_map)
+
+        await coordinator._fetch_missing_map()
+
+        scoped = coordinator._pending_map_display_cache_snapshot
+        assert scoped is not None
+        assert (scoped.map_id, scoped.map_created_at) == (12, 34)
+
     async def test_poll_preserves_recent_active_working_status(self) -> None:
         """Poll only refreshes hardware fields while task metrics are fresh."""
         coordinator = self._make_coordinator()
@@ -1010,6 +3281,37 @@ class TestCoordinatorResilience:
 
         coordinator.client.get_status.assert_awaited_once_with(full_update=False)
         assert result is coordinator.client.state
+
+    async def test_poll_clean_transition_clears_stale_restored_trail(self) -> None:
+        """Polling must clear a previous clean's trail when push updates are absent."""
+        coordinator = self._make_coordinator()
+        type(coordinator.client).connected = PropertyMock(return_value=True)
+        coordinator.client.state = _trajectory_state()
+        coordinator.client.state.working_status = WorkingStatus.STANDBY
+        coordinator.client.last_display_map_age = float("inf")
+        coordinator._prev_working_status = WorkingStatus.STANDBY
+        coordinator._map_display_cache_signature = (4, 4, 99)
+        coordinator._map_display_cache_restored = True
+        coordinator._map_display_cache_restored_from_active = False
+
+        async def get_status(*, full_update: bool) -> CommandResponse:
+            coordinator.client.state.update_from_base_status(
+                {"3": {"1": int(WorkingStatus.CLEANING)}}
+            )
+            return CommandResponse(
+                data={"2": {"3": {"1": int(WorkingStatus.CLEANING)}}}
+            )
+
+        coordinator.client.get_status = AsyncMock(side_effect=get_status)
+
+        result = await coordinator._async_update_data()
+
+        coordinator.client.get_status.assert_awaited_once_with(full_update=True)
+        assert result is coordinator.client.state
+        assert result.map_display_data is None
+        assert coordinator._map_display_cache_signature == ()
+        assert coordinator._prev_working_status == WorkingStatus.CLEANING
+        coordinator.config_entry.async_create_background_task.assert_called_once()
 
     async def test_push_update_resets_failure_counter(self) -> None:
         """_on_state_update resets _consecutive_failures to 0."""
@@ -1162,6 +3464,52 @@ class TestCoordinatorResilience:
 
         assert await coordinator.async_refresh_dock_status()
         assert seen == [True]
+
+    async def test_refresh_dock_status_refreshes_queued_cache_metadata(self) -> None:
+        """A direct terminal refresh replaces queued active route metadata."""
+        coordinator = self._make_coordinator()
+        state = _trajectory_state()
+        state.working_status = WorkingStatus.CLEANING
+        coordinator.client.state = state
+        coordinator._map_display_cache_restored_from_active = False
+        coordinator._retained_map_display = state.map_display_data
+        coordinator._retained_map_identity = (12, 34)
+        coordinator._map_display_cache_active_clean = True
+        coordinator._pending_map_display_cache_snapshot = (
+            coordinator._map_display_cache_snapshot(state)
+        )
+
+        async def get_status(*, full_update: bool) -> CommandResponse:
+            assert full_update
+            state.update_from_base_status(
+                {
+                    "3": {
+                        "1": int(WorkingStatus.DOCKED),
+                        "3": 6,
+                        "10": 1,
+                    },
+                    "11": 2,
+                }
+            )
+            return CommandResponse(
+                data={
+                    "2": {
+                        "3": {
+                            "1": int(WorkingStatus.DOCKED),
+                            "3": 6,
+                            "10": 1,
+                        },
+                        "11": 2,
+                    }
+                }
+            )
+
+        coordinator.client.get_status = AsyncMock(side_effect=get_status)
+        coordinator.async_set_updated_data = MagicMock()
+
+        assert await coordinator.async_refresh_dock_status()
+        assert coordinator._pending_map_display_cache_snapshot is not None
+        assert not coordinator._pending_map_display_cache_snapshot.active_clean
 
     async def test_refresh_dock_status_preserves_live_working_status(self) -> None:
         """Action preflight must not clobber fresh working_status task telemetry."""
@@ -1489,6 +3837,8 @@ class TestTopicSubscriptionRenewal:
         # Keep that background path suppressed so its mocked task creator does
         # not leave an unconsumed coroutine behind.
         c._map_fetch_pending = True
+        c._pending_map_display_cache_snapshot = None
+        c._pending_map_display_cache_restore = None
         c._last_display_map_resub = 0.0
         c._last_topic_subscribe = last_subscribe
         c._prev_working_status = MagicMock()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -25,6 +25,8 @@ from custom_components.narwal.coordinator import (  # noqa: E402
     CleanSettings,
     NarwalCoordinator,
     can_edit_pending_clean_settings,
+    can_pause_cleaning,
+    can_prepare_clean_start,
     can_start_cleaning,
     is_clean_session_context,
     is_live_clean_setting_available,
@@ -41,8 +43,24 @@ from custom_components.narwal.narwal_client import (  # noqa: E402
     WorkingStatus,
     WorkMode,
 )
+from custom_components.narwal.narwal_client.models import (  # noqa: E402
+    DOCK_TASK_DRY_DOCK_BAG,
+    DOCK_TASK_DRY_DUST_BIN,
+    DOCK_TASK_DRY_MOP,
+    DOCK_TASK_EMPTY_DUSTBIN,
+    DOCK_TASK_WASH_MOP,
+)
 
 UpdateFailed = sys.modules["homeassistant.helpers.update_coordinator"].UpdateFailed
+
+
+def test_pause_available_with_stale_unconfirmed_return_flag() -> None:
+    """A stale field 3.7 alone must not hide Pause during an active clean."""
+    state = NarwalState()
+    state.update_from_base_status({"3": {"1": 4, "7": 1}})
+    state.last_active_working_status_time = 0.0
+
+    assert can_pause_cleaning(state)
 
 
 class _RoomSelectionStore:
@@ -58,6 +76,14 @@ class _RoomSelectionStore:
     async def async_save(self, data: object) -> None:
         """Store data."""
         self.data = data
+
+
+def _docked_state() -> NarwalState:
+    """Return an idle on-dock state."""
+    state = NarwalState(working_status=WorkingStatus.DOCKED)
+    state.dock_presence = 6
+    state.dock_field11 = 2
+    return state
 
 
 def test_non_broadcast_product_key_configures_polling_client() -> None:
@@ -1167,6 +1193,261 @@ class TestCoordinatorResilience:
 
         assert not await coordinator.async_refresh_dock_status()
         assert seen == [False]
+
+    async def test_prepare_clean_start_stops_single_safe_dock_blocker(self) -> None:
+        """A clean-start intent clears one known safe dock blocker first."""
+        coordinator = self._make_coordinator()
+        state = _docked_state()
+        state.station_activity = 1
+        coordinator.client.state = state
+        coordinator.data = state
+        coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+        coordinator.async_set_updated_data = MagicMock()
+
+        async def stop_task(task: str | None = None) -> CommandResponse:
+            assert task == DOCK_TASK_EMPTY_DUSTBIN
+            state.station_activity = 0
+            return CommandResponse(result_code=CommandResult.SUCCESS)
+
+        coordinator.client.stop_dock_task = AsyncMock(side_effect=stop_task)
+
+        assert can_prepare_clean_start(state)
+        assert await coordinator.async_prepare_clean_start()
+
+        coordinator.client.stop_dock_task.assert_awaited_once_with(
+            DOCK_TASK_EMPTY_DUSTBIN
+        )
+        assert coordinator.async_refresh_dock_status.await_count == 2
+        assert can_start_cleaning(state)
+
+    async def test_prepare_clean_start_rejects_failed_initial_refresh(self) -> None:
+        """Preparation does not act when its initial state refresh fails."""
+        coordinator = self._make_coordinator()
+        coordinator.async_refresh_dock_status = AsyncMock(return_value=False)
+        coordinator.client.stop_dock_task = AsyncMock()
+
+        assert not await coordinator.async_prepare_clean_start()
+
+        coordinator.async_refresh_dock_status.assert_awaited_once()
+        coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_prepare_clean_start_rejects_failed_dock_stop(self) -> None:
+        """Preparation does not start after the dock rejects its required stop."""
+        coordinator = self._make_coordinator()
+        state = _docked_state()
+        state.station_activity = 1
+        coordinator.client.state = state
+        coordinator.data = state
+        coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+        coordinator.client.stop_dock_task = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.CONFLICT)
+        )
+
+        assert not await coordinator.async_prepare_clean_start()
+
+        coordinator.async_refresh_dock_status.assert_awaited_once()
+        coordinator.client.stop_dock_task.assert_awaited_once_with(
+            DOCK_TASK_EMPTY_DUSTBIN
+        )
+
+    async def test_prepare_clean_start_rejects_failed_post_stop_refresh(self) -> None:
+        """An accepted stop still requires authoritative refreshed state."""
+        coordinator = self._make_coordinator()
+        state = _docked_state()
+        state.station_activity = 1
+        coordinator.client.state = state
+        coordinator.data = state
+        coordinator.async_refresh_dock_status = AsyncMock(
+            side_effect=(True, False)
+        )
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator.client.stop_dock_task = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        assert not await coordinator.async_prepare_clean_start()
+
+        assert coordinator.async_refresh_dock_status.await_count == 2
+        coordinator.client.stop_dock_task.assert_awaited_once_with(
+            DOCK_TASK_EMPTY_DUSTBIN
+        )
+
+    @pytest.mark.parametrize(
+        ("task", "fields"),
+        [
+            (DOCK_TASK_DRY_MOP, ("8", "9")),
+            (DOCK_TASK_DRY_DUST_BIN, ("10", "11")),
+            (DOCK_TASK_DRY_DOCK_BAG, ("12", "13")),
+        ],
+    )
+    async def test_prepare_clean_start_keeps_typed_drying_task(
+        self,
+        task: str,
+        fields: tuple[str, str],
+    ) -> None:
+        """A new clean lets firmware hand off typed drying work."""
+        coordinator = self._make_coordinator()
+        state = _docked_state()
+        state.set_dock_drying_task(
+            task,
+            elapsed=60,
+            target=180,
+            fields=fields,
+        )
+        coordinator.client.state = state
+        coordinator.data = state
+        coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator.client.stop_dock_task = AsyncMock()
+
+        assert can_prepare_clean_start(state)
+        assert await coordinator.async_prepare_clean_start()
+        assert can_prepare_clean_start(state, allow_dock_stop=False)
+
+        coordinator.client.stop_dock_task.assert_not_awaited()
+        assert coordinator.async_refresh_dock_status.await_count == 1
+        assert can_start_cleaning(state)
+
+    async def test_prepare_clean_start_rejects_lingering_dock_task_after_stop(self) -> None:
+        """Accepted stop is not enough if refreshed telemetry still shows a task."""
+        coordinator = self._make_coordinator()
+        state = _docked_state()
+        state.station_activity = 1
+        coordinator.client.state = state
+        coordinator.data = state
+        coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator.client.stop_dock_task = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        assert can_prepare_clean_start(state)
+        assert not await coordinator.async_prepare_clean_start()
+
+        coordinator.client.stop_dock_task.assert_awaited_once_with(
+            DOCK_TASK_EMPTY_DUSTBIN
+        )
+        assert coordinator.async_refresh_dock_status.await_count == 2
+
+    async def test_prepare_clean_start_rejects_dock_stop_when_disabled(self) -> None:
+        """No-stop preparation mode should never cancel dock maintenance."""
+        coordinator = self._make_coordinator()
+        state = _docked_state()
+        state.station_activity = 2
+        coordinator.client.state = state
+        coordinator.data = state
+        coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+        coordinator.client.stop_dock_task = AsyncMock()
+
+        assert not can_prepare_clean_start(state, allow_dock_stop=False)
+        assert not await coordinator.async_prepare_clean_start(allow_dock_stop=False)
+
+        coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_prepare_clean_start_accepts_wash_follow_on_drying(self) -> None:
+        """Stopping a wash may hand off mop drying to the clean command."""
+        coordinator = self._make_coordinator()
+        state = _docked_state()
+        state.station_activity = 2
+        coordinator.client.state = state
+        coordinator.data = state
+        coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+        coordinator.async_set_updated_data = MagicMock()
+
+        async def stop_task(task: str | None = None) -> CommandResponse:
+            assert task == DOCK_TASK_WASH_MOP
+            state.station_activity = 0
+            state.set_dock_drying_task(
+                DOCK_TASK_DRY_MOP,
+                elapsed=0,
+                target=18000,
+                fields=("8", "9"),
+            )
+            return CommandResponse(result_code=CommandResult.SUCCESS)
+
+        coordinator.client.stop_dock_task = AsyncMock(side_effect=stop_task)
+
+        assert can_prepare_clean_start(state)
+        assert await coordinator.async_prepare_clean_start()
+
+        coordinator.client.stop_dock_task.assert_awaited_once_with(
+            DOCK_TASK_WASH_MOP
+        )
+        assert coordinator.async_refresh_dock_status.await_count == 2
+        assert state.active_dock_task_keys == (DOCK_TASK_DRY_MOP,)
+
+    async def test_prepare_clean_start_allows_multiple_typed_dryers(self) -> None:
+        """Multiple typed drying tasks can be handed off without pre-stops."""
+        coordinator = self._make_coordinator()
+        state = _docked_state()
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DUST_BIN,
+            elapsed=60,
+            target=180,
+            fields=("10", "11"),
+        )
+        coordinator.client.state = state
+        coordinator.data = state
+        coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+        coordinator.client.stop_dock_task = AsyncMock()
+
+        assert can_prepare_clean_start(state)
+        assert await coordinator.async_prepare_clean_start()
+
+        coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_prepare_clean_start_rejects_mixed_stop_and_dry_tasks(self) -> None:
+        """Mixed generic-stop and drying tasks remain ambiguous."""
+        coordinator = self._make_coordinator()
+        state = _docked_state()
+        state.station_activity = 1
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+        coordinator.client.state = state
+        coordinator.data = state
+        coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+        coordinator.client.stop_dock_task = AsyncMock()
+
+        assert not can_prepare_clean_start(state)
+        assert not await coordinator.async_prepare_clean_start()
+
+        coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_action_refresh_preserves_recent_active_working_status(self) -> None:
+        """Robot action gates avoid full base-status refresh while task data is fresh."""
+        coordinator = self._make_coordinator()
+        coordinator.client.state.update_from_working_status({"3": 120})
+        coordinator.client.get_status = AsyncMock(return_value=CommandResponse(data={}))
+        coordinator.async_set_updated_data = MagicMock()
+
+        assert await coordinator.async_refresh_action_status()
+
+        coordinator.client.get_status.assert_awaited_once_with(full_update=False)
+        coordinator.async_set_updated_data.assert_called_once_with(
+            coordinator.client.state
+        )
+        assert not coordinator._dock_status_refresh_failed
+
+    async def test_action_refresh_requires_dock_payload_when_full_update_needed(self) -> None:
+        """Without active task telemetry, action refresh needs real dock/base status."""
+        coordinator = self._make_coordinator()
+        coordinator.client.get_status = AsyncMock(return_value=CommandResponse(data={}))
+        coordinator.async_set_updated_data = MagicMock()
+
+        assert not await coordinator.async_refresh_action_status()
+
+        coordinator.client.get_status.assert_awaited_once_with(full_update=True)
+        assert coordinator._dock_status_refresh_failed
 
 
 class TestTopicSubscriptionRenewal:

--- a/tests/test_coordinator_map.py
+++ b/tests/test_coordinator_map.py
@@ -8,7 +8,7 @@ Covers MAP-04 (post-cleaning map refresh) validation gaps:
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 # Install HA stubs before any custom_components import
 import tests.ha_stubs  # noqa: E402
@@ -211,3 +211,51 @@ def test_remapping_does_not_start_a_cleaning_trail() -> None:
     camera._handle_coordinator_update()
 
     camera._reset_trail.assert_not_called()
+
+
+def test_metric_only_clean_starts_camera_trail_once() -> None:
+    """Fresh clean metrics drive the camera without rewriting coarse status."""
+    state = NarwalState(working_status=WorkingStatus.STANDBY)
+    state.update_from_working_status({"3": 120})
+    coordinator = MagicMock()
+    coordinator.client.state = state
+    camera = NarwalMapCamera.__new__(NarwalMapCamera)
+    camera.coordinator = coordinator
+    camera._last_cleaning_status = WorkingStatus.STANDBY
+    camera._reset_trail = MagicMock()
+    camera.async_write_ha_state = MagicMock()
+
+    camera._handle_coordinator_update()
+    camera._handle_coordinator_update()
+
+    assert state.working_status == WorkingStatus.STANDBY
+    camera._reset_trail.assert_called_once_with()
+
+
+def test_metric_only_pause_resume_keeps_existing_camera_trail() -> None:
+    """Pausing a metric-only clean must not turn resume into a new session."""
+    state = NarwalState(working_status=WorkingStatus.STANDBY)
+    with patch("narwal_client.models.time.monotonic", return_value=100.0):
+        state.update_from_working_status({"3": 120})
+    coordinator = MagicMock()
+    coordinator.client.state = state
+    camera = NarwalMapCamera.__new__(NarwalMapCamera)
+    camera.coordinator = coordinator
+    camera._last_cleaning_status = WorkingStatus.STANDBY
+    camera._reset_trail = MagicMock()
+    camera.async_write_ha_state = MagicMock()
+
+    with patch("narwal_client.models.time.monotonic", return_value=100.0):
+        camera._handle_coordinator_update()
+    state.is_paused = True
+    camera._handle_coordinator_update()
+    with patch("narwal_client.models.time.monotonic", return_value=116.0):
+        state.update_from_working_status({"3": 120})
+    assert state.is_paused
+    camera._handle_coordinator_update()
+    with patch("narwal_client.models.time.monotonic", return_value=117.0):
+        state.update_from_working_status({"3": 121})
+    assert not state.is_paused
+    camera._handle_coordinator_update()
+
+    camera._reset_trail.assert_called_once_with()

--- a/tests/test_coordinator_map.py
+++ b/tests/test_coordinator_map.py
@@ -8,7 +8,7 @@ Covers MAP-04 (post-cleaning map refresh) validation gaps:
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # Install HA stubs before any custom_components import
 import tests.ha_stubs  # noqa: E402
@@ -50,6 +50,14 @@ class TestCoordinatorMapRefresh:
         coordinator._prev_working_status = WorkingStatus.UNKNOWN
         coordinator.active_clean_work_mode = None
         coordinator.active_room_clean_settings = {}
+        coordinator._map_display_cache_store = MagicMock()
+        coordinator._map_display_cache_store.async_save = AsyncMock()
+        coordinator._map_display_cache_signature = ()
+        coordinator._pending_map_display_cache_snapshot = None
+        coordinator._pending_map_display_cache_restore = None
+        coordinator._map_display_cache_save_task = None
+        coordinator._map_display_cache_last_save = 0.0
+        coordinator._map_display_cache_restored = False
         coordinator.update_interval = None
         coordinator.async_set_updated_data = MagicMock()
         def _close_background_task(*args: object) -> None:

--- a/tests/test_coordinator_map.py
+++ b/tests/test_coordinator_map.py
@@ -8,14 +8,13 @@ Covers MAP-04 (post-cleaning map refresh) validation gaps:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 # Install HA stubs before any custom_components import
 import tests.ha_stubs  # noqa: E402
 
 tests.ha_stubs.install()
 
-from custom_components.narwal.camera import NarwalMapCamera  # noqa: E402
 from custom_components.narwal.coordinator import NarwalCoordinator  # noqa: E402
 from custom_components.narwal.narwal_client import NarwalState  # noqa: E402
 from custom_components.narwal.narwal_client.const import WorkingStatus  # noqa: E402
@@ -187,83 +186,3 @@ class TestCoordinatorMapRefresh:
 
         assert coordinator._fast_poll_remaining == 0
         assert coordinator.update_interval == POLL_INTERVAL
-
-
-def test_custom_cleaning_starts_a_new_camera_trail() -> None:
-    """A custom room clean must reset the sampled trail like every clean status."""
-    state = NarwalState(working_status=WorkingStatus.CUSTOM_CLEANING)
-    coordinator = MagicMock()
-    coordinator.client.state = state
-    camera = NarwalMapCamera.__new__(NarwalMapCamera)
-    camera.coordinator = coordinator
-    camera._last_cleaning_status = WorkingStatus.STANDBY
-    camera._reset_trail = MagicMock()
-    camera.async_write_ha_state = MagicMock()
-
-    camera._handle_coordinator_update()
-
-    camera._reset_trail.assert_called_once_with()
-
-
-def test_remapping_does_not_start_a_cleaning_trail() -> None:
-    """Map exploration must not be recorded as cleaning history."""
-    state = NarwalState(working_status=WorkingStatus.REMAPPING)
-    coordinator = MagicMock()
-    coordinator.client.state = state
-    camera = NarwalMapCamera.__new__(NarwalMapCamera)
-    camera.coordinator = coordinator
-    camera._last_cleaning_status = WorkingStatus.STANDBY
-    camera._reset_trail = MagicMock()
-    camera.async_write_ha_state = MagicMock()
-
-    camera._handle_coordinator_update()
-
-    camera._reset_trail.assert_not_called()
-
-
-def test_metric_only_clean_starts_camera_trail_once() -> None:
-    """Fresh clean metrics drive the camera without rewriting coarse status."""
-    state = NarwalState(working_status=WorkingStatus.STANDBY)
-    state.update_from_working_status({"3": 120})
-    coordinator = MagicMock()
-    coordinator.client.state = state
-    camera = NarwalMapCamera.__new__(NarwalMapCamera)
-    camera.coordinator = coordinator
-    camera._last_cleaning_status = WorkingStatus.STANDBY
-    camera._reset_trail = MagicMock()
-    camera.async_write_ha_state = MagicMock()
-
-    camera._handle_coordinator_update()
-    camera._handle_coordinator_update()
-
-    assert state.working_status == WorkingStatus.STANDBY
-    camera._reset_trail.assert_called_once_with()
-
-
-def test_metric_only_pause_resume_keeps_existing_camera_trail() -> None:
-    """Pausing a metric-only clean must not turn resume into a new session."""
-    state = NarwalState(working_status=WorkingStatus.STANDBY)
-    with patch("narwal_client.models.time.monotonic", return_value=100.0):
-        state.update_from_working_status({"3": 120})
-    coordinator = MagicMock()
-    coordinator.client.state = state
-    camera = NarwalMapCamera.__new__(NarwalMapCamera)
-    camera.coordinator = coordinator
-    camera._last_cleaning_status = WorkingStatus.STANDBY
-    camera._reset_trail = MagicMock()
-    camera.async_write_ha_state = MagicMock()
-
-    with patch("narwal_client.models.time.monotonic", return_value=100.0):
-        camera._handle_coordinator_update()
-    state.is_paused = True
-    camera._handle_coordinator_update()
-    with patch("narwal_client.models.time.monotonic", return_value=116.0):
-        state.update_from_working_status({"3": 120})
-    assert state.is_paused
-    camera._handle_coordinator_update()
-    with patch("narwal_client.models.time.monotonic", return_value=117.0):
-        state.update_from_working_status({"3": 121})
-    assert not state.is_paused
-    camera._handle_coordinator_update()
-
-    camera._reset_trail.assert_called_once_with()

--- a/tests/test_dock_tasks.py
+++ b/tests/test_dock_tasks.py
@@ -17,6 +17,7 @@ from custom_components.narwal.dock_tasks import (  # noqa: E402
     can_start_dock_task,
     can_start_robot_clean,
     can_stop_dock_task,
+    dock_task_blocks_robot_return,
 )
 from custom_components.narwal.switch import (  # noqa: E402
     DOCK_TASK_SWITCHES,
@@ -112,6 +113,18 @@ def test_cleaning_state_hides_dock_start_controls() -> None:
     state.dock_field11 = 1
     state.dock_field47 = 2
 
+    assert not can_start_dock_task(state, DOCK_TASK_EMPTY_DUSTBIN)
+
+
+def test_retained_paused_context_hides_dock_start_controls() -> None:
+    """A paused clean remains robot work after live metric freshness expires."""
+    state = _docked_state()
+    state.working_status = WorkingStatus.STANDBY
+    state.is_paused = True
+    state.cleaning_time = 120
+    state.task_elapsed_time = 120
+
+    assert state.has_paused_clean_task_context
     assert not can_start_dock_task(state, DOCK_TASK_EMPTY_DUSTBIN)
 
 
@@ -343,6 +356,34 @@ async def test_active_dry_dust_bin_switch_stops_with_scoped_command() -> None:
     coordinator.client.stop_dock_task.assert_awaited_once_with(DOCK_TASK_DRY_DUST_BIN)
 
 
+async def test_switch_refreshes_before_stop_validation() -> None:
+    """A stale local status cannot reject a typed stop before refresh."""
+    state = _docked_state()
+    state.working_status = WorkingStatus.UNKNOWN
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_DUST_BIN,
+        elapsed=61,
+        target=180,
+        fields=("10", "11"),
+    )
+    coordinator = _coordinator(state)
+
+    async def refresh_dock_status() -> bool:
+        state.working_status = WorkingStatus.DOCKED
+        return True
+
+    coordinator.async_refresh_dock_status = AsyncMock(side_effect=refresh_dock_status)
+    coordinator.client.stop_dock_task = AsyncMock(
+        return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+    )
+    switch = NarwalDockTaskSwitch(coordinator, DOCK_TASK_SWITCHES[3])
+
+    await switch.async_turn_off()
+
+    coordinator.async_refresh_dock_status.assert_awaited()
+    coordinator.client.stop_dock_task.assert_awaited_once_with(DOCK_TASK_DRY_DUST_BIN)
+
+
 def test_multiple_tasks_only_allow_scoped_stop() -> None:
     """Generic stop is unavailable for ambiguous multi-task dock activity."""
     state = _docked_state()
@@ -447,20 +488,125 @@ def test_unmapped_coarse_activity_allows_scoped_dock_bag_stop() -> None:
     assert not can_stop_dock_task(state, DOCK_TASK_DRY_MOP)
 
 
-def test_robot_clean_start_allows_only_typed_dock_bag() -> None:
-    """Robot starts are blocked by dock work except typed dock-bag drying."""
+@pytest.mark.parametrize(
+    ("task", "fields"),
+    [
+        (DOCK_TASK_DRY_MOP, ("8", "9")),
+        (DOCK_TASK_DRY_DUST_BIN, ("10", "11")),
+        (DOCK_TASK_DRY_DOCK_BAG, ("12", "13")),
+    ],
+)
+def test_robot_clean_start_allows_typed_drying_tasks(
+    task: str,
+    fields: tuple[str, str],
+) -> None:
+    """Typed drying tasks can be handed off to the robot clean command."""
     state = _docked_state()
-    state.assume_dock_task(DOCK_TASK_DRY_DOCK_BAG)
+    state.assume_dock_task(task)
     assert not can_start_robot_clean(state)
 
     state = _docked_state()
+    state.set_dock_drying_task(
+        task,
+        elapsed=45,
+        target=180,
+        fields=fields,
+    )
+    assert can_start_robot_clean(state)
+
+
+def test_robot_clean_start_allows_multiple_typed_drying_tasks() -> None:
+    """Multiple typed drying timers can be handed off on clean start."""
+    state = _docked_state()
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_MOP,
+        elapsed=45,
+        target=180,
+        fields=("8", "9"),
+    )
     state.set_dock_drying_task(
         DOCK_TASK_DRY_DOCK_BAG,
         elapsed=45,
         target=180,
         fields=("12", "13"),
     )
+
     assert can_start_robot_clean(state)
+
+
+def test_robot_clean_start_rejects_typed_drying_with_unmapped_activity() -> None:
+    """Typed drying must not mask additional unmapped station work."""
+    state = _docked_state()
+    state.station_activity = 99
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_DOCK_BAG,
+        elapsed=45,
+        target=180,
+        fields=("12", "13"),
+    )
+
+    assert not can_start_robot_clean(state)
+
+
+def test_robot_return_allows_only_typed_dock_bag() -> None:
+    """Robot return is blocked by dock work except typed dock-bag drying."""
+    state = NarwalState(working_status=WorkingStatus.STANDBY)
+    state.station_activity = 4
+    assert dock_task_blocks_robot_return(state)
+
+    state = NarwalState(working_status=WorkingStatus.STANDBY)
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_DOCK_BAG,
+        elapsed=45,
+        target=180,
+        fields=("12", "13"),
+    )
+    assert not dock_task_blocks_robot_return(state)
+
+    state = NarwalState(working_status=WorkingStatus.STANDBY)
+    state.dock_presence = 6
+    state.set_dock_drying_task(
+        DOCK_TASK_DRY_MOP,
+        elapsed=45,
+        target=180,
+        fields=("8", "9"),
+    )
+    assert dock_task_blocks_robot_return(state)
+
+
+@pytest.mark.parametrize(
+    "task",
+    [
+        DOCK_TASK_EMPTY_DUSTBIN,
+        DOCK_TASK_WASH_MOP,
+        DOCK_TASK_DRY_MOP,
+        DOCK_TASK_DRY_DUST_BIN,
+    ],
+)
+def test_accepted_dock_task_blocks_robot_return_during_handoff(task: str) -> None:
+    """Accepted incompatible dock work blocks robot actions before telemetry."""
+    state = NarwalState(working_status=WorkingStatus.STANDBY)
+    state.assume_dock_task(task)
+
+    assert dock_task_blocks_robot_return(state)
+
+
+def test_accepted_dock_bag_dry_keeps_robot_return_compatible() -> None:
+    """The proven dock-bag exception applies during its telemetry handoff too."""
+    state = NarwalState(working_status=WorkingStatus.STANDBY)
+    state.assume_dock_task(DOCK_TASK_DRY_DOCK_BAG)
+
+    assert not dock_task_blocks_robot_return(state)
+
+
+def test_unmapped_dock_timer_blocks_robot_return_without_coarse_activity() -> None:
+    """Fresh unknown timer work blocks return despite an idle station field."""
+    state = NarwalState(working_status=WorkingStatus.STANDBY)
+    state.update_from_working_status({"14": 60, "15": 180})
+
+    assert state.has_unmapped_active_dock_task
+    assert not state.is_station_active
+    assert dock_task_blocks_robot_return(state)
 
 
 async def test_wash_mop_switch_uses_status_gated_command() -> None:

--- a/tests/test_fan_speed.py
+++ b/tests/test_fan_speed.py
@@ -34,7 +34,6 @@ def test_canonical_labels_map_to_the_proto_enum() -> None:
     assert FAN_SPEED_MAP["Quiet"] is FanLevel.MUTE
     assert FAN_SPEED_MAP["Standard"] is FanLevel.NORMAL
     assert FAN_SPEED_MAP["Strong"] is FanLevel.STRONG
-    # #70 capture: the app's top tier ("super puissant") sends tag 2 = 4.
     assert FAN_SPEED_MAP["Super Powerful"] is FanLevel.DEEP
     assert int(FAN_SPEED_MAP["Super Powerful"]) == 4
     assert FAN_SPEED_MAP["Ultra"] is FanLevel.SUPER
@@ -43,8 +42,8 @@ def test_canonical_labels_map_to_the_proto_enum() -> None:
 def test_pre_rename_labels_still_resolve() -> None:
     """Labels shipped through v1.0.3 keep working in existing automations."""
     assert FAN_SPEED_MAP["Super"] is FanLevel.DEEP
-    assert FAN_SPEED_MAP["Super powerful"] is FanLevel.DEEP
     assert FAN_SPEED_MAP["Ultra powerful"] is FanLevel.SUPER
+    assert FAN_SPEED_MAP["Super powerful"] is FanLevel.DEEP
 
 
 def test_lowercase_aliases_still_resolve() -> None:

--- a/tests/test_map_display.py
+++ b/tests/test_map_display.py
@@ -9,7 +9,14 @@ Covers MAP-03 (live overlay / to_grid_coords) validation gaps:
 
 from __future__ import annotations
 
+import struct
+
 from narwal_client.models import MapDisplayData
+
+
+def _float_stream(*values: float) -> bytes:
+    """Encode a packed float32 stream as display_map field 2 uses it."""
+    return b"".join(struct.pack("<f", value) for value in values)
 
 
 class TestToGridCoords:
@@ -22,14 +29,11 @@ class TestToGridCoords:
 
         assert result is not None
         px, py = result
-        # 10.0 - (-100) = 110.0
         assert abs(px - 110.0) < 0.01
-        # 20.0 - (-200) = 220.0
         assert abs(py - 220.0) < 0.01
 
     def test_at_origin(self) -> None:
         """Robot at origin position returns (0, 0) grid coords."""
-        # origin_x=-280, origin_y=-341: robot at (-280, -341) should give (0, 0)
         display = MapDisplayData(robot_x=-280.0, robot_y=-341.0)
         result = display.to_grid_coords(resolution=60, origin_x=-280, origin_y=-341)
 
@@ -48,9 +52,7 @@ class TestToGridCoords:
 
         assert result is not None
         px, py = result
-        # -7.97 - (-280) = 272.03
         assert abs(px - 272.03) < 0.1
-        # 1.25 - (-341) = 342.25
         assert abs(py - 342.25) < 0.1
 
     def test_zero_position_returns_none(self) -> None:
@@ -81,9 +83,7 @@ class TestToGridCoords:
 
         assert result is not None
         px, py = result
-        # 50.0 - 10 = 40.0
         assert abs(px - 40.0) < 0.01
-        # 60.0 - 20 = 40.0
         assert abs(py - 40.0) < 0.01
 
 
@@ -111,9 +111,56 @@ class TestMapDisplayDataFromBroadcast:
         assert abs(result.dock_ref_y - 0.22) < 0.01
         assert result.timestamp == 1709900000000
 
+    def test_trajectory_window_parsing(self) -> None:
+        """Parse display_map field 2 as a native cleaning trajectory window."""
+        decoded = {
+            "2": {
+                "1": _float_stream(1.5, 2.0, 2.5),
+                "2": _float_stream(-2.25, 3.0, 3.5),
+            }
+        }
+
+        result = MapDisplayData.from_broadcast(decoded)
+
+        assert result.has_trajectory
+        assert result.trajectory_points() == [(1.5, -2.25), (2.0, 3.0), (2.5, 3.5)]
+
+    def test_trajectory_window_filters_invalid_pairs_without_shifting_axes(
+        self,
+    ) -> None:
+        """Drop bad x/y pairs without inventing coordinates from later values."""
+        decoded = {
+            "2": {
+                "1": _float_stream(1.5, float("nan"), 2.5),
+                "2": _float_stream(-2.25, 3.0, 3.5),
+            }
+        }
+
+        result = MapDisplayData.from_broadcast(decoded)
+
+        assert result.has_trajectory
+        assert result.trajectory_points() == [(1.5, -2.25), (2.5, 3.5)]
+
+    def test_trajectory_window_list_values_preserve_bad_pair_slots(
+        self,
+    ) -> None:
+        """Bad list entries become NaN slots so later x/y values stay aligned."""
+        decoded = {
+            "2": {
+                "1": [1.5, "bad", 2.5],
+                "2": [-2.25, 3.0, 3.5],
+            }
+        }
+
+        result = MapDisplayData.from_broadcast(decoded)
+
+        assert result.has_trajectory
+        assert result.trajectory_points() == [(1.5, -2.25), (2.5, 3.5)]
+
     def test_empty_broadcast(self) -> None:
         """Empty broadcast returns default values."""
         result = MapDisplayData.from_broadcast({})
         assert result.robot_x == 0.0
         assert result.robot_y == 0.0
         assert result.timestamp == 0
+        assert not result.has_trajectory

--- a/tests/test_map_renderer.py
+++ b/tests/test_map_renderer.py
@@ -13,15 +13,13 @@ import zlib
 
 from narwal_client.map_renderer import (
     MAP_RENDER_SCALE,
-    render_base_map,
-    render_overlay,
-    decompress_map,
-    _decode_packed_varints,
-    _scaled_coord,
-    OBSTACLE_COLORS,
     OBSTACLE_COLOR_DEFAULT,
-    render_map_png,
+    OBSTACLE_COLORS,
+    _scaled_coord,
     _transform_point,
+    render_base_map,
+    render_map_png,
+    render_overlay,
 )
 from narwal_client.models import ObstacleInfo
 
@@ -161,7 +159,7 @@ class TestRenderOverlay:
         assert result[:8] == b"\x89PNG\r\n\x1a\n"
 
     def test_with_trail(self) -> None:
-        """render_overlay draws trail positions as line segments."""
+        """render_overlay draws native trajectory positions as line segments."""
         base = self._make_base_image(width=50, height=50)
         trail = [(10.0, 10.0), (20.0, 20.0), (30.0, 30.0)]
 
@@ -188,7 +186,6 @@ class TestRenderOverlay:
 
     def test_does_not_modify_base(self) -> None:
         """render_overlay does not mutate the base image."""
-        from PIL import Image
         base = self._make_base_image()
         # Save original pixel for comparison
         original_pixel = base.getpixel((15, 15))
@@ -284,8 +281,6 @@ class TestObstacleRendering:
 
     def test_empty_obstacles_same_as_no_obstacles(self) -> None:
         """render_base_map with empty obstacles list produces same output as without."""
-        from PIL import Image
-
         width, height = 20, 20
         compressed = _make_room_grid(width, height, room_id=1)
 
@@ -317,15 +312,22 @@ class TestObstacleRendering:
 
     def test_obstacle_modifies_image(self) -> None:
         """An in-bounds obstacle should change some pixels compared to no-obstacle render."""
-        from PIL import Image
-
         width, height = 40, 40
         compressed = _make_room_grid(width, height, room_id=1)
 
         result_without = render_base_map(compressed, width, height)
         result_with = render_base_map(
             compressed, width, height,
-            obstacles=[ObstacleInfo(id=1, type_id=2, center_x=20.0, center_y=20.0, width=10.0, height=10.0)],
+            obstacles=[
+                ObstacleInfo(
+                    id=1,
+                    type_id=2,
+                    center_x=20.0,
+                    center_y=20.0,
+                    width=10.0,
+                    height=10.0,
+                )
+            ],
             origin_x=0, origin_y=0,
         )
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,89 @@
+"""Tests for Narwal config-entry migrations."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import tests.ha_stubs
+
+tests.ha_stubs.install()
+
+from custom_components.narwal import (  # noqa: E402
+    _async_remove_legacy_replaced_sensors,
+    async_migrate_entry,
+)
+from custom_components.narwal.const import CONF_DEVICE_ID  # noqa: E402
+
+
+async def test_migration_removes_legacy_replaced_sensor_registry_entries() -> None:
+    """Old standalone task sensors are removed once native entities replace them."""
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.version = 2
+    entry.minor_version = 1
+    entry.data = {CONF_DEVICE_ID: "test_device"}
+    entry.entry_id = "entry-id"
+
+    registry = MagicMock()
+    entity_ids_by_unique_id = {
+        "test_device_current_room": "sensor.test_current_room",
+        "test_device_task_status": "sensor.test_status",
+    }
+    registry.async_get_entity_id.side_effect = (
+        lambda _domain, _platform, unique_id: entity_ids_by_unique_id.get(unique_id)
+    )
+    registry.async_get.return_value = SimpleNamespace(platform="narwal")
+
+    with patch(
+        "custom_components.narwal.er.async_get",
+        return_value=registry,
+    ), patch("custom_components.narwal.er.async_entries_for_config_entry", return_value=()):
+        assert await async_migrate_entry(hass, entry)
+
+    registry.async_get_entity_id.assert_any_call(
+        "sensor",
+        "narwal",
+        "test_device_task_status",
+    )
+    registry.async_get_entity_id.assert_any_call(
+        "sensor",
+        "narwal",
+        "test_device_current_room",
+    )
+    assert registry.async_remove.call_count == 2
+    registry.async_remove.assert_any_call("sensor.test_current_room")
+    registry.async_remove.assert_any_call("sensor.test_status")
+    hass.config_entries.async_update_entry.assert_called_once_with(
+        entry,
+        minor_version=2,
+    )
+
+
+def test_legacy_replaced_sensor_cleanup_scans_config_entry_entities() -> None:
+    """Renamed legacy sensors are still removed by unique_id."""
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.data = {CONF_DEVICE_ID: "test_device"}
+    entry.entry_id = "entry-id"
+    stale = SimpleNamespace(
+        domain="sensor",
+        platform="narwal",
+        unique_id="test_device_task_progress",
+        entity_id="sensor.renamed_progress",
+    )
+
+    registry = MagicMock()
+    registry.async_get_entity_id.return_value = None
+    registry.async_get.return_value = stale
+
+    with patch(
+        "custom_components.narwal.er.async_get",
+        return_value=registry,
+    ), patch(
+        "custom_components.narwal.er.async_entries_for_config_entry",
+        return_value=(stale,),
+    ):
+        _async_remove_legacy_replaced_sensors(hass, entry)
+
+    registry.async_remove.assert_called_once_with("sensor.renamed_progress")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,6 +7,8 @@ import struct
 from dataclasses import replace
 from unittest.mock import patch
 
+import pytest
+
 from narwal_client.const import WorkingStatus
 from narwal_client.models import (
     DOCK_TASK_DRY_DOCK_BAG,
@@ -35,7 +37,7 @@ class TestNarwalState:
         assert not state.is_returning
 
     def test_update_from_working_status(self) -> None:
-        """working_status topic sets cleaning metrics and marks active cleaning."""
+        """working_status topic sets cleaning metrics without rewriting status."""
         state = NarwalState()
         # Field 2 = coveredArea (float32, m²); field 13 = totalDryStationBagTime, ignored.
         state.update_from_working_status(
@@ -43,7 +45,7 @@ class TestNarwalState:
         )
         assert state.cleaning_time == 120
         assert state.cleaning_area == 12.5
-        assert state.working_status == WorkingStatus.CLEANING
+        assert state.working_status == WorkingStatus.UNKNOWN
         assert state.has_recent_active_working_status
 
     def test_working_status_station_timers_do_not_mark_cleaning(self) -> None:
@@ -51,7 +53,33 @@ class TestNarwalState:
         state = NarwalState()
         state.update_from_working_status({"13": 18000})
         assert state.working_status == WorkingStatus.UNKNOWN
+        assert state.last_active_working_status_time == 0.0
         assert not state.has_recent_active_working_status
+
+    def test_robot_side_drying_ignores_stale_clean_counters(self) -> None:
+        """Mop and robot-bin drying timers override prior clean metrics."""
+        for payload in (
+            {"3": 120, "8": 60, "9": 180},
+            {"3": 120, "10": 60, "11": 180},
+        ):
+            state = NarwalState()
+            state.update_from_base_status(
+                {"3": {"1": 10, "3": 6}, "11": 2, "47": 3}
+            )
+
+            state.update_from_working_status(payload)
+
+            assert not state.has_recent_active_working_status
+
+    def test_dock_bag_drying_does_not_hide_live_clean_counters(self) -> None:
+        """Dock-bag drying may continue while the robot cleans off-dock."""
+        state = NarwalState()
+
+        state.update_from_working_status(
+            {"3": 120, "12": 60, "13": 180}
+        )
+
+        assert state.has_recent_active_working_status
 
     def test_working_status_maps_dock_task_timers(self) -> None:
         """Typed dock timer pairs expose task progress without marking cleaning."""
@@ -101,6 +129,80 @@ class TestNarwalState:
         assert state.working_status == WorkingStatus.DOCKED_V2
         assert state.has_explicit_off_dock_signal
         assert not state.is_docked
+
+    def test_off_dock_fields_prevent_false_terminal_metric_suppression(self) -> None:
+        """A coarse dock enum cannot suppress later live off-dock metrics."""
+        state = NarwalState()
+
+        state.update_from_base_status(
+            {"3": {"1": 10, "3": 6, "10": 1}, "11": 2, "47": 3}
+        )
+        assert state.last_terminal_working_status_time > 0
+
+        state.update_from_base_status({"3": {"1": 2}, "11": 1, "47": 2})
+        state.update_from_working_status({"3": 120})
+
+        assert state.has_explicit_off_dock_signal
+        assert state.has_recent_active_working_status
+        assert state.is_cleaning
+
+    def test_off_dock_standby_clears_terminal_metric_suppression(self) -> None:
+        """Explicit departure clears a prior terminal timestamp before metrics."""
+        state = NarwalState()
+        state.update_from_base_status(
+            {"3": {"1": 10, "3": 6, "10": 1}, "11": 2, "47": 3}
+        )
+        assert state.last_terminal_working_status_time > 0
+
+        state.update_from_base_status(
+            {"3": {"1": 1, "3": 2, "10": 2}, "11": 1, "47": 2}
+        )
+        state.update_from_working_status({"3": 120})
+
+        assert state.working_status == WorkingStatus.STANDBY
+        assert state.has_explicit_off_dock_signal
+        assert state.last_terminal_working_status_time == 0.0
+        assert state.has_recent_active_working_status
+        assert state.is_cleaning
+
+    def test_nested_off_dock_fields_apply_before_terminal_classification(self) -> None:
+        """Current nested presence overrides retained dock indicators."""
+        state = NarwalState()
+        state.update_from_base_status(
+            {"3": {"1": 10, "3": 6, "10": 1}, "11": 2, "47": 3}
+        )
+
+        state.update_from_base_status({"3": {"1": 2, "3": 2, "10": 2}})
+        state.update_from_working_status({"3": 120})
+
+        assert state.has_explicit_off_dock_signal
+        assert state.has_recent_active_working_status
+        assert state.is_cleaning
+
+    def test_sparse_docked_status_preserves_current_dock_evidence(self) -> None:
+        """Retained off-dock fields cannot erase a newer confirmed docking."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 4, "3": 2, "10": 2}})
+        state.update_from_base_status({"3": {"1": 10, "3": 6}})
+
+        state.update_from_base_status({"3": {"1": 2}})
+
+        assert not state.has_explicit_off_dock_signal
+        assert state.is_docked
+
+    def test_presence_only_departure_clears_retained_dock_evidence(self) -> None:
+        """Current nested departure wins over omitted prior dock fields."""
+        state = NarwalState()
+        state.update_from_base_status(
+            {"3": {"1": 10, "3": 6, "10": 1}, "11": 2, "47": 3}
+        )
+
+        state.update_from_base_status({"3": {"1": 2, "3": 2}})
+        state.update_from_working_status({"3": 120})
+
+        assert state.has_explicit_off_dock_signal
+        assert state.has_recent_active_working_status
+        assert state.is_cleaning
 
     def test_explicit_off_dock_fields_override_retained_dock_activity(self) -> None:
         """Coarse station activity cannot override current off-dock fields."""
@@ -173,6 +275,15 @@ class TestNarwalState:
         assert state.active_dock_task_keys == (DOCK_TASK_DRY_MOP,)
         assert not state.has_fresh_idle_dock_drying_snapshot
 
+    def test_recent_clean_metrics_preserve_fresh_emptying_activity(self) -> None:
+        """An intermediate empty phase remains active despite recent counters."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.update_from_working_status({"3": 60})
+        state.station_activity = 1
+
+        assert state.has_recent_active_working_status
+        assert state.is_station_active
+
     def test_unmapped_dock_timer_expires_by_freshness_window(self) -> None:
         """Unmapped timer fields stop blocking when their packet is stale."""
         state = NarwalState()
@@ -213,6 +324,74 @@ class TestNarwalState:
         assert state.is_docked
         assert state.working_status == WorkingStatus.DOCKED
 
+    def test_working_status_decodes_progress_and_remaining_time(self) -> None:
+        """working_status reports progress and remaining time for vacuum attrs."""
+        state = NarwalState()
+
+        state.update_from_working_status(
+            {"1": _float_to_uint32(0.64), "3": 120, "4": 600}
+        )
+
+        assert state.task_progress_percent == 64
+        assert state.cleaning_time == 120
+        assert state.task_elapsed_time == 120
+        assert state.task_remaining_time == 600
+
+    def test_non_cleaning_base_status_clears_stale_task_details(self) -> None:
+        """Progress/current-room fields from the prior clean should not leak."""
+        state = NarwalState()
+        state.task_progress_percent = 72
+        state.task_elapsed_time = 900
+        state.task_remaining_time = 300
+        state.current_room_id = 4
+        state.current_room_aux_name = "Kitchen"
+
+        state.update_from_base_status({"3": {"1": 10, "10": 1}})
+
+        assert state.task_progress_percent is None
+        assert state.task_elapsed_time == 0
+        assert state.task_remaining_time == 0
+        assert state.current_room_id is None
+        assert state.current_room_aux_name == ""
+
+    def test_terminal_docked_status_clears_stale_paused_context(self) -> None:
+        """A stale paused bit cannot keep a confirmed docked robot active."""
+        state = NarwalState()
+        state.last_active_working_status_time = 1.0
+        state.task_progress_percent = 72
+        state.task_elapsed_time = 900
+        state.current_room_id = 4
+
+        state.update_from_base_status(
+            {"3": {"1": 10, "2": 1, "10": 1}, "11": 2, "47": 3}
+        )
+
+        assert state.last_active_working_status_time == 0.0
+        assert not state.has_recent_active_working_status
+        assert state.task_progress_percent is None
+        assert state.task_elapsed_time == 0
+        assert state.current_room_id is None
+        assert state.is_docked
+
+    def test_off_dock_task_completed_clears_stale_paused_context(self) -> None:
+        """Completion cannot retain a resumable paused overlay off the dock."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.is_paused = True
+        state.cleaning_area = 25.5
+        state.cleaning_time = 900
+        state.task_elapsed_time = 900
+        state.dock_presence = 2
+
+        state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.TASK_COMPLETED), "2": 1, "3": 2}}
+        )
+
+        assert not state.is_paused
+        assert state.cleaning_area == 0.0
+        assert state.cleaning_time == 0
+        assert state.task_elapsed_time == 0
+        assert not state.has_paused_clean_task_context
+
     def test_working_status_clears_stale_dock_fields(self) -> None:
         """Fresh task metrics override stale dock indicators."""
         state = NarwalState(working_status=WorkingStatus.DOCKED)
@@ -225,10 +404,24 @@ class TestNarwalState:
 
         assert state.is_cleaning
         assert not state.is_docked
-        assert state.dock_sub_state == 0
-        assert state.dock_activity == 0
-        assert state.dock_field11 == 1
-        assert state.dock_field47 == 2
+        assert state.working_status == WorkingStatus.DOCKED
+
+    def test_recent_working_status_survives_stale_docked_base_packet(self) -> None:
+        """A delayed dock packet cannot erase a confirmed clean handoff."""
+        state = NarwalState(working_status=WorkingStatus.DOCKED)
+        state.assume_robot_clean()
+        state.update_from_working_status({"1": 25, "3": 120, "6": 4})
+
+        state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.DOCKED), "10": 1}, "11": 2, "47": 3}
+        )
+
+        assert state.has_recent_active_working_status
+        assert state.is_cleaning
+        assert not state.is_docked
+        assert state.task_progress_percent == 25
+        assert state.task_elapsed_time == 120
+        assert state.current_room_id == 4
 
     def test_update_from_base_status_cleaning(self) -> None:
         state = NarwalState()
@@ -303,19 +496,24 @@ class TestNarwalState:
 
         assert state.active_dock_task_keys == ()
 
-    def test_active_cleaning_clears_stale_station_activity(self) -> None:
-        """Cleaning telemetry clears coarse dock activity from prior station work."""
-        state = NarwalState()
-        state.station_activity = 1
-        state.dock_activity = 4
-        state.assume_dock_task(DOCK_TASK_EMPTY_DUSTBIN)
+    def test_stale_working_metrics_do_not_override_active_station_task(self) -> None:
+        """Historic clean counters cannot hide fresh emptying or washing."""
+        for station_activity, dock_activity, task in (
+            (1, 0, DOCK_TASK_EMPTY_DUSTBIN),
+            (2, 0, DOCK_TASK_WASH_MOP),
+            (0, 3, DOCK_TASK_WASH_MOP),
+        ):
+            state = NarwalState(working_status=WorkingStatus.DOCKED)
+            state.dock_presence = 6
+            state.station_activity = station_activity
+            state.dock_activity = dock_activity
 
-        state.update_from_working_status({"3": 120})
+            state.update_from_working_status({"3": 120})
 
-        assert state.station_activity == 0
-        assert state.dock_activity == 0
-        assert not state.is_station_active
-        assert state.active_dock_task_keys == ()
+            assert state.station_activity == station_activity
+            assert state.dock_activity == dock_activity
+            assert not state.has_recent_active_working_status
+            assert state.active_dock_task_keys == (task,)
 
     def test_active_base_status_clears_stale_station_activity(self) -> None:
         """Active robot base-status packets cannot keep stale dock switches on."""
@@ -357,7 +555,7 @@ class TestNarwalState:
         assert not state.has_dock_presence_signal
         assert state.dock_task_timer(DOCK_TASK_DRY_MOP) is not None
         assert state.active_dock_task_keys == (DOCK_TASK_DRY_MOP,)
-        assert state.blocks_robot_start_for_dock_task
+        assert not state.blocks_robot_start_for_dock_task
 
     def test_stale_dock_timer_does_not_remain_active(self) -> None:
         """Typed dock timers stop driving visible state after telemetry expires."""
@@ -394,21 +592,26 @@ class TestNarwalState:
         assert state.has_unmapped_active_dock_task
         assert state.blocks_robot_start_for_dock_task
 
-    def test_robot_start_blocked_by_dock_work_except_typed_dock_bag(self) -> None:
-        """Only typed dock-bag drying is compatible with a new robot clean."""
+    def test_robot_start_allows_only_typed_drying_work(self) -> None:
+        """Typed drying is compatible with a new robot clean."""
         state = NarwalState()
         state.update_from_base_status({"3": {"1": 10, "3": 6, "18": 1}, "11": 2})
         assert state.blocks_robot_start_for_dock_task
 
-        state = NarwalState()
-        state.update_from_base_status({"3": {"1": 10, "3": 6}, "11": 2})
-        state.set_dock_drying_task(
-            DOCK_TASK_DRY_DOCK_BAG,
-            elapsed=60,
-            target=180,
-            fields=("12", "13"),
-        )
-        assert not state.blocks_robot_start_for_dock_task
+        for task, fields in (
+            (DOCK_TASK_DRY_MOP, ("8", "9")),
+            (DOCK_TASK_DRY_DUST_BIN, ("10", "11")),
+            (DOCK_TASK_DRY_DOCK_BAG, ("12", "13")),
+        ):
+            state = NarwalState()
+            state.update_from_base_status({"3": {"1": 10, "3": 6}, "11": 2})
+            state.set_dock_drying_task(
+                task,
+                elapsed=60,
+                target=180,
+                fields=fields,
+            )
+            assert not state.blocks_robot_start_for_dock_task
 
         state.dock_drying_status_time -= 181
 
@@ -423,15 +626,62 @@ class TestNarwalState:
         assert state.active_dock_task_keys == (DOCK_TASK_DRY_DOCK_BAG,)
         assert state.blocks_robot_start_for_dock_task
 
-    def test_assumed_robot_clean_clears_on_active_telemetry(self) -> None:
-        """Accepted robot-start reservations stop once real cleaning status arrives."""
+    def test_assumed_robot_clean_waits_for_active_base_status(self) -> None:
+        """Working metrics do not expose a start to delayed dock packets."""
         state = NarwalState()
         state.assume_robot_clean()
 
         state.update_from_working_status({"3": 120})
 
-        assert not state.has_assumed_robot_clean
+        assert state.has_assumed_robot_clean
         assert state.is_cleaning
+
+        state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.CLEANING)}, "11": 1, "47": 2}
+        )
+
+        assert not state.has_assumed_robot_clean
+
+    def test_assumed_robot_clean_covers_slow_status_handoff(self) -> None:
+        """Accepted room starts may take over 30s to publish task telemetry."""
+        state = NarwalState()
+
+        with patch("narwal_client.models.time.monotonic", return_value=1000.0):
+            state.assume_robot_clean()
+        with patch("narwal_client.models.time.monotonic", return_value=1179.0):
+            assert state.has_assumed_robot_clean
+        with patch("narwal_client.models.time.monotonic", return_value=1181.0):
+            assert not state.has_assumed_robot_clean
+
+    def test_assumed_robot_clean_ignores_unknown_off_dock_handoff(self) -> None:
+        """UNKNOWN/off-dock base status can appear before task telemetry arrives."""
+        state = NarwalState()
+        state.assume_robot_clean()
+
+        state.update_from_base_status({"3": {"1": 0}, "11": 1, "47": 2})
+
+        assert state.has_assumed_robot_clean
+
+    def test_assumed_robot_clean_ignores_previous_docked_base_status(self) -> None:
+        """A stale dock status cannot erase an accepted start during handoff."""
+        state = NarwalState()
+        with patch("narwal_client.models.time.monotonic", return_value=1000.0):
+            state.assume_robot_clean()
+
+        with patch("narwal_client.models.time.monotonic", return_value=1059.0):
+            state.update_from_base_status({"3": {"1": 10, "10": 1}, "11": 2})
+            assert state.has_assumed_robot_clean
+
+    def test_assumed_robot_clean_clears_after_docked_handoff_grace(self) -> None:
+        """Current idle dock telemetry wins if an accepted start never begins."""
+        state = NarwalState()
+        with patch("narwal_client.models.time.monotonic", return_value=1000.0):
+            state.assume_robot_clean()
+
+        with patch("narwal_client.models.time.monotonic", return_value=1061.0):
+            state.update_from_base_status({"3": {"1": 10, "10": 1}, "11": 2})
+
+        assert not state.has_assumed_robot_clean
 
     def test_paused_context_handles_missing_task_metrics(self) -> None:
         """Paused context is safe before richer task metric fields exist."""
@@ -444,6 +694,95 @@ class TestNarwalState:
 
         assert state.has_paused_clean_task_context
 
+    @pytest.mark.parametrize(
+        "status",
+        (
+            WorkingStatus.DOCKED,
+            WorkingStatus.CHARGED,
+            WorkingStatus.DOCKED_V2,
+            WorkingStatus.TASK_COMPLETED,
+            WorkingStatus.ERROR,
+        ),
+    )
+    def test_terminal_status_ignores_late_active_metrics(
+        self, status: WorkingStatus
+    ) -> None:
+        """Late counters cannot reactivate a terminal robot state."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": int(status)}})
+
+        state.update_from_working_status({"2": 12.5, "3": 900})
+
+        assert not state.has_recent_active_working_status
+        assert not state.is_cleaning
+
+    def test_terminal_suppressed_metrics_cannot_revive_paused_context(self) -> None:
+        """A later pause bit cannot revive metrics rejected after docking."""
+        state = NarwalState()
+        state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.DOCKED), "10": 1}, "11": 2}
+        )
+
+        state.update_from_working_status({"1": 25, "2": 12.5, "3": 900, "6": 4})
+        state.update_from_base_status({"3": {"2": 1}})
+
+        assert state.task_progress_percent is None
+        assert state.task_elapsed_time == 0
+        assert state.current_room_id is None
+        assert not state.has_paused_clean_task_context
+
+    @pytest.mark.parametrize(
+        "status", (WorkingStatus.TASK_COMPLETED, WorkingStatus.ERROR)
+    )
+    def test_explicit_terminal_status_rejects_progressing_metrics(
+        self, status: WorkingStatus
+    ) -> None:
+        """Metric progression cannot override an explicit terminal robot state."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": int(status)}})
+
+        state.update_from_working_status({"1": 25, "3": 120})
+        state.update_from_working_status({"1": 26, "3": 121})
+
+        assert not state.has_recent_active_working_status
+        assert not state.is_cleaning
+
+    @pytest.mark.parametrize(
+        "dock_fields",
+        ({"11": 2}, {"11": 3}, {"47": 1}, {"47": 3}),
+    )
+    def test_docked_standby_ignores_late_active_metrics(
+        self, dock_fields: dict[str, int]
+    ) -> None:
+        """Legacy and newer docked STANDBY packets are terminal telemetry."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.update_from_working_status({"2": 12.5, "3": 900})
+        assert state.has_recent_active_working_status
+
+        state.update_from_base_status({"3": {"1": 1}, **dock_fields})
+        state.update_from_working_status({"2": 12.5, "3": 900})
+
+        assert state.working_status == WorkingStatus.STANDBY
+        assert state.is_docked
+        assert not state.has_recent_active_working_status
+        assert not state.is_cleaning
+
+    def test_task_completed_clears_metrics_after_accepted_start(self) -> None:
+        """Completion ends fresh metrics even during the accepted-start handoff."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        state.assume_robot_clean()
+        state.update_from_working_status({"2": 12.5, "3": 900})
+        assert state.has_assumed_robot_clean
+        assert state.is_cleaning
+
+        state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.TASK_COMPLETED)}}
+        )
+
+        assert not state.has_assumed_robot_clean
+        assert not state.has_recent_active_working_status
+        assert not state.is_cleaning
+
     def test_paused_context_ignores_stale_metrics_after_docking(self) -> None:
         """Docked API state ends stale paused overlays from the previous task."""
         state = NarwalState()
@@ -452,6 +791,17 @@ class TestNarwalState:
         state.current_room_id = 4
 
         assert not state.has_paused_clean_task_context
+
+    def test_paused_context_outranks_cached_dock_fields(self) -> None:
+        """Only a current terminal update may end retained paused context."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        state.is_paused = True
+        state.cleaning_time = 120
+        state.dock_presence = 6
+        state.dock_field11 = 2
+        state.dock_field47 = 3
+
+        assert state.has_paused_clean_task_context
 
     def test_dock_task_assumption_is_only_a_short_command_guard(self) -> None:
         """Dock task assumptions must not fabricate long-running device state."""
@@ -892,6 +1242,16 @@ class TestNarwalState:
         assert state.is_returning  # should be True via field 3.7
         assert not state.is_cleaning  # returning takes priority
 
+    def test_stale_return_flag_does_not_hide_active_clean(self) -> None:
+        """Field 3.7 alone is not an authoritative returning state."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 4, "7": 1}})
+        state.last_active_working_status_time = 0.0
+
+        assert state.is_returning_to_dock
+        assert not state.is_returning
+        assert state.is_cleaning
+
     def test_returning_clears_when_docked(self) -> None:
         """Returning flag clears when robot docks."""
         state = NarwalState()
@@ -1239,6 +1599,16 @@ class TestCurrentRoomTracking:
         state = NarwalState()
         state.update_from_working_status({"6": 0})
         assert state.current_room_id is None
+
+    def test_nested_current_room_details_supply_id_and_name(self) -> None:
+        """Nested firmware room details populate the fallback room name."""
+        state = NarwalState()
+
+        state.update_from_working_status({"6": {"1": 4, "3": b"Kitchen"}})
+
+        assert state.current_room_id == 4
+        assert state.current_room_aux_name == "Kitchen"
+        assert state.current_room_name == "Kitchen"
 
     def test_current_room_id_not_cleared_when_field6_absent(self) -> None:
         """If field 6 is not in the message, current_room_id is not cleared.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,6 +17,7 @@ from narwal_client.models import (
     DOCK_TASK_EMPTY_DUSTBIN,
     DOCK_TASK_WASH_MOP,
     MapData,
+    MapDisplayData,
     NarwalState,
     ObstacleInfo,
     RoomInfo,
@@ -683,6 +684,15 @@ class TestNarwalState:
 
         assert not state.has_assumed_robot_clean
 
+    def test_assumed_robot_clean_clears_previous_display_map(self) -> None:
+        """A newly accepted clean should not render the previous task's route."""
+        state = NarwalState()
+        state.map_display_data = MapDisplayData(robot_x=1.0, robot_y=2.0)
+
+        state.assume_robot_clean()
+
+        assert state.map_display_data is None
+
     def test_paused_context_handles_missing_task_metrics(self) -> None:
         """Paused context is safe before richer task metric fields exist."""
         state = NarwalState()
@@ -1335,7 +1345,6 @@ class TestMapData:
             "17": b"",
         }}
         m = MapData.from_response(decoded)
-        # factor 1.0: -8.0188 - (-280) = 271.98, 0.221 - (-341) = 341.22
         assert m.dock_x is not None
         assert m.dock_y is not None
         assert abs(m.dock_x - 272.0) < 1.0
@@ -1352,7 +1361,6 @@ class TestMapData:
             "17": b"",
         }}
         m = MapData.from_response(decoded)
-        # factor 1.0: -8.0188 - (-280) = 271.98, 0.221 - (-341) = 341.22
         assert m.dock_x is not None
         assert m.dock_y is not None
         assert abs(m.dock_x - 272.0) < 1.0

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,67 @@
+"""Tests for Narwal sensor entities."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import tests.ha_stubs
+
+tests.ha_stubs.install()
+
+from custom_components.narwal.sensor import (  # noqa: E402
+    SENSOR_DESCRIPTIONS,
+    NarwalSensor,
+)
+from narwal_client.const import WorkingStatus  # noqa: E402
+from narwal_client.models import NarwalState  # noqa: E402
+
+
+def _sensor(key: str, state: NarwalState) -> NarwalSensor:
+    """Create a NarwalSensor with mocked coordinator data."""
+    coordinator = MagicMock()
+    coordinator.data = state
+    coordinator.last_update_success = True
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.data = {"device_id": "test_device"}
+    coordinator.config_entry.title = "Narwal Test"
+    coordinator.client = MagicMock()
+    coordinator.client.state = state
+    coordinator.client.state.firmware_version = "1.0.0"
+    description = next(item for item in SENSOR_DESCRIPTIONS if item.key == key)
+    return NarwalSensor(coordinator, description)
+
+
+def test_current_room_is_not_a_standalone_sensor() -> None:
+    """Live task context is carried by the vacuum entity, not stale sensors."""
+    sensor_keys = {description.key for description in SENSOR_DESCRIPTIONS}
+    assert "current_room" not in sensor_keys
+    assert "map_metadata" not in sensor_keys
+    assert "status" not in sensor_keys
+    assert "task_progress" not in sensor_keys
+
+
+def test_cleaning_metrics_are_unavailable_when_idle() -> None:
+    """Cleaning metric sensors should not expose stale previous-clean values."""
+    state = NarwalState(working_status=WorkingStatus.DOCKED)
+    state.cleaning_area = 12.5
+    state.cleaning_time = 900
+    state.task_remaining_time = 300
+
+    assert not _sensor("cleaning_area", state).available
+    assert not _sensor("cleaning_time", state).available
+    assert not _sensor("remaining_time", state).available
+
+
+def test_cleaning_metrics_are_available_during_active_clean() -> None:
+    """Cleaning metric sensors expose current robot task values while active."""
+    state = NarwalState(working_status=WorkingStatus.CLEANING)
+    state.cleaning_area = 12.5
+    state.cleaning_time = 900
+    state.task_remaining_time = 300
+
+    assert _sensor("cleaning_area", state).available
+    assert _sensor("cleaning_area", state).native_value == 12.5
+    assert _sensor("cleaning_time", state).available
+    assert _sensor("cleaning_time", state).native_value == 900
+    assert _sensor("remaining_time", state).available
+    assert _sensor("remaining_time", state).native_value == 300

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -81,6 +81,7 @@ def _coordinator(
     coordinator.active_clean_work_mode = None
     coordinator.data = state
     coordinator.async_set_updated_data = MagicMock()
+    coordinator.async_clear_map_display_cache = AsyncMock()
     return coordinator
 
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -65,6 +65,13 @@ def _coordinator(
         return_value=CommandResponse(result_code=result_code)
     )
     coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+
+    async def prepare_clean_start(*, allow_dock_stop: bool = True) -> bool:
+        return coordinator.client.state.is_docked and (
+            allow_dock_stop or not coordinator.client.state.active_dock_task_keys
+        )
+
+    coordinator.async_prepare_clean_start = AsyncMock(side_effect=prepare_clean_start)
     coordinator.dock_action_lock = asyncio.Lock()
     coordinator.config_entry = MagicMock()
     coordinator.config_entry.data = {"product_key": product_key}
@@ -169,7 +176,7 @@ async def test_clean_rooms_service_starts_requested_rooms() -> None:
         await handler(call)
 
     extract_entity_ids.assert_awaited_once()
-    assert extract_entity_ids.await_args.args == (call,)
+    assert extract_entity_ids.await_args.args[0] is call
     coordinator.client.start_rooms.assert_awaited_once()
     assert coordinator.client.start_rooms.await_args.args[0] == [4, 7]
     assert coordinator.client.state.has_assumed_robot_clean
@@ -178,28 +185,30 @@ async def test_clean_rooms_service_starts_requested_rooms() -> None:
     coordinator.async_set_updated_data.assert_called_once_with(coordinator.client.state)
 
 
-async def test_clean_rooms_service_accepts_legacy_extract_signature() -> None:
-    """The service supports HA versions where extraction also takes hass."""
+async def test_clean_rooms_service_supports_legacy_entity_extractor() -> None:
+    """Target extraction remains compatible with older HA helper signatures."""
     coordinator = _coordinator()
     handler, registry = _register_clean_rooms_handler(coordinator)
     call = _clean_rooms_call()
-    extract_entity_ids = AsyncMock(
-        side_effect=[TypeError, ["vacuum.downstairs_narwal"]]
-    )
 
     with (
         patch(
             "custom_components.narwal.service.async_extract_entity_ids",
-            extract_entity_ids,
-        ),
+            new_callable=AsyncMock,
+            side_effect=[
+                TypeError("missing required positional argument: service_call"),
+                ["vacuum.downstairs_narwal"],
+            ],
+        ) as extract_entity_ids,
         patch("custom_components.narwal.er.async_get", return_value=registry),
     ):
         await handler(call)
 
+    assert len(extract_entity_ids.await_args_list) == 2
     assert extract_entity_ids.await_args_list[0].args == (call,)
-    legacy_args = extract_entity_ids.await_args_list[1].args
-    assert legacy_args[1] is call
-    assert legacy_args[0].data[DOMAIN]["entry-1"] is coordinator
+    assert len(extract_entity_ids.await_args_list[1].args) == 2
+    assert extract_entity_ids.await_args_list[1].args[1] is call
+    coordinator.client.start_rooms.assert_awaited_once()
 
 
 async def test_clean_rooms_service_accepts_async_accepted_response() -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -254,6 +254,37 @@ async def test_clean_rooms_service_uses_requested_settings_over_room_profiles() 
     assert kwargs["room_settings"][7].fan == FanLevel.STRONG
 
 
+@pytest.mark.parametrize(
+    ("product_key", "expected"),
+    [
+        ("QoEsI5qYXO", FanLevel.SUPER),
+        ("qV6BujoYLz", FanLevel.DEEP),
+    ],
+)
+async def test_clean_rooms_service_resolves_max_for_each_model(
+    product_key: str,
+    expected: FanLevel,
+) -> None:
+    """The max alias resolves through each model's visible tiers."""
+    coordinator = _coordinator(product_key=product_key)
+    handler, registry = _register_clean_rooms_handler(coordinator)
+    call = _clean_rooms_call()
+    call.data[FIELD_SUCTION] = "max"
+
+    with (
+        patch(
+            "custom_components.narwal.service.async_extract_entity_ids",
+            new_callable=AsyncMock,
+            return_value=["vacuum.downstairs_narwal"],
+        ),
+        patch("custom_components.narwal.er.async_get", return_value=registry),
+    ):
+        await handler(call)
+
+    room_settings = coordinator.client.start_rooms.await_args.kwargs["room_settings"]
+    assert all(settings.fan == expected for settings in room_settings.values())
+
+
 async def test_clean_rooms_service_rejects_unavailable_start() -> None:
     """The service enforces the same availability as the start entities."""
     coordinator = _coordinator(docked=False)

--- a/tests/test_vacuum_segments.py
+++ b/tests/test_vacuum_segments.py
@@ -77,6 +77,7 @@ def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
     coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
     coordinator.async_prepare_clean_start = AsyncMock(return_value=True)
     coordinator.async_refresh_action_status = AsyncMock(return_value=True)
+    coordinator.async_clear_map_display_cache = AsyncMock()
     coordinator.dock_action_lock = asyncio.Lock()
     coordinator.room_clean_settings_for_rooms = MagicMock(
         side_effect=lambda room_ids, **_kwargs: {

--- a/tests/test_vacuum_segments.py
+++ b/tests/test_vacuum_segments.py
@@ -391,6 +391,20 @@ class TestVacuumSupportedFeatures:
         assert features & VacuumEntityFeature.LOCATE
         assert features & VacuumEntityFeature.FAN_SPEED
 
+    def test_metric_only_clean_with_dock_bag_drying_keeps_stop(self) -> None:
+        """Fresh clean metrics identify robot work alongside compatible drying."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        state.update_from_working_status({"3": 120})
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
+        )
+        vac = _make_vacuum(state=state)
+
+        assert vac.supported_features & VacuumEntityFeature.STOP
+
     def test_intermediate_mop_wash_keeps_active_clean_stop(self) -> None:
         """Mapped station work cannot hide Stop for a current robot clean."""
         state = _active_clean_state()
@@ -1864,6 +1878,28 @@ class TestAsyncStop:
         await vac.async_stop()
 
         vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.stop.assert_awaited_once()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_stop_routes_metric_only_clean_with_dock_bag_to_robot(self) -> None:
+        """Fresh metrics keep robot STOP actionable during dock-bag drying."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        state.update_from_working_status({"3": 120})
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        await vac.async_stop()
+
         vac.coordinator.client.stop.assert_awaited_once()
         vac.coordinator.client.stop_dock_task.assert_not_awaited()
 

--- a/tests/test_vacuum_segments.py
+++ b/tests/test_vacuum_segments.py
@@ -23,7 +23,7 @@ from homeassistant.exceptions import HomeAssistantError  # noqa: E402
 from custom_components.narwal.coordinator import (  # noqa: E402
     CleanSettings,
     NarwalCoordinator,
-    is_clean_session_context,
+    can_prepare_clean_start,
 )
 from custom_components.narwal.vacuum import (  # noqa: E402
     FanSettingRestoreData,
@@ -33,12 +33,16 @@ from narwal_client import RoomCleanSettings  # noqa: E402
 from narwal_client.const import (  # noqa: E402
     CommandResult,
     FanLevel,
+    MopHumidity,
     WorkingStatus,
     WorkMode,
 )
 from narwal_client.models import (  # noqa: E402
     DOCK_TASK_DRY_DOCK_BAG,
+    DOCK_TASK_DRY_DUST_BIN,
     DOCK_TASK_DRY_MOP,
+    DOCK_TASK_EMPTY_DUSTBIN,
+    DOCK_TASK_WASH_MOP,
     CommandResponse,
     MapData,
     NarwalState,
@@ -46,6 +50,7 @@ from narwal_client.models import (  # noqa: E402
 )
 
 Segment = sys.modules["homeassistant.components.vacuum"].Segment
+VacuumActivity = sys.modules["homeassistant.components.vacuum"].VacuumActivity
 VacuumEntityFeature = sys.modules["homeassistant.components.vacuum"].VacuumEntityFeature
 
 
@@ -56,17 +61,22 @@ def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
     coordinator.data = state
     coordinator.config_entry = MagicMock()
     coordinator.config_entry.data = {"device_id": "test_dev_001"}
+    coordinator.config_entry.entry_id = "entry-1"
     coordinator.config_entry.title = "Narwal Test"
     coordinator.client = MagicMock()
     coordinator.client.state = client_state
     coordinator.client.state.firmware_version = "1.0.0"
     coordinator.client.get_map = AsyncMock(return_value=client_state.map_data)
     coordinator.last_update_success = True
+    coordinator.has_fresh_state = True
     coordinator.clean_settings = CleanSettings()
     coordinator.active_clean_work_mode = None
+    coordinator._room_selection_store_loaded = True
     coordinator.active_clean_setting.return_value = None
     coordinator.has_selected_clean_rooms.return_value = False
     coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
+    coordinator.async_prepare_clean_start = AsyncMock(return_value=True)
+    coordinator.async_refresh_action_status = AsyncMock(return_value=True)
     coordinator.dock_action_lock = asyncio.Lock()
     coordinator.room_clean_settings_for_rooms = MagicMock(
         side_effect=lambda room_ids, **_kwargs: {
@@ -91,7 +101,7 @@ def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
     coordinator.clean_setting_applicability_mode = MagicMock(
         side_effect=lambda live=False: (
             coordinator.active_clean_work_mode
-            if live and is_clean_session_context(coordinator.data)
+            if live and coordinator.active_clean_work_mode is not None
             else coordinator.clean_settings.work_mode
         )
     )
@@ -100,9 +110,11 @@ def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
     vac.coordinator = coordinator
     vac._attr_unique_id = "test_dev_001"
     vac._attr_device_info = {}
+    vac.hass = MagicMock()
 
     # Stub StateVacuumEntity attributes
     vac.last_seen_segments = None
+    vac._last_reported_segment_signature = None
     vac.async_create_segments_issue = MagicMock()
     vac.async_write_ha_state = MagicMock()
 
@@ -122,6 +134,345 @@ def _docked_state() -> NarwalState:
     state.dock_presence = 6
     state.dock_field11 = 2
     return state
+
+
+class TestVacuumActivity:
+    """Tests for mapping Narwal task context to HA vacuum activity."""
+
+    def test_active_clean_details_remain_visible(self) -> None:
+        state = _active_clean_state()
+        state.task_progress_percent = 72
+        state.current_room_id = 4
+        state.current_room_aux_name = "Kitchen"
+        state.task_remaining_time = 300
+        state.cleaning_area = 12.5
+        state.cleaning_time = 900
+        vac = _make_vacuum(state=state)
+
+        attrs = vac.extra_state_attributes
+
+        assert attrs["progress"] == 72
+        assert attrs["status_summary"] == "Kitchen - 72%"
+        assert "charging_to_resume" not in attrs
+        assert "progress_display" not in attrs
+        assert "remaining_time" not in attrs
+        assert "current_room_id" not in attrs
+        assert attrs["current_room"] == "Kitchen"
+        assert "active_room_ids" not in attrs
+        assert "cleaning_area" not in attrs
+        assert "cleaning_time" not in attrs
+
+    @pytest.mark.parametrize("transition", ("paused", "returning"))
+    def test_transition_status_takes_priority_over_retained_metrics(
+        self,
+        transition: str,
+    ) -> None:
+        state = _active_clean_state()
+        state.task_progress_percent = 72
+        state.current_room_aux_name = "Kitchen"
+        if transition == "paused":
+            state.is_paused = True
+        else:
+            state.is_returning_to_dock = True
+            state.dock_sub_state = 2
+        vac = _make_vacuum(state=state)
+
+        assert vac.extra_state_attributes["status_summary"] == transition.title()
+
+    def test_stale_clean_details_hidden_after_clean_ends(self) -> None:
+        state = NarwalState(working_status=WorkingStatus.CHARGED)
+        state.task_progress_percent = 72
+        state.current_room_id = 4
+        state.current_room_aux_name = "Kitchen"
+        state.cleaning_area = 12.5
+        state.cleaning_time = 900
+        vac = _make_vacuum(state=state)
+
+        attrs = vac.extra_state_attributes
+
+        assert attrs["task_status"] == "docked"
+        assert "progress" not in attrs
+        assert "remaining_time" not in attrs
+        assert "current_room_id" not in attrs
+        assert "current_room" not in attrs
+        assert "active_room_ids" not in attrs
+        assert "cleaning_area" not in attrs
+        assert "cleaning_time" not in attrs
+
+    def test_unknown_off_dock_status_reports_conservative_cleaning(self) -> None:
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 0}, "11": 1, "47": 2})
+        vac = _make_vacuum(state=state)
+
+        assert state.working_status == WorkingStatus.UNKNOWN
+        assert not state.is_cleaning
+        assert vac.activity == VacuumActivity.CLEANING
+        assert vac.extra_state_attributes["task_status"] == "unknown"
+
+    def test_task_completed_reports_returning_status(self) -> None:
+        """Task-completed transition agrees with the HA returning activity."""
+        state = NarwalState(working_status=WorkingStatus.TASK_COMPLETED)
+        vac = _make_vacuum(state=state)
+
+        assert vac.activity == VacuumActivity.RETURNING
+        assert vac.extra_state_attributes["task_status"] == "returning"
+        assert vac.extra_state_attributes["status_summary"] == "Returning"
+
+    def test_assumed_clean_reports_active_during_start_handoff(self) -> None:
+        """An accepted start remains visible until native task telemetry arrives."""
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 0}, "11": 1, "47": 2})
+        state.assume_robot_clean()
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+        attrs = vac.extra_state_attributes
+
+        assert vac.activity == VacuumActivity.CLEANING
+        assert attrs["task_status"] == "cleaning"
+        assert attrs["status_summary"] == "Cleaning"
+        assert "progress" not in attrs
+        assert "current_room" not in attrs
+        assert features & VacuumEntityFeature.STOP
+
+    def test_station_activity_alone_does_not_report_robot_docked(self) -> None:
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        state.dock_presence = 2
+        state.dock_field11 = 1
+        state.dock_field47 = 2
+        state.station_activity = 4
+        vac = _make_vacuum(state=state)
+
+        assert not state.is_docked
+        assert state.is_station_active
+        assert vac.activity == VacuumActivity.IDLE
+        assert vac.extra_state_attributes["task_status"] == "station_active"
+
+    def test_paused_remapping_reports_paused_task_status(self) -> None:
+        """The paused overlay takes precedence over the remapping label."""
+        state = NarwalState(working_status=WorkingStatus.REMAPPING)
+        state.is_paused = True
+        state.task_elapsed_time = 60
+        vac = _make_vacuum(state=state)
+
+        assert vac.activity == VacuumActivity.PAUSED
+        assert vac.extra_state_attributes["task_status"] == "paused"
+
+
+class TestVacuumSupportedFeatures:
+    """Tests for dynamically exposed native HA vacuum features."""
+
+    def test_idle_docked_exposes_start_features(self) -> None:
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 10, "10": 1}, "11": 2})
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+
+        assert features & VacuumEntityFeature.STATE
+        assert features & VacuumEntityFeature.START
+        assert features & VacuumEntityFeature.FAN_SPEED
+        assert features & VacuumEntityFeature.CLEAN_AREA
+        assert features & VacuumEntityFeature.RETURN_HOME
+        assert not features & VacuumEntityFeature.STOP
+        assert not features & VacuumEntityFeature.PAUSE
+
+    def test_stale_dock_state_keeps_refreshable_start_features(self) -> None:
+        """Start services remain reachable so handlers can refresh dock state."""
+        state = _docked_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.has_fresh_state = False
+
+        features = vac.supported_features
+
+        assert features & VacuumEntityFeature.START
+        assert features & VacuumEntityFeature.CLEAN_AREA
+
+    def test_failed_selection_restore_hides_start_without_cached_map(self) -> None:
+        """Do not advertise START when its room selection is non-authoritative."""
+        state = _docked_state()
+        state.map_data = None
+        vac = _make_vacuum(state=state)
+        vac.coordinator._room_selection_store_loaded = False
+
+        features = vac.supported_features
+
+        assert not features & VacuumEntityFeature.START
+
+    def test_stale_dock_state_keeps_live_robot_controls(self) -> None:
+        """Fresh active-task context remains controllable after a dock poll failure."""
+        state = _active_clean_state()
+        state.update_from_working_status({"3": 120})
+        vac = _make_vacuum(state=state)
+        vac.coordinator.has_fresh_state = False
+
+        features = vac.supported_features
+
+        assert features & VacuumEntityFeature.PAUSE
+        assert features & VacuumEntityFeature.STOP
+        assert features & VacuumEntityFeature.RETURN_HOME
+        assert features & VacuumEntityFeature.FAN_SPEED
+
+    def test_docked_v2_with_off_dock_fields_exposes_return_home_not_start(self) -> None:
+        state = NarwalState()
+        state.update_from_base_status({"3": {"1": 2}, "11": 1, "47": 2})
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+
+        assert vac.activity == VacuumActivity.IDLE
+        assert features & VacuumEntityFeature.RETURN_HOME
+        assert not features & VacuumEntityFeature.START
+        assert not features & VacuumEntityFeature.CLEAN_AREA
+
+    def test_active_clean_exposes_active_native_features(self) -> None:
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+
+        assert features & VacuumEntityFeature.STATE
+        assert features & VacuumEntityFeature.PAUSE
+        assert features & VacuumEntityFeature.STOP
+        assert features & VacuumEntityFeature.RETURN_HOME
+        assert features & VacuumEntityFeature.FAN_SPEED
+        assert not features & VacuumEntityFeature.START
+        assert not features & VacuumEntityFeature.CLEAN_AREA
+
+    def test_active_clean_with_unknown_mode_hides_fan_speed(self) -> None:
+        """A reconnect cannot advertise suction until the task mode is known."""
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.clean_setting_applicability_mode.side_effect = None
+        vac.coordinator.clean_setting_applicability_mode.return_value = None
+
+        assert not vac.supported_features & VacuumEntityFeature.FAN_SPEED
+
+    def test_unmapped_dock_phase_keeps_stop_during_robot_clean(self) -> None:
+        """Ambiguous station telemetry must not mask the robot's stop action."""
+        state = _active_clean_state()
+        state.dock_activity = 99
+        vac = _make_vacuum(state=state)
+
+        assert vac.supported_features & VacuumEntityFeature.STOP
+
+    def test_off_dock_dock_bag_drying_exposes_return_home(self) -> None:
+        """Dock-bag drying can continue while an off-dock robot returns home."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
+        )
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+
+        assert features & VacuumEntityFeature.RETURN_HOME
+        assert not features & VacuumEntityFeature.STOP
+
+    def test_active_clean_with_dock_bag_drying_keeps_robot_controls(self) -> None:
+        """A compatible dock task must not hide controls for an active off-dock clean."""
+        state = _active_clean_state()
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
+        )
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+
+        assert features & VacuumEntityFeature.PAUSE
+        assert features & VacuumEntityFeature.STOP
+        assert features & VacuumEntityFeature.RETURN_HOME
+        assert features & VacuumEntityFeature.LOCATE
+        assert features & VacuumEntityFeature.FAN_SPEED
+
+    def test_intermediate_mop_wash_keeps_active_clean_stop(self) -> None:
+        """Mapped station work cannot hide Stop for a current robot clean."""
+        state = _active_clean_state()
+        state.station_activity = 2
+        vac = _make_vacuum(state=state)
+
+        assert state.active_dock_task_keys == (DOCK_TASK_WASH_MOP,)
+        assert vac.supported_features & VacuumEntityFeature.STOP
+
+    def test_off_dock_mop_drying_hides_return_home(self) -> None:
+        """Mop drying still blocks return-home until hardware proves otherwise."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        state.dock_presence = 6
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+
+        assert not features & VacuumEntityFeature.RETURN_HOME
+
+    def test_stoppable_dock_task_exposes_start_features(self) -> None:
+        """Start stays exposed when it can first clear a safe dock blocker."""
+        state = _docked_state()
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+
+        assert can_prepare_clean_start(state)
+        assert features & VacuumEntityFeature.START
+        assert features & VacuumEntityFeature.CLEAN_AREA
+
+    def test_mixed_selected_room_profiles_expose_start_feature(self) -> None:
+        """Native START remains available for a valid mixed-room custom task."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=11), RoomInfo(room_id=12)],
+        )
+        vac = _make_vacuum(state=state)
+        features = vac.supported_features
+
+        assert features & VacuumEntityFeature.START
+        assert features & VacuumEntityFeature.CLEAN_AREA
+
+    def test_empty_cached_map_hides_start_feature(self) -> None:
+        """Native START is hidden when the cached map has no cleanable rooms."""
+        state = _docked_state()
+        state.map_data = MapData(map_id=2, rooms=[RoomInfo(room_id=0)])
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+
+        assert not features & VacuumEntityFeature.START
+        assert features & VacuumEntityFeature.CLEAN_AREA
+
+    def test_recent_clean_with_unstoppable_dock_task_hides_stop(self) -> None:
+        """Retained clean metrics must not expose generic stop over dry dust-bin."""
+        state = NarwalState(working_status=WorkingStatus.CHARGED)
+        state.update_from_working_status({"3": 120})
+        state.dock_presence = 1
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DUST_BIN,
+            elapsed=60,
+            target=180,
+            fields=("10", "11"),
+        )
+        vac = _make_vacuum(state=state)
+
+        features = vac.supported_features
+
+        assert not features & VacuumEntityFeature.STOP
 
 
 class TestAsyncGetSegments:
@@ -311,11 +662,13 @@ class TestAsyncCleanSegments:
 
         assert "Room clean failed" not in caplog.text
 
-    async def test_rejects_room_clean_when_dock_task_is_active(self) -> None:
-        """Room clean requests are blocked before dispatch during dock work."""
+    async def test_rejects_room_clean_when_start_planner_fails(self) -> None:
+        """Room clean requests are blocked when the start planner fails closed."""
         state = _docked_state()
+        state.map_data = MapData(map_id=2, rooms=[RoomInfo(room_id=11)])
         state.station_activity = 1
         vac = _make_vacuum(state=state)
+        vac.coordinator.async_prepare_clean_start = AsyncMock(return_value=False)
         vac.coordinator.client.robot_awake = True
         vac.coordinator.client.start_rooms = AsyncMock()
 
@@ -323,6 +676,7 @@ class TestAsyncCleanSegments:
             await vac.async_clean_segments(["11"])
 
         vac.coordinator.client.start_rooms.assert_not_awaited()
+        vac.coordinator.async_prepare_clean_start.assert_awaited_once()
 
     async def test_accepted_room_clean_reserves_robot_start_context(self) -> None:
         """Accepted room-start commands block immediate dock starts."""
@@ -366,6 +720,62 @@ class TestAsyncCleanSegments:
             vac.coordinator.client.start_rooms.await_args.kwargs["room_settings"]
             == room_settings
         )
+
+    async def test_mixed_segment_modes_prepare_dock_then_start(self) -> None:
+        """A mixed-room custom task uses the normal dock-start preparation path."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=11), RoomInfo(room_id=12)],
+        )
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        room_settings = {
+            11: RoomCleanSettings(work_mode=WorkMode.MOP),
+            12: RoomCleanSettings(work_mode=WorkMode.VACUUM),
+        }
+        vac.coordinator.room_clean_settings_for_rooms = MagicMock(
+            return_value=room_settings
+        )
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_clean_segments(["11", "12"])
+
+        vac.coordinator.async_prepare_clean_start.assert_awaited_once()
+        assert (
+            vac.coordinator.client.start_rooms.await_args.kwargs["room_settings"]
+            == room_settings
+        )
+
+    async def test_segment_clean_without_map_fails_before_dock_prepare(self) -> None:
+        """Segment commands do not use stale HA segment cache as command input."""
+        state = _docked_state()
+        state.map_data = None
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+        vac = _make_vacuum(state=state)
+        vac.last_seen_segments = [Segment(id="11", name="Bathroom")]
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.get_map = AsyncMock()
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="Narwal map is not available"):
+            await vac.async_clean_segments(["11"])
+
+        vac.coordinator.async_prepare_clean_start.assert_not_awaited()
+        vac.coordinator.client.start_rooms.assert_not_awaited()
 
     async def test_rejected_room_clean_raises_service_error(self) -> None:
         """Rejected clean/start_clean responses fail the HA service call."""
@@ -489,6 +899,8 @@ class TestDockTaskRobotActionGates:
         state = NarwalState(working_status=WorkingStatus.CLEANING)
         vac = _make_vacuum(state)
         vac.coordinator.active_clean_work_mode = None
+        vac.coordinator.clean_setting_applicability_mode.side_effect = None
+        vac.coordinator.clean_setting_applicability_mode.return_value = None
 
         assert not vac.supported_features & VacuumEntityFeature.FAN_SPEED
 
@@ -530,12 +942,28 @@ class TestDockTaskRobotActionGates:
     def test_active_dock_task_hides_robot_actions(self) -> None:
         vac = self._active_dock_vacuum()
 
-        assert not vac.supported_features & VacuumEntityFeature.START
+        # Start remains available because the vacuum contract can stop this
+        # task during preflight before dispatching the clean.
+        assert vac.supported_features & VacuumEntityFeature.START
         assert not vac.supported_features & VacuumEntityFeature.STOP
         assert not vac.supported_features & VacuumEntityFeature.PAUSE
         assert not vac.supported_features & VacuumEntityFeature.RETURN_HOME
         assert not vac.supported_features & VacuumEntityFeature.LOCATE
-        assert not vac.supported_features & VacuumEntityFeature.CLEAN_AREA
+        assert vac.supported_features & VacuumEntityFeature.CLEAN_AREA
+
+    async def test_intermediate_emptying_hides_and_rejects_pause(self) -> None:
+        """Fresh emptying telemetry wins over recent robot clean counters."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.update_from_working_status({"3": 60})
+        state.station_activity = 1
+        vac = _make_vacuum(state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.pause = AsyncMock()
+
+        assert not vac.supported_features & VacuumEntityFeature.PAUSE
+        with pytest.raises(HomeAssistantError):
+            await vac.async_pause()
+        vac.coordinator.client.pause.assert_not_awaited()
 
     @pytest.mark.parametrize(
         ("method_name", "client_method"),
@@ -554,10 +982,22 @@ class TestDockTaskRobotActionGates:
         command = AsyncMock()
         setattr(vac.coordinator.client, client_method, command)
 
-        with pytest.raises(HomeAssistantError, match="Narwal dock task is active"):
+        with pytest.raises(HomeAssistantError):
             await getattr(vac, method_name)()
 
         command.assert_not_awaited()
+
+    async def test_locate_aborts_when_action_status_refresh_fails(self) -> None:
+        """Locate cannot race dock work from a stale idle snapshot."""
+        vac = _make_vacuum(_docked_state())
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.async_refresh_action_status = AsyncMock(return_value=False)
+        vac.coordinator.client.locate = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="status could not be refreshed"):
+            await vac.async_locate()
+
+        vac.coordinator.client.locate.assert_not_awaited()
 
 
 class TestVacuumFanSpeed:
@@ -583,11 +1023,65 @@ class TestVacuumFanSpeed:
 
         assert vac.coordinator.clean_settings.fan == FanLevel.UNSPECIFIED
 
+    async def test_restore_raw_fan_value_survives_label_rename(self) -> None:
+        """Versioned restore data takes precedence over the display label."""
+        vac = _make_vacuum(state=_docked_state())
+        extra = FanSettingRestoreData(value=int(FanLevel.SUPER))
+
+        with (
+            patch.object(
+                vac, "async_get_last_extra_data", AsyncMock(return_value=extra)
+            ),
+            patch.object(
+                vac,
+                "async_get_last_state",
+                AsyncMock(return_value=MagicMock(attributes={"fan_speed": "Ultra"})),
+            ),
+        ):
+            await vac.async_added_to_hass()
+
+        assert vac.coordinator.clean_settings.fan == FanLevel.SUPER
+
+    async def test_restore_clamps_level_five_on_four_tier_model(self) -> None:
+        """A stale persisted tier cannot leave an unsupported pending value."""
+        vac = _make_vacuum(state=_docked_state())
+        vac.coordinator.config_entry.data["product_key"] = "qV6BujoYLz"
+        extra = FanSettingRestoreData(value=int(FanLevel.SUPER))
+
+        with patch.object(
+            vac, "async_get_last_extra_data", AsyncMock(return_value=extra)
+        ):
+            await vac.async_added_to_hass()
+
+        assert vac.coordinator.clean_settings.fan == FanLevel.DEEP
+        assert vac.fan_speed == "Super Powerful"
+
+    async def test_unversioned_ultra_preserves_level(self) -> None:
+        """An unversioned Ultra state restores its existing enum 5 meaning."""
+        vac = _make_vacuum(state=_docked_state())
+
+        with patch.object(
+            vac,
+            "async_get_last_state",
+            AsyncMock(return_value=MagicMock(attributes={"fan_speed": "Ultra"})),
+        ):
+            await vac.async_added_to_hass()
+
+        assert vac.coordinator.clean_settings.fan == FanLevel.SUPER
+
+    def test_fan_restore_data_records_stable_robot_value(self) -> None:
+        vac = _make_vacuum(state=_docked_state())
+        vac.coordinator.clean_settings.fan = FanLevel.DEEP
+
+        assert vac.extra_restore_state_data.as_dict() == {
+            "version": 1,
+            "value": int(FanLevel.DEEP),
+        }
+
     async def test_live_fan_change_applies_while_paused(self) -> None:
         state = _active_clean_state()
         state.is_paused = True
         vac = _make_vacuum(state=state)
-        vac.coordinator.active_clean_work_mode = WorkMode.VACUUM
         vac.coordinator.client.set_fan_speed = AsyncMock(
             return_value=CommandResponse(result_code=0)
         )
@@ -680,6 +1174,30 @@ class TestVacuumFanSpeed:
 
         vac.coordinator.client.set_fan_speed.assert_not_awaited()
 
+    async def test_live_fan_change_rejects_unknown_active_mode(self) -> None:
+        """A reconnect must not expose suction without the active task mode."""
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.clean_setting_applicability_mode.side_effect = None
+        vac.coordinator.clean_setting_applicability_mode.return_value = None
+        vac.coordinator.client.set_fan_speed = AsyncMock()
+
+        with pytest.raises(Exception, match="fan speed cannot be changed|mop-only"):
+            await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_not_awaited()
+
+    async def test_unknown_fan_speed_raises(self) -> None:
+        """Unsupported suction labels must not silently no-op."""
+        state = NarwalState(working_status=WorkingStatus.CHARGED)
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.set_fan_speed = AsyncMock()
+
+        with pytest.raises(Exception, match="Unsupported Narwal fan speed"):
+            await vac.async_set_fan_speed("Turbo")
+
+        vac.coordinator.client.set_fan_speed.assert_not_awaited()
+
     async def test_fan_change_rejected_in_mop_only_mode(self) -> None:
         state = _active_clean_state()
         vac = _make_vacuum(state=state)
@@ -694,7 +1212,6 @@ class TestVacuumFanSpeed:
     async def test_rejected_live_fan_change_does_not_update_settings(self) -> None:
         state = _active_clean_state()
         vac = _make_vacuum(state=state)
-        vac.coordinator.active_clean_work_mode = WorkMode.VACUUM
         vac.coordinator.client.set_fan_speed = AsyncMock(
             return_value=CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
         )
@@ -737,6 +1254,53 @@ class TestCheckSegmentChanges:
 
         vac.async_create_segments_issue.assert_called_once()
 
+    def test_segment_change_reports_once_per_signature(self) -> None:
+        """Repeated coordinator updates for one mismatch do not spam repairs/logs."""
+        rooms_old = [
+            Segment(id="1", name="Kitchen"),
+            Segment(id="2", name="Bathroom"),
+        ]
+        rooms_new = [
+            RoomInfo(room_id=1, name="Kitchen", room_sub_type=4, category=1),
+            RoomInfo(room_id=3, name="Study", room_sub_type=5, category=1),
+        ]
+        state = NarwalState()
+        state.map_data = MapData(rooms=rooms_new)
+        vac = _make_vacuum(state=state)
+        vac.last_seen_segments = rooms_old
+
+        vac._check_segment_changes()
+        vac._check_segment_changes()
+
+        vac.async_create_segments_issue.assert_called_once()
+
+    def test_segment_change_reports_again_after_matching_snapshot(self) -> None:
+        """A resolved mismatch clears the debounce for future room changes."""
+        rooms_old = [
+            Segment(id="1", name="Kitchen"),
+            Segment(id="2", name="Bathroom"),
+        ]
+        changed = [
+            RoomInfo(room_id=1, name="Kitchen", room_sub_type=4, category=1),
+            RoomInfo(room_id=3, name="Study", room_sub_type=5, category=1),
+        ]
+        matching = [
+            RoomInfo(room_id=1, name="Kitchen", room_sub_type=4, category=1),
+            RoomInfo(room_id=2, name="Bathroom", room_sub_type=6, category=1),
+        ]
+        state = NarwalState()
+        state.map_data = MapData(rooms=changed)
+        vac = _make_vacuum(state=state)
+        vac.last_seen_segments = rooms_old
+
+        vac._check_segment_changes()
+        state.map_data = MapData(rooms=matching)
+        vac._check_segment_changes()
+        state.map_data = MapData(rooms=changed)
+        vac._check_segment_changes()
+
+        assert vac.async_create_segments_issue.call_count == 2
+
     def test_no_change_when_same_rooms(self) -> None:
         """Does NOT call async_create_segments_issue when rooms match."""
         rooms_old = [
@@ -771,12 +1335,10 @@ class TestCheckSegmentChanges:
 class TestAsyncStartWholeHouse:
     """async_start runs a room-selection aware clean via clean/start_clean."""
 
-    async def test_paused_returning_standby_resumes_existing_clean(self) -> None:
-        """Paused return context takes precedence over a stale status enum."""
-        state = NarwalState(working_status=WorkingStatus.CLEANING)
+    async def test_paused_standby_resumes_existing_clean(self) -> None:
+        """Retained paused task context takes precedence over a stale status enum."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
         state.is_paused = True
-        state.is_returning_to_dock = True
-        state.dock_sub_state = 2
         state.task_elapsed_time = 60
         state.dock_presence = 2
         vac = _make_vacuum(state=state)
@@ -915,6 +1477,7 @@ class TestAsyncStartWholeHouse:
             rooms=[RoomInfo(room_id=1), RoomInfo(room_id=2)],
         )
         vac = _make_vacuum(state=state)
+        vac.coordinator.has_selected_clean_rooms.return_value = True
         vac.coordinator.selected_clean_room_ids_for = MagicMock(return_value=[2])
         vac.coordinator.client.robot_awake = True
         vac.coordinator.client.start_rooms = AsyncMock(
@@ -1006,17 +1569,48 @@ class TestAsyncStartWholeHouse:
         )
         assert vac.coordinator.client.start_rooms.await_args.args[0] == [5]
 
-    async def test_whole_house_start_passes_room_profiles(self) -> None:
-        """Whole-house start uses room-specific profiles for each room."""
+    async def test_start_rejects_stale_room_selection(self) -> None:
+        """A vanished selected room must not expand into a whole-map clean."""
         state = _docked_state()
         state.map_data = MapData(
             map_id=2,
             rooms=[RoomInfo(room_id=1), RoomInfo(room_id=2)],
         )
-        profile = RoomCleanSettings(fan=FanLevel.STRONG)
+        vac = _make_vacuum(state=state)
+        vac.coordinator.selected_clean_rooms = {None: {99}}
+        vac.coordinator.room_settings_map_id.return_value = None
+        vac.coordinator.selected_clean_room_ids_for = MagicMock(
+            side_effect=lambda room_ids, **kwargs: (
+                NarwalCoordinator.selected_clean_room_ids_for(
+                    vac.coordinator,
+                    room_ids,
+                    **kwargs,
+                )
+            )
+        )
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="selection is not available"):
+            await vac.async_start()
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+        assert vac.coordinator.selected_clean_rooms == {None: {99}}
+
+    async def test_whole_house_start_preserves_room_profiles(self) -> None:
+        """No room selection still applies each configured room profile."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=1), RoomInfo(room_id=2)],
+        )
+        profiles = {
+            1: RoomCleanSettings(work_mode=WorkMode.VACUUM, fan=FanLevel.STRONG),
+            2: RoomCleanSettings(work_mode=WorkMode.MOP, water=MopHumidity.WET),
+        }
         vac = _make_vacuum(state=state)
         vac.coordinator.room_clean_settings_for_rooms = MagicMock(
-            return_value={1: profile, 2: RoomCleanSettings()}
+            return_value=profiles
         )
         vac.coordinator.client.robot_awake = True
         vac.coordinator.client.start_rooms = AsyncMock(
@@ -1025,13 +1619,65 @@ class TestAsyncStartWholeHouse:
 
         await vac.async_start()
 
+        vac.coordinator.room_clean_settings_for_rooms.assert_called_once_with(
+            [1, 2], map_id=vac.coordinator.room_settings_map_id.return_value
+        )
         kwargs = vac.coordinator.client.start_rooms.await_args.kwargs
-        assert kwargs["room_settings"] == {1: profile, 2: RoomCleanSettings()}
+        assert kwargs["room_settings"] == profiles
+
+    async def test_start_refreshes_action_status_before_resume(self) -> None:
+        """Resume uses the action refresh path before deciding the command."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.is_paused = True
+        state.task_progress_percent = 40
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.resume = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        await vac.async_start()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.resume.assert_awaited_once()
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_start_aborts_when_action_status_refresh_fails(self) -> None:
+        """Start cannot route from a stale robot snapshot."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.is_paused = True
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.async_refresh_action_status = AsyncMock(return_value=False)
+        vac.coordinator.client.resume = AsyncMock()
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="status could not be refreshed"):
+            await vac.async_start()
+
+        vac.coordinator.client.resume.assert_not_awaited()
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_start_aborts_when_map_refresh_fails(self) -> None:
+        """A cached whole-floor map cannot authorize a new clean."""
+        state = _docked_state()
+        state.map_data = MapData(map_id=2, rooms=[RoomInfo(room_id=1)])
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.get_map = AsyncMock(side_effect=RuntimeError("offline"))
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="map could not be refreshed"):
+            await vac.async_start()
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
 
     async def test_whole_house_without_map_raises(self) -> None:
         """With no map rooms available, no ambiguous start command is sent."""
         state = _docked_state()  # no map_data
         vac = _make_vacuum(state=state)
+        vac.last_seen_segments = [Segment(id="1", name="Bedroom")]
         vac.coordinator.client.robot_awake = True
         vac.coordinator.client.get_map = AsyncMock()  # does not populate map_data
         vac.coordinator.client.start = AsyncMock(
@@ -1044,6 +1690,7 @@ class TestAsyncStartWholeHouse:
 
         vac.coordinator.client.start.assert_not_awaited()
         vac.coordinator.client.start_rooms.assert_not_called()
+        vac.coordinator.async_prepare_clean_start.assert_not_awaited()
 
     async def test_rejected_whole_house_start_raises_service_error(self) -> None:
         """Rejected whole-house starts fail the HA service call."""
@@ -1057,6 +1704,40 @@ class TestAsyncStartWholeHouse:
 
         with pytest.raises(HomeAssistantError, match="Narwal start command failed"):
             await vac.async_start()
+
+    async def test_mixed_whole_house_modes_prepare_dock_then_start(self) -> None:
+        """Whole-house custom profiles use the normal dock preparation path."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=11), RoomInfo(room_id=12)],
+        )
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        room_settings = {
+            11: RoomCleanSettings(work_mode=WorkMode.MOP),
+            12: RoomCleanSettings(work_mode=WorkMode.VACUUM),
+        }
+        vac.coordinator.room_clean_settings_for_rooms = MagicMock(
+            return_value=room_settings
+        )
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_start()
+
+        vac.coordinator.async_prepare_clean_start.assert_awaited_once()
+        assert (
+            vac.coordinator.client.start_rooms.await_args.kwargs["room_settings"]
+            == room_settings
+        )
 
 
 async def test_fan_restore_prefers_pending_value_over_active_room_display() -> None:
@@ -1109,7 +1790,41 @@ class TestAsyncStop:
 
         vac.coordinator.client.stop.assert_awaited_once()
 
-    async def test_stop_routes_dock_only_task_through_dock_policy(self) -> None:
+    def test_stale_clean_metrics_do_not_expose_robot_stop_during_station_task(
+        self,
+    ) -> None:
+        """Late clean counters cannot make vacuum STOP target dock work."""
+        for station_activity, dock_activity, task in (
+            (1, 0, DOCK_TASK_EMPTY_DUSTBIN),
+            (2, 0, DOCK_TASK_WASH_MOP),
+            (0, 3, DOCK_TASK_WASH_MOP),
+        ):
+            state = _docked_state()
+            state.station_activity = station_activity
+            state.dock_activity = dock_activity
+            state.update_from_working_status({"3": 120})
+            vac = _make_vacuum(state=state)
+
+            assert state.active_dock_task_keys == (task,)
+            assert not vac.supported_features & VacuumEntityFeature.STOP
+
+    async def test_old_firmware_wash_rejects_vacuum_stop(self) -> None:
+        """A field 3.12 wash signal cannot make vacuum STOP target dock work."""
+        state = _docked_state()
+        state.dock_activity = 3
+        state.update_from_working_status({"3": 120})
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock()
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="no active robot task"):
+            await vac.async_stop()
+
+        vac.coordinator.client.stop.assert_not_awaited()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_stop_rejects_dock_only_task(self) -> None:
         state = NarwalState(working_status=WorkingStatus.DOCKED)
         state.dock_presence = 6
         state.set_dock_drying_task(
@@ -1121,14 +1836,80 @@ class TestAsyncStop:
         vac = _make_vacuum(state=state)
         vac.coordinator.client.robot_awake = True
         vac.coordinator.client.stop = AsyncMock()
-        vac.coordinator.client.stop_dock_task = AsyncMock(
-            return_value=CommandResponse(result_code=0)
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="no active robot task"):
+            await vac.async_stop()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.stop.assert_not_awaited()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_stop_routes_active_clean_with_dock_bag_to_robot_stop(self) -> None:
+        """Drying the dock bag does not make robot STOP ambiguous while cleaning."""
+        state = _active_clean_state()
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DOCK_BAG,
+            elapsed=60,
+            target=180,
+            fields=("12", "13"),
         )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+        vac.coordinator.client.stop_dock_task = AsyncMock()
 
         await vac.async_stop()
 
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.stop.assert_awaited_once()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_stop_routes_active_clean_with_mop_wash_to_robot_stop(self) -> None:
+        """Stop cancels the clean, not its mapped intermediate station phase."""
+        state = _active_clean_state()
+        state.station_activity = 2
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        await vac.async_stop()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.stop.assert_awaited_once()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_stop_rejects_refresh_transition_to_dock_only_work(self) -> None:
+        """Vacuum STOP cannot cross the robot/dock boundary after a refresh."""
+        vac = _make_vacuum(state=_active_clean_state())
+        vac.coordinator.client.robot_awake = True
+        docked = _docked_state()
+        docked.set_dock_drying_task(
+            DOCK_TASK_DRY_MOP,
+            elapsed=60,
+            target=180,
+            fields=("8", "9"),
+        )
+
+        async def refresh() -> bool:
+            vac.coordinator.client.state = docked
+            return True
+
+        vac.coordinator.async_refresh_action_status = AsyncMock(side_effect=refresh)
+        vac.coordinator.client.stop = AsyncMock()
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        assert vac.supported_features & VacuumEntityFeature.STOP
+        with pytest.raises(HomeAssistantError, match="no active robot task"):
+            await vac.async_stop()
+
         vac.coordinator.client.stop.assert_not_awaited()
-        vac.coordinator.client.stop_dock_task.assert_awaited_once_with()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
 
     async def test_stop_rejects_ambiguous_dock_only_task(self) -> None:
         state = NarwalState(working_status=WorkingStatus.DOCKED)
@@ -1150,15 +1931,17 @@ class TestAsyncStop:
         vac.coordinator.client.stop = AsyncMock()
         vac.coordinator.client.stop_dock_task = AsyncMock()
 
-        with pytest.raises(HomeAssistantError, match="cannot be stopped safely"):
+        with pytest.raises(HomeAssistantError, match="no active robot task"):
             await vac.async_stop()
 
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
         vac.coordinator.client.stop.assert_not_awaited()
         vac.coordinator.client.stop_dock_task.assert_not_awaited()
 
     async def test_stop_preserves_robot_stop_during_unmapped_dock_activity(self) -> None:
         """An unmapped dock phase must not hide stop for a real robot clean."""
         state = NarwalState(working_status=WorkingStatus.CLEANING)
+
         state.dock_activity = 99
         vac = _make_vacuum(state=state)
         vac.coordinator.client.robot_awake = True
@@ -1169,5 +1952,256 @@ class TestAsyncStop:
 
         await vac.async_stop()
 
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
         vac.coordinator.client.stop.assert_awaited_once()
         vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_stop_rejects_dry_dust_task(self) -> None:
+        state = NarwalState(working_status=WorkingStatus.DOCKED)
+        state.dock_presence = 6
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DUST_BIN,
+            elapsed=60,
+            target=180,
+            fields=("10", "11"),
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock()
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="no active robot task"):
+            await vac.async_stop()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.stop.assert_not_awaited()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_stop_rejects_recent_clean_with_unstoppable_dry_dust(self) -> None:
+        """Recent clean metrics must not route dry dust-bin through generic stop."""
+        state = NarwalState(working_status=WorkingStatus.CHARGED)
+        state.update_from_working_status({"3": 120})
+        state.dock_presence = 1
+        state.set_dock_drying_task(
+            DOCK_TASK_DRY_DUST_BIN,
+            elapsed=60,
+            target=180,
+            fields=("10", "11"),
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock()
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="no active robot task"):
+            await vac.async_stop()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.stop.assert_not_awaited()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_stop_rejects_unmapped_dock_only_task(self) -> None:
+        state = NarwalState(working_status=WorkingStatus.DOCKED)
+        state.dock_presence = 6
+        state.dock_activity = 99
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock()
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="no active robot task"):
+            await vac.async_stop()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.stop.assert_not_awaited()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_stop_rejects_unmapped_task_with_late_clean_metrics(self) -> None:
+        """Late terminal counters cannot route an unknown station force-end."""
+        state = NarwalState(working_status=WorkingStatus.CHARGED)
+        state.update_from_working_status({"3": 120})
+        state.dock_presence = 6
+        state.dock_activity = 99
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock()
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="no active robot task"):
+            await vac.async_stop()
+
+        vac.coordinator.client.stop.assert_not_awaited()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_robot_stop_refreshes_action_status_before_stop(self) -> None:
+        """Robot stop revalidates active task status under the action lock."""
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_stop()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.stop.assert_awaited_once()
+
+    async def test_stop_aborts_when_action_status_refresh_fails(self) -> None:
+        """A stale snapshot cannot choose between robot and dock force-end."""
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.async_refresh_action_status = AsyncMock(return_value=False)
+        vac.coordinator.client.stop = AsyncMock()
+        vac.coordinator.client.stop_dock_task = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="status could not be refreshed"):
+            await vac.async_stop()
+
+        vac.coordinator.client.stop.assert_not_awaited()
+        vac.coordinator.client.stop_dock_task.assert_not_awaited()
+
+    async def test_pause_refreshes_action_status_before_pause(self) -> None:
+        """Pause revalidates active task status under the action lock."""
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.pause = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_pause()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.pause.assert_awaited_once()
+
+    async def test_pause_aborts_when_action_status_refresh_fails(self) -> None:
+        """Pause cannot use stale clean state after a failed refresh."""
+        vac = _make_vacuum(state=_active_clean_state())
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.async_refresh_action_status = AsyncMock(return_value=False)
+        vac.coordinator.client.pause = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="status could not be refreshed"):
+            await vac.async_pause()
+
+        vac.coordinator.client.pause.assert_not_awaited()
+
+    async def test_return_home_refreshes_action_status_before_return(self) -> None:
+        """Return-to-base revalidates dock and robot status under the action lock."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.return_to_base = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_return_to_base()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.return_to_base.assert_awaited_once()
+
+    async def test_return_home_refreshes_then_noops_when_already_docked(self) -> None:
+        """An unconditional return-home automation confirms the idle dock first."""
+        vac = _make_vacuum(state=_docked_state())
+        vac.coordinator.client.return_to_base = AsyncMock()
+
+        await vac.async_return_to_base()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.return_to_base.assert_not_awaited()
+
+    async def test_return_home_detects_external_start_after_cached_dock(self) -> None:
+        """A cached dock snapshot cannot hide a clean started outside HA."""
+        vac = _make_vacuum(state=_docked_state())
+        vac.coordinator.client.robot_awake = True
+        off_dock = NarwalState(working_status=WorkingStatus.CLEANING)
+
+        async def refresh() -> bool:
+            vac.coordinator.client.state = off_dock
+            return True
+
+        vac.coordinator.async_refresh_action_status = AsyncMock(side_effect=refresh)
+        vac.coordinator.client.return_to_base = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_return_to_base()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.return_to_base.assert_awaited_once()
+
+    async def test_return_home_refreshes_stale_cached_dock_state(self) -> None:
+        """A stale dock snapshot cannot suppress a required return command."""
+        vac = _make_vacuum(state=_docked_state())
+        vac.coordinator.has_fresh_state = False
+        vac.coordinator.client.robot_awake = True
+        off_dock = NarwalState(working_status=WorkingStatus.STANDBY)
+
+        async def refresh() -> bool:
+            vac.coordinator.client.state = off_dock
+            return True
+
+        vac.coordinator.async_refresh_action_status = AsyncMock(side_effect=refresh)
+        vac.coordinator.client.return_to_base = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_return_to_base()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.return_to_base.assert_awaited_once()
+
+    async def test_return_home_refreshes_assumed_clean_from_docked_state(self) -> None:
+        """An accepted start cannot be mistaken for an idle dock no-op."""
+        cached = _docked_state()
+        cached.assume_robot_clean()
+        vac = _make_vacuum(state=cached)
+        vac.coordinator.client.robot_awake = True
+        off_dock = NarwalState(working_status=WorkingStatus.CLEANING)
+
+        async def refresh() -> bool:
+            vac.coordinator.client.state = off_dock
+            return True
+
+        vac.coordinator.async_refresh_action_status = AsyncMock(side_effect=refresh)
+        vac.coordinator.client.return_to_base = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_return_to_base()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.return_to_base.assert_awaited_once()
+
+    async def test_return_home_is_noop_when_refresh_discovers_docked(self) -> None:
+        """A state transition to idle-docked still satisfies return-home."""
+        vac = _make_vacuum(state=NarwalState(working_status=WorkingStatus.STANDBY))
+        vac.coordinator.client.robot_awake = True
+        docked = _docked_state()
+
+        async def refresh() -> bool:
+            vac.coordinator.client.state = docked
+            return True
+
+        vac.coordinator.async_refresh_action_status = AsyncMock(side_effect=refresh)
+        vac.coordinator.client.return_to_base = AsyncMock()
+
+        await vac.async_return_to_base()
+
+        vac.coordinator.async_refresh_action_status.assert_awaited_once()
+        vac.coordinator.client.return_to_base.assert_not_awaited()
+
+    async def test_return_home_aborts_when_action_status_refresh_fails(self) -> None:
+        """Return-to-base cannot use stale dock state after a failed refresh."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.async_refresh_action_status = AsyncMock(return_value=False)
+        vac.coordinator.client.return_to_base = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="status could not be refreshed"):
+            await vac.async_return_to_base()
+
+        vac.coordinator.client.return_to_base.assert_not_awaited()

--- a/tests/test_vacuum_segments.py
+++ b/tests/test_vacuum_segments.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -18,12 +18,24 @@ import tests.ha_stubs  # noqa: E402
 
 tests.ha_stubs.install()
 
-from homeassistant.components.vacuum import VacuumEntityFeature  # noqa: E402
 from homeassistant.exceptions import HomeAssistantError  # noqa: E402
 
-from custom_components.narwal.coordinator import CleanSettings  # noqa: E402
-from custom_components.narwal.vacuum import NarwalVacuum  # noqa: E402
-from narwal_client.const import CommandResult, WorkingStatus  # noqa: E402
+from custom_components.narwal.coordinator import (  # noqa: E402
+    CleanSettings,
+    NarwalCoordinator,
+    is_clean_session_context,
+)
+from custom_components.narwal.vacuum import (  # noqa: E402
+    FanSettingRestoreData,
+    NarwalVacuum,
+)
+from narwal_client import RoomCleanSettings  # noqa: E402
+from narwal_client.const import (  # noqa: E402
+    CommandResult,
+    FanLevel,
+    WorkingStatus,
+    WorkMode,
+)
 from narwal_client.models import (  # noqa: E402
     DOCK_TASK_DRY_DOCK_BAG,
     DOCK_TASK_DRY_MOP,
@@ -34,6 +46,7 @@ from narwal_client.models import (  # noqa: E402
 )
 
 Segment = sys.modules["homeassistant.components.vacuum"].Segment
+VacuumEntityFeature = sys.modules["homeassistant.components.vacuum"].VacuumEntityFeature
 
 
 def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
@@ -50,8 +63,38 @@ def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
     coordinator.client.get_map = AsyncMock(return_value=client_state.map_data)
     coordinator.last_update_success = True
     coordinator.clean_settings = CleanSettings()
+    coordinator.active_clean_work_mode = None
+    coordinator.active_clean_setting.return_value = None
+    coordinator.has_selected_clean_rooms.return_value = False
     coordinator.async_refresh_dock_status = AsyncMock(return_value=True)
     coordinator.dock_action_lock = asyncio.Lock()
+    coordinator.room_clean_settings_for_rooms = MagicMock(
+        side_effect=lambda room_ids, **_kwargs: {
+            room_id: RoomCleanSettings() for room_id in room_ids
+        }
+    )
+    coordinator.selected_clean_room_ids_for = MagicMock(
+        side_effect=lambda room_ids, **_kwargs: list(room_ids)
+    )
+    coordinator.shared_room_clean_work_mode = MagicMock(
+        side_effect=lambda room_settings: next(
+            iter({settings.work_mode for settings in room_settings.values()}), None
+        )
+    )
+    coordinator.record_accepted_clean_start = MagicMock(
+        side_effect=lambda room_settings: setattr(
+            coordinator,
+            "active_clean_work_mode",
+            next(iter({settings.work_mode for settings in room_settings.values()})),
+        )
+    )
+    coordinator.clean_setting_applicability_mode = MagicMock(
+        side_effect=lambda live=False: (
+            coordinator.active_clean_work_mode
+            if live and is_clean_session_context(coordinator.data)
+            else coordinator.clean_settings.work_mode
+        )
+    )
 
     vac = NarwalVacuum.__new__(NarwalVacuum)
     vac.coordinator = coordinator
@@ -64,6 +107,13 @@ def _make_vacuum(state: NarwalState | None = None) -> NarwalVacuum:
     vac.async_write_ha_state = MagicMock()
 
     return vac
+
+
+def _active_clean_state() -> NarwalState:
+    """Return a state whose working_status still looks like active cleaning."""
+    state = NarwalState()
+    state.working_status = WorkingStatus.CLEANING_ALT
+    return state
 
 
 def _docked_state() -> NarwalState:
@@ -210,6 +260,40 @@ class TestAsyncCleanSegments:
             water=settings.water,
             mop_strength=settings.mop_strength,
             passes=settings.passes,
+            route=settings.route,
+            room_settings={
+                11: RoomCleanSettings(),
+                9: RoomCleanSettings(),
+            },
+        )
+        assert state.has_assumed_robot_clean
+        vac.async_write_ha_state.assert_called_once()
+
+    async def test_deduplicates_segment_ids_without_changing_order(self) -> None:
+        """Repeated HA segment IDs produce one ordered clean item per room."""
+        state = _docked_state()
+        state.map_data = MapData(rooms=[RoomInfo(room_id=11), RoomInfo(room_id=9)])
+        vac = _make_vacuum(state=state)
+        settings = vac.coordinator.clean_settings
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+        vac.coordinator.client.robot_awake = True
+
+        await vac.async_clean_segments(["11", "9", "11"])
+
+        vac.coordinator.client.start_rooms.assert_awaited_once_with(
+            [11, 9],
+            work_mode=settings.work_mode,
+            fan=settings.fan,
+            water=settings.water,
+            mop_strength=settings.mop_strength,
+            passes=settings.passes,
+            route=settings.route,
+            room_settings={
+                11: RoomCleanSettings(),
+                9: RoomCleanSettings(),
+            },
         )
 
     async def test_segment_clean_accepted_response_does_not_warn(self, caplog) -> None:
@@ -253,6 +337,35 @@ class TestAsyncCleanSegments:
         await vac.async_clean_segments(["11"])
 
         assert state.has_assumed_robot_clean
+        vac.coordinator.record_accepted_clean_start.assert_called_once()
+
+    async def test_mixed_room_modes_start_as_one_custom_task(self) -> None:
+        """Mixed room profiles dispatch together without flattening their modes."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=11), RoomInfo(room_id=12)],
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        room_settings = {
+            11: RoomCleanSettings(work_mode=WorkMode.MOP),
+            12: RoomCleanSettings(work_mode=WorkMode.VACUUM),
+        }
+        vac.coordinator.room_clean_settings_for_rooms = MagicMock(
+            return_value=room_settings
+        )
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_clean_segments(["11", "12"])
+
+        vac.coordinator.client.start_rooms.assert_awaited_once()
+        assert (
+            vac.coordinator.client.start_rooms.await_args.kwargs["room_settings"]
+            == room_settings
+        )
 
     async def test_rejected_room_clean_raises_service_error(self) -> None:
         """Rejected clean/start_clean responses fail the HA service call."""
@@ -274,7 +387,7 @@ class TestAsyncCleanSegments:
         vac = _make_vacuum(state=state)
         vac.coordinator.client.robot_awake = True
         vac.coordinator.client.start_rooms = AsyncMock(
-            return_value=MagicMock(result_code=0, success=True)
+            return_value=CommandResponse(result_code=0)
         )
         await vac.coordinator.dock_action_lock.acquire()
 
@@ -331,23 +444,75 @@ class TestAsyncCleanSegments:
         vac.coordinator.client.get_map.assert_awaited_once()
         vac.coordinator.client.start_rooms.assert_awaited_once()
 
+    async def test_segment_validation_rejects_failed_map_refresh(self) -> None:
+        """A cached room cannot authorize cleaning after refresh failure."""
+        state = _docked_state()
+        state.map_data = MapData(map_id=2, rooms=[RoomInfo(room_id=11)])
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.get_map = AsyncMock(side_effect=RuntimeError("offline"))
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="map could not be refreshed"):
+            await vac.async_clean_segments(["11"])
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
     async def test_empty_cached_room_table_defers_validation_to_client(self) -> None:
         """A payloadless cached map must not reject every known HA segment."""
         state = _docked_state()
         state.map_data = MapData()
         vac = _make_vacuum(state=state)
         vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.get_map = AsyncMock(
+            side_effect=lambda: setattr(
+                state,
+                "map_data",
+                MapData(map_id=2, rooms=[RoomInfo(room_id=11)]),
+            )
+        )
         vac.coordinator.client.start_rooms = AsyncMock(
             return_value=CommandResponse(result_code=CommandResult.SUCCESS)
         )
 
         await vac.async_clean_segments(["11"])
 
+        vac.coordinator.client.get_map.assert_awaited_once()
         vac.coordinator.client.start_rooms.assert_awaited_once()
 
 
 class TestDockTaskRobotActionGates:
     """Dock work must not leak unsafe robot controls through the vacuum."""
+
+    def test_unknown_active_mode_hides_native_fan_control(self) -> None:
+        """A reload cannot advertise suction before task mode is reconstructed."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        vac = _make_vacuum(state)
+        vac.coordinator.active_clean_work_mode = None
+
+        assert not vac.supported_features & VacuumEntityFeature.FAN_SPEED
+
+    def test_idle_mop_mode_hides_native_fan_control(self) -> None:
+        """Feature advertisement matches the pending fan command handler."""
+        vac = _make_vacuum(_docked_state())
+        vac.coordinator.clean_settings.work_mode = WorkMode.MOP
+
+        assert not vac.supported_features & VacuumEntityFeature.FAN_SPEED
+
+    def test_selected_rooms_hide_pending_native_fan_control(self) -> None:
+        """Room profiles, not the whole-floor fan command, own selected jobs."""
+        vac = _make_vacuum(_docked_state())
+        vac.coordinator.has_selected_clean_rooms.return_value = True
+
+        assert not vac.supported_features & VacuumEntityFeature.FAN_SPEED
+
+    def test_unread_profiles_hide_new_clean_actions(self) -> None:
+        """Advertised actions must agree with profile-authority guards."""
+        vac = _make_vacuum(_docked_state())
+        vac.coordinator._room_profile_store_loaded = False
+
+        assert not vac.supported_features & VacuumEntityFeature.START
+        assert not vac.supported_features & VacuumEntityFeature.CLEAN_AREA
 
     @staticmethod
     def _active_dock_vacuum() -> NarwalVacuum:
@@ -394,6 +559,151 @@ class TestDockTaskRobotActionGates:
 
         command.assert_not_awaited()
 
+
+class TestVacuumFanSpeed:
+    def test_fan_speed_reports_active_room_profile(self) -> None:
+        """The vacuum entity reports the dispatched room fan while cleaning."""
+        vac = _make_vacuum(state=_active_clean_state())
+        vac.coordinator.clean_settings.fan = FanLevel.NORMAL
+        vac.coordinator.active_clean_setting.return_value = FanLevel.STRONG
+
+        assert vac.fan_speed == "Strong"
+
+    async def test_restore_none_fan_speed_as_ai_suction(self) -> None:
+        """HA persists AI fan_speed as None; restore it as FanLevel.UNSPECIFIED."""
+        vac = _make_vacuum(state=_docked_state())
+        vac.coordinator.clean_settings.fan = FanLevel.NORMAL
+
+        with patch.object(
+            vac,
+            "async_get_last_state",
+            AsyncMock(return_value=MagicMock(attributes={"fan_speed": None})),
+        ):
+            await vac.async_added_to_hass()
+
+        assert vac.coordinator.clean_settings.fan == FanLevel.UNSPECIFIED
+
+    async def test_live_fan_change_applies_while_paused(self) -> None:
+        state = _active_clean_state()
+        state.is_paused = True
+        vac = _make_vacuum(state=state)
+        vac.coordinator.active_clean_work_mode = WorkMode.VACUUM
+        vac.coordinator.client.set_fan_speed = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+
+        await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_awaited_once_with(FanLevel.STRONG)
+        assert vac.coordinator.clean_settings.fan == FanLevel.STRONG
+        vac.coordinator.set_active_clean_setting.assert_called_once_with(
+            "fan", FanLevel.STRONG
+        )
+
+    async def test_fan_change_stages_when_unavailable_idle(self) -> None:
+        """Idle pending fan changes do not need a live coordinator connection."""
+        state = _docked_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.last_update_success = False
+        vac.coordinator.client.set_fan_speed = AsyncMock()
+
+        await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_not_awaited()
+        assert vac.coordinator.clean_settings.fan == FanLevel.STRONG
+
+    async def test_fan_change_rejected_when_entity_unavailable(self) -> None:
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.last_update_success = False
+        vac.coordinator.client.set_fan_speed = AsyncMock()
+
+        with pytest.raises(Exception, match="fan speed cannot be changed"):
+            await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_not_awaited()
+
+    async def test_live_fan_change_uses_active_room_mode(self) -> None:
+        """Live fan gating follows the accepted room mode, not pending global mode."""
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.clean_settings.work_mode = WorkMode.MOP
+        vac.coordinator.active_clean_work_mode = WorkMode.VACUUM
+        vac.coordinator.client.set_fan_speed = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+
+        await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_awaited_once_with(FanLevel.STRONG)
+        assert vac.coordinator.clean_settings.fan == FanLevel.STRONG
+
+    async def test_selected_rooms_block_pending_native_fan_change(self) -> None:
+        """The vacuum service cannot alter global fallback for selected rooms."""
+        vac = _make_vacuum(state=_docked_state())
+        vac.coordinator.has_selected_clean_rooms.return_value = True
+        vac.coordinator.clean_settings.fan = FanLevel.NORMAL
+
+        with pytest.raises(HomeAssistantError, match="cannot be changed"):
+            await vac.async_set_fan_speed("Strong")
+
+        assert vac.coordinator.clean_settings.fan == FanLevel.NORMAL
+
+    async def test_selected_rooms_keep_live_fan_change_runtime_only(self) -> None:
+        """A selected-room task accepts live suction without changing defaults."""
+        vac = _make_vacuum(state=_active_clean_state())
+        vac.coordinator.has_selected_clean_rooms.return_value = True
+        vac.coordinator.active_clean_work_mode = WorkMode.VACUUM
+        vac.coordinator.clean_settings.fan = FanLevel.NORMAL
+        vac.coordinator.client.set_fan_speed = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+
+        await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_awaited_once_with(FanLevel.STRONG)
+        vac.coordinator.set_active_clean_setting.assert_called_once_with(
+            "fan", FanLevel.STRONG
+        )
+        assert vac.coordinator.clean_settings.fan == FanLevel.NORMAL
+
+    async def test_live_fan_change_rejects_active_mop_mode(self) -> None:
+        """Pending vacuum mode must not expose fan control for an active mop-only task."""
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.clean_settings.work_mode = WorkMode.VACUUM
+        vac.coordinator.active_clean_work_mode = WorkMode.MOP
+        vac.coordinator.client.set_fan_speed = AsyncMock()
+
+        with pytest.raises(Exception, match="fan speed cannot be changed|mop-only"):
+            await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_not_awaited()
+
+    async def test_fan_change_rejected_in_mop_only_mode(self) -> None:
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.clean_settings.work_mode = WorkMode.MOP
+        vac.coordinator.client.set_fan_speed = AsyncMock()
+
+        with pytest.raises(Exception, match="mop-only mode"):
+            await vac.async_set_fan_speed("Strong")
+
+        vac.coordinator.client.set_fan_speed.assert_not_awaited()
+
+    async def test_rejected_live_fan_change_does_not_update_settings(self) -> None:
+        state = _active_clean_state()
+        vac = _make_vacuum(state=state)
+        vac.coordinator.active_clean_work_mode = WorkMode.VACUUM
+        vac.coordinator.client.set_fan_speed = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        )
+        vac.coordinator.clean_settings.fan = FanLevel.NORMAL
+
+        with pytest.raises(Exception, match="set fan speed failed"):
+            await vac.async_set_fan_speed("Strong")
+
+        assert vac.coordinator.clean_settings.fan == FanLevel.NORMAL
 
 class TestCheckSegmentChanges:
     """Tests for _check_segment_changes."""
@@ -459,10 +769,121 @@ class TestCheckSegmentChanges:
 
 
 class TestAsyncStartWholeHouse:
-    """async_start runs a whole-house clean via start_rooms(all rooms), not the saved plan."""
+    """async_start runs a room-selection aware clean via clean/start_clean."""
+
+    async def test_paused_returning_standby_resumes_existing_clean(self) -> None:
+        """Paused return context takes precedence over a stale status enum."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.is_paused = True
+        state.is_returning_to_dock = True
+        state.dock_sub_state = 2
+        state.task_elapsed_time = 60
+        state.dock_presence = 2
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.resume = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        await vac.async_start()
+
+        vac.coordinator.client.resume.assert_awaited_once()
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_rejected_resume_fails_native_start(self) -> None:
+        """A rejected resume cannot be reported to HA as a successful start."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.is_paused = True
+        state.task_elapsed_time = 60
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.resume = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.NOT_APPLICABLE)
+        )
+
+        with pytest.raises(HomeAssistantError, match="resume failed"):
+            await vac.async_start()
+
+    @pytest.mark.parametrize(
+        "working_status", (WorkingStatus.ERROR, WorkingStatus.TASK_COMPLETED)
+    )
+    async def test_terminal_status_does_not_resume_stale_paused_context(
+        self, working_status: WorkingStatus
+    ) -> None:
+        """A terminal packet takes precedence over its stale paused overlay."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.assume_robot_clean()
+        state.update_from_base_status(
+            {"3": {"1": int(working_status), "2": 1}}
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.resume = AsyncMock()
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError):
+            await vac.async_start()
+
+        vac.coordinator.client.resume.assert_not_awaited()
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_hardware_fault_does_not_resume_stale_paused_context(self) -> None:
+        """ErrorCode telemetry blocks resume even with a non-error status enum."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.assume_robot_clean()
+        state.update_from_base_status(
+            {"1": {"1": 2105}, "3": {"1": int(WorkingStatus.STANDBY), "2": 1}}
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.resume = AsyncMock()
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError):
+            await vac.async_start()
+
+        vac.coordinator.client.resume.assert_not_awaited()
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_terminal_transition_clears_future_stale_resume_context(self) -> None:
+        """A later paused standby cannot revive a completed accepted start."""
+        state = NarwalState(working_status=WorkingStatus.CLEANING)
+        state.assume_robot_clean()
+        state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.TASK_COMPLETED)}}
+        )
+        state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.DOCKED), "10": 1}, "11": 2}
+        )
+        state.update_from_base_status(
+            {"3": {"1": int(WorkingStatus.STANDBY), "2": 1, "10": 1}, "11": 2}
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.resume = AsyncMock()
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError):
+            await vac.async_start()
+
+        assert not state.has_assumed_robot_clean
+        vac.coordinator.client.resume.assert_not_awaited()
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_unread_room_profiles_block_native_start(self) -> None:
+        """A start cannot substitute defaults for unread durable profiles."""
+        vac = _make_vacuum(state=_docked_state())
+        vac.coordinator._room_profile_store_loaded = False
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="not restored"):
+            await vac.async_start()
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
 
     async def test_enumerates_all_rooms(self, caplog) -> None:
-        """Whole-house start passes every room id to clean/start_clean, skipping plan/start."""
+        """With no selected rooms, start passes every room id to clean/start_clean."""
         state = _docked_state()
         state.map_data = MapData(map_id=2, rooms=[
             RoomInfo(room_id=1), RoomInfo(room_id=2), RoomInfo(room_id=0),  # 0 filtered
@@ -479,12 +900,136 @@ class TestAsyncStartWholeHouse:
 
         vac.coordinator.client.start_rooms.assert_awaited_once()
         assert vac.coordinator.client.start_rooms.await_args.args[0] == [1, 2]
+        vac.coordinator.selected_clean_room_ids_for.assert_called_once_with(
+            [1, 2], map_id=vac.coordinator.room_settings_map_id.return_value
+        )
         vac.coordinator.client.start.assert_not_called()
         assert "Start command was rejected" not in caplog.text
         assert state.has_assumed_robot_clean
 
-    async def test_falls_back_to_saved_plan_without_map(self) -> None:
-        """With no map rooms available, falls back to the saved-plan start()."""
+    async def test_start_uses_selected_rooms(self) -> None:
+        """Selected room switches narrow the native vacuum start command."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=1), RoomInfo(room_id=2)],
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.selected_clean_room_ids_for = MagicMock(return_value=[2])
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+
+        await vac.async_start()
+
+        vac.coordinator.selected_clean_room_ids_for.assert_called_once_with(
+            [1, 2], map_id=vac.coordinator.room_settings_map_id.return_value
+        )
+        vac.coordinator.room_clean_settings_for_rooms.assert_called_once_with(
+            [2], map_id=vac.coordinator.room_settings_map_id.return_value
+        )
+        vac.coordinator.client.start_rooms.assert_awaited_once()
+        assert vac.coordinator.client.start_rooms.await_args.args[0] == [2]
+
+    async def test_start_rejects_non_authoritative_room_selection(self) -> None:
+        """A failed selection restore cannot broaden START to every room."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=1), RoomInfo(room_id=2)],
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.selected_clean_room_ids_for = MagicMock(return_value=[])
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="selection is not available"):
+            await vac.async_start()
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_start_rejects_explicit_selection_without_map_identity(self) -> None:
+        """An unidentified refreshed map cannot broaden a scoped selection."""
+        state = _docked_state()
+        state.map_data = MapData(
+            rooms=[RoomInfo(room_id=4), RoomInfo(room_id=5)],
+        )
+        vac = _make_vacuum(state=state)
+        vac.coordinator.selected_clean_rooms = {"100": {4}}
+        vac.coordinator.room_settings_map_id.return_value = None
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="selection is not available"):
+            await vac.async_start()
+
+        vac.coordinator.client.start_rooms.assert_not_awaited()
+
+    async def test_start_scopes_selection_to_map_fetched_after_start(self) -> None:
+        """START resolves selection against the freshly fetched map identity."""
+        state = _docked_state()
+        state.map_data = MapData(map_id=100, rooms=[RoomInfo(room_id=4)])
+        vac = _make_vacuum(state=state)
+        vac.coordinator.selected_clean_rooms = {"100": {4}, "200": {5}}
+        vac.coordinator.room_settings_map_id = MagicMock(
+            side_effect=lambda map_data=None: (
+                str(map_data.map_id) if map_data is not None else None
+            )
+        )
+        vac.coordinator.selected_clean_room_ids_for = MagicMock(
+            side_effect=lambda room_ids, **kwargs: (
+                NarwalCoordinator.selected_clean_room_ids_for(
+                    vac.coordinator,
+                    room_ids,
+                    **kwargs,
+                )
+            )
+        )
+
+        async def get_map() -> None:
+            state.map_data = MapData(
+                map_id=200,
+                rooms=[RoomInfo(room_id=4), RoomInfo(room_id=5)],
+            )
+
+        vac.coordinator.client.get_map = AsyncMock(side_effect=get_map)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=0)
+        )
+
+        await vac.async_start()
+
+        vac.coordinator.selected_clean_room_ids_for.assert_called_once_with(
+            [4, 5], map_id="200"
+        )
+        assert vac.coordinator.client.start_rooms.await_args.args[0] == [5]
+
+    async def test_whole_house_start_passes_room_profiles(self) -> None:
+        """Whole-house start uses room-specific profiles for each room."""
+        state = _docked_state()
+        state.map_data = MapData(
+            map_id=2,
+            rooms=[RoomInfo(room_id=1), RoomInfo(room_id=2)],
+        )
+        profile = RoomCleanSettings(fan=FanLevel.STRONG)
+        vac = _make_vacuum(state=state)
+        vac.coordinator.room_clean_settings_for_rooms = MagicMock(
+            return_value={1: profile, 2: RoomCleanSettings()}
+        )
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.start_rooms = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_start()
+
+        kwargs = vac.coordinator.client.start_rooms.await_args.kwargs
+        assert kwargs["room_settings"] == {1: profile, 2: RoomCleanSettings()}
+
+    async def test_whole_house_without_map_raises(self) -> None:
+        """With no map rooms available, no ambiguous start command is sent."""
         state = _docked_state()  # no map_data
         vac = _make_vacuum(state=state)
         vac.coordinator.client.robot_awake = True
@@ -494,9 +1039,10 @@ class TestAsyncStartWholeHouse:
         )
         vac.coordinator.client.start_rooms = AsyncMock()
 
-        await vac.async_start()
+        with pytest.raises(HomeAssistantError, match="room map is not available"):
+            await vac.async_start()
 
-        vac.coordinator.client.start.assert_awaited_once()
+        vac.coordinator.client.start.assert_not_awaited()
         vac.coordinator.client.start_rooms.assert_not_called()
 
     async def test_rejected_whole_house_start_raises_service_error(self) -> None:
@@ -513,8 +1059,55 @@ class TestAsyncStartWholeHouse:
             await vac.async_start()
 
 
+async def test_fan_restore_prefers_pending_value_over_active_room_display() -> None:
+    """An active room's displayed fan must not replace the pending default."""
+    vac = _make_vacuum(state=_docked_state())
+    extra = FanSettingRestoreData(value=int(FanLevel.DEEP))
+
+    with (
+        patch.object(
+            vac,
+            "async_get_last_state",
+            AsyncMock(return_value=MagicMock(attributes={"fan_speed": "Strong"})),
+        ),
+        patch.object(
+            vac,
+            "async_get_last_extra_data",
+            AsyncMock(return_value=extra),
+        ),
+    ):
+        await vac.async_added_to_hass()
+
+    assert vac.coordinator.clean_settings.fan == FanLevel.DEEP
+
+
+def test_fan_extra_restore_data_records_pending_value() -> None:
+    """Vacuum restore data is sourced from the pending global setting."""
+    vac = _make_vacuum(state=_active_clean_state())
+    vac.coordinator.clean_settings.fan = FanLevel.NORMAL
+    vac.coordinator.active_clean_setting.return_value = FanLevel.STRONG
+
+    assert vac.extra_restore_state_data.as_dict()["value"] == int(FanLevel.NORMAL)
+
+
 class TestAsyncStop:
     """Tests for stop routing between robot and dock task contexts."""
+
+    async def test_paused_standby_stops_existing_clean(self) -> None:
+        """Stop honors retained paused task context after a stale status enum."""
+        state = NarwalState(working_status=WorkingStatus.STANDBY)
+        state.is_paused = True
+        state.task_elapsed_time = 60
+        state.dock_presence = 2
+        vac = _make_vacuum(state=state)
+        vac.coordinator.client.robot_awake = True
+        vac.coordinator.client.stop = AsyncMock(
+            return_value=CommandResponse(result_code=CommandResult.SUCCESS)
+        )
+
+        await vac.async_stop()
+
+        vac.coordinator.client.stop.assert_awaited_once()
 
     async def test_stop_routes_dock_only_task_through_dock_policy(self) -> None:
         state = NarwalState(working_status=WorkingStatus.DOCKED)


### PR DESCRIPTION
## Summary
- decode the rolling native trajectory windows from `map/display_map` field 2
- join exact overlapping coordinates into one HA-retained route
- render only Narwal-native points and keep the sampled-position fallback removed
- persist the retained route across Home Assistant restarts and terminal pose-only packets
- clear the prior route whenever a new clean is accepted or confirmed, then build the new route from subsequent native windows

## Why
Narwal does not send the complete cleaning route in every `display_map` packet. A live Flow 2 running v01.09.09.05 capture repeatedly carried a moving 30-point window; a later observed window shared four exact points with its predecessor. Replacing each frame therefore left Home Assistant with only the latest short segment.

The integration joins those robot-recorded windows by exact coordinate overlap. Non-overlapping live windows within one observed session are retained as separate rendered sections, so no connector is invented across missing telemetry. After restart, an active cached prefix is resumed only when the first live window overlaps it; Narwal exposes no cleaning-session identifier, so an unverified prefix is discarded rather than risk joining two different cleans. The integration does not sample robot positions or smooth coordinates. The resulting native route is stored by Home Assistant and retained after the clean finishes until the next clean starts.

A confirmed new-clean transition always clears the old route. The integration does not infer whether a pre-status trajectory packet belongs to the previous or next session; the next native rolling window received after the transition starts the new retained route.

## Commit layout
1. decode and identify native trajectory windows in the client
2. join, persist, restore, and clear native routes in the coordinator
3. render only native Narwal trajectories in the camera

## Runtime validation
During an active Flow 2 running v01.09.09.05 clean, the persisted route contained 30 points immediately before a Home Assistant restart. After restart it restored that route and grew to 168, then 179, then 183 native points as later robot windows arrived. The robot continued cleaning throughout, and no sampled-position fallback was involved.

## Stack
Depends on #87 and #88; #85 and #86 are already merged. This branch is stacked in the fork; until those land, GitHub may show earlier commits in this diff too. The native-trails series is three commits ending at `be9009d`.

## Related
- Fixes #75